### PR TITLE
fix: Push to main.

### DIFF
--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -1,0 +1,32 @@
+name: On pull request
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  commitlint:
+    - uses: momentohq/standards-and-practices/github-actions/shared-build@gh-actions-v1
+    - env:
+      GITHUB_TOKEN: ${{ secrets.github-token }}
+
+  readme:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.MOMENTO_MACHINE_USER_GITHUB_TOKEN }}
+
+      - name: Verify README generation
+        uses: momentohq/standards-and-practices/github-actions/oss-readme-template@gh-actions-v1
+        with:
+          project_status: official
+          project_stability: alpha
+          project_type: sdk
+          sdk_language: Go
+          usage_example_path: ./examples/main.go
+
+  test:
+    uses: ./.github/workflows/test.yml
+    secrets:
+      auth-token: ${{ secrets.ALPHA_TEST_AUTH_TOKEN }}
+      github-token: ${{ secrets.MOMENTO_MACHINE_USER_GITHUB_TOKEN }}

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -5,6 +5,7 @@ on:
 
 jobs:
   commitlint:
+    runs-on: ubuntu-latest
     steps:
       - uses: momentohq/standards-and-practices/github-actions/shared-build@gh-actions-v1
         env:

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -7,9 +7,10 @@ jobs:
   commitlint:
     runs-on: ubuntu-latest
     steps:
-      - uses: momentohq/standards-and-practices/github-actions/shared-build@gh-actions-v1
+      - name: Commitlint and Other Shared Build Steps
+        uses: momentohq/standards-and-practices/github-actions/shared-build@gh-actions-v1
         env:
-          GITHUB_TOKEN: ${{ secrets.github-token }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   readme:
     runs-on: ubuntu-latest

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -5,8 +5,8 @@ on:
 
 jobs:
   commitlint:
-    - uses: momentohq/standards-and-practices/github-actions/shared-build@gh-actions-v1
-    - env:
+    uses: momentohq/standards-and-practices/github-actions/shared-build@gh-actions-v1
+    env:
       GITHUB_TOKEN: ${{ secrets.github-token }}
 
   readme:

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -5,9 +5,10 @@ on:
 
 jobs:
   commitlint:
-    uses: momentohq/standards-and-practices/github-actions/shared-build@gh-actions-v1
-    env:
-      GITHUB_TOKEN: ${{ secrets.github-token }}
+    steps:
+      - uses: momentohq/standards-and-practices/github-actions/shared-build@gh-actions-v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.github-token }}
 
   readme:
     runs-on: ubuntu-latest

--- a/.github/workflows/on-push-to-main.yml
+++ b/.github/workflows/on-push-to-main.yml
@@ -1,7 +1,5 @@
-name: On pull request or push to main
+name: On push to main
 on:
-  pull_request:
-    branches: [main]
   push:
     branches: [main]
 
@@ -9,12 +7,13 @@ jobs:
   readme:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - name: Setup repo
+        uses: actions/checkout@v3
         with:
           token: ${{ secrets.MOMENTO_MACHINE_USER_GITHUB_TOKEN }}
 
-      - name: Verify README generation
-        uses: momentohq/standards-and-practices/github-actions/oss-readme-template@gh-actions-v1
+      - name: Generate README
+        uses: momentohq/standards-and-practices/github-actions/generate-and-commit-oss-readme@gh-actions-v1
         with:
           project_status: official
           project_stability: alpha

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,12 +26,6 @@ jobs:
         with:
           token: ${{ secrets.github-token }}
 
-
-      - name: Commitlint and Other Shared Build Steps
-        uses: momentohq/standards-and-practices/github-actions/shared-build@gh-actions-v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.github-token }}
-
       - name: Install Go
         uses: actions/setup-go@v3
         with:


### PR DESCRIPTION
* Commitlint can only run as part of a PR
* Put verifying and generating the readmes back where they were. It doesn't seem right, but that's how other repos do it.