### PR TITLE
chore: add a string token provider for use with canary

### DIFF
--- a/auth/credential_provider.go
+++ b/auth/credential_provider.go
@@ -55,6 +55,12 @@ func NewEnvMomentoTokenProvider(envVariableName string) (CredentialProvider, err
 			errors.New("invalid argument"),
 		)
 	}
+	return NewStringMomentoTokenProvider(authToken)
+}
+
+// NewStringMomentoTokenProvider
+// TODO: add overrides for endpoints
+func NewStringMomentoTokenProvider(authToken string) (CredentialProvider, error) {
 	endpoints, err := resolve(&ResolveRequest{
 		AuthToken: authToken,
 	})


### PR DESCRIPTION
This adds a `NewStringMomentoTokenProvider` method to construct a credential provider from an auth token.