### PR TITLE
chore: update word `item(s)` to `element(s)`

### DIFF
--- a/examples/sortedset-example/main.go
+++ b/examples/sortedset-example/main.go
@@ -70,7 +70,7 @@ func main() {
 	top5Rsp, err := client.SortedSetFetch(ctx, &incubating.SortedSetFetchRequest{
 		CacheName:       cacheName,
 		SetName:         setName,
-		NumberOfResults: incubating.FetchLimitedItems{Limit: 5},
+		NumberOfResults: incubating.FetchLimitedElements{Limit: 5},
 		Order:           incubating.DESCENDING,
 	})
 	if err != nil {

--- a/examples/sortedset-example/main.go
+++ b/examples/sortedset-example/main.go
@@ -19,27 +19,30 @@ const (
 )
 
 func main() {
-	// Initialization
+	// Create Momento client
 	client := getClient()
 	ctx := context.Background()
+
+	// Create cache
 	setupCache(client, ctx)
 
+	// Put score for each element to set
+	// Using counter, element N has score N
 	for i := 1; i < 11; i++ {
 		err := client.SortedSetPut(ctx, &incubating.SortedSetPutRequest{
 			CacheName: cacheName,
 			SetName:   setName,
 			Elements: []*incubating.SortedSetScoreRequestElement{{
-				Name:  momento.StringBytes{Text: fmt.Sprintf("key:%d", i)},
+				Name:  momento.StringBytes{Text: fmt.Sprintf("element-%d", i)},
 				Score: float64(i),
 			}},
 		})
 		if err != nil {
 			panic(err)
 		}
-
 	}
 
-	// Fetch All
+	// Fetch sorted set
 	fetchResp, err := client.SortedSetFetch(ctx, &incubating.SortedSetFetchRequest{
 		CacheName: cacheName,
 		SetName:   setName,
@@ -48,21 +51,22 @@ func main() {
 		panic(err)
 	}
 
+	// Display all elements in sorted set
 	switch r := fetchResp.(type) {
 	case *incubating.SortedSetFetchHit:
 		fmt.Println("--------------")
 		fmt.Println("Found sorted set with following elements:")
 		for _, e := range r.Elements {
-			fmt.Println(fmt.Sprintf("set: %s elementName: %s score: %f", setName, e.Name, e.Score))
+			fmt.Println(fmt.Sprintf("setName: %s elementName: %s score: %f", setName, e.Name, e.Score))
 		}
 	case *incubating.SortedSetFetchMiss:
 		fmt.Println("we regret to inform you there is no such set")
 		os.Exit(1)
 	}
 
-	// Fetch Top 5 items
+	// Fetch top 5 elements in descending order (high -> low)
 	fmt.Println("--------------")
-	fmt.Println("\n\nFetching Top5 values from sorted set:")
+	fmt.Println("\n\nFetching Top 5 elements from sorted set:")
 	top5Rsp, err := client.SortedSetFetch(ctx, &incubating.SortedSetFetchRequest{
 		CacheName:       cacheName,
 		SetName:         setName,
@@ -73,11 +77,13 @@ func main() {
 		panic(err)
 	}
 
+	// Display top 5 elements using the result from SortedSetFetch in descending order
 	switch r := top5Rsp.(type) {
 	case *incubating.SortedSetFetchHit:
 		for _, e := range r.Elements {
-			fmt.Println(fmt.Sprintf("set: %s elementName: %s score: %f", setName, e.Name, e.Score))
+			fmt.Println(fmt.Sprintf("setName: %s elementName: %s score: %f", setName, e.Name, e.Score))
 		}
+		fmt.Println("\n")
 	case *incubating.SortedSetFetchMiss:
 		fmt.Println("we regret to inform you there is no such set")
 		os.Exit(1)

--- a/incubating/simple_cache_client.go
+++ b/incubating/simple_cache_client.go
@@ -569,10 +569,10 @@ func convertListPopBackResponse(r models.ListPopBackResponse) (ListPopBackRespon
 
 func convertSortedSetFetchNumResultsRequest(results SortedSetFetchNumResults) models.SortedSetFetchNumResults {
 	switch r := results.(type) {
-	case FetchLimitedItems:
-		return &models.FetchLimitedItems{Limit: r.Limit}
+	case FetchLimitedElements:
+		return &models.FetchLimitedElements{Limit: r.Limit}
 	default:
-		return &models.FetchAllItems{}
+		return &models.FetchAllElements{}
 	}
 }
 
@@ -614,14 +614,14 @@ func convertSortedSetScoreElement(e []*models.SortedSetScore) []SortedSetScoreEl
 	return rList
 }
 
-func convertSortedSetRemoveNumItemsRequest(results SortedSetRemoveNumItems) models.SortedSetRemoveNumItems {
+func convertSortedSetRemoveNumItemsRequest(results SortedSetRemoveNumElements) models.SortedSetRemoveNumElements {
 	switch r := results.(type) {
-	case RemoveSomeItems:
-		return &models.RemoveSomeItems{
+	case RemoveSomeElements:
+		return &models.RemoveSomeElements{
 			ElementsToRemove: momentoBytesListToPrimitiveByteList(r.elementsToRemove),
 		}
 	default:
-		return &models.RemoveAllItems{}
+		return &models.RemoveAllElements{}
 	}
 }
 

--- a/incubating/sortedset_requests.go
+++ b/incubating/sortedset_requests.go
@@ -32,15 +32,15 @@ type SortedSetFetchNumResults interface {
 	isSortedSetFetchNumResults()
 }
 
-type FetchAllItems struct{}
+type FetchAllElements struct{}
 
-func (FetchAllItems) isSortedSetFetchNumResults() {}
+func (FetchAllElements) isSortedSetFetchNumResults() {}
 
-type FetchLimitedItems struct {
+type FetchLimitedElements struct {
 	Limit uint32
 }
 
-func (FetchLimitedItems) isSortedSetFetchNumResults() {}
+func (FetchLimitedElements) isSortedSetFetchNumResults() {}
 
 type SortedSetFetchRequest struct {
 	CacheName       string
@@ -58,22 +58,22 @@ type SortedSetGetScoreRequest struct {
 type SortedSetRemoveRequest struct {
 	CacheName        string
 	SetName          string
-	ElementsToRemove SortedSetRemoveNumItems
+	ElementsToRemove SortedSetRemoveNumElements
 }
 
-type SortedSetRemoveNumItems interface {
-	isSortedSetRemoveNumItem()
+type SortedSetRemoveNumElements interface {
+	isSortedSetRemoveNumElement()
 }
 
-type RemoveAllItems struct{}
+type RemoveAllElements struct{}
 
-func (RemoveAllItems) isSortedSetRemoveNumItem() {}
+func (RemoveAllElements) isSortedSetRemoveNumElement() {}
 
-type RemoveSomeItems struct {
+type RemoveSomeElements struct {
 	elementsToRemove []momento.Bytes
 }
 
-func (RemoveSomeItems) isSortedSetRemoveNumItem() {}
+func (RemoveSomeElements) isSortedSetRemoveNumElement() {}
 
 type SortedSetGetRankRequest struct {
 	CacheName   string

--- a/internal/models/sortedset_requests.go
+++ b/internal/models/sortedset_requests.go
@@ -27,15 +27,15 @@ type SortedSetFetchNumResults interface {
 	isSortedSetFetchNumResults()
 }
 
-type FetchAllItems struct{}
+type FetchAllElements struct{}
 
-func (FetchAllItems) isSortedSetFetchNumResults() {}
+func (FetchAllElements) isSortedSetFetchNumResults() {}
 
-type FetchLimitedItems struct {
+type FetchLimitedElements struct {
 	Limit uint32
 }
 
-func (FetchLimitedItems) isSortedSetFetchNumResults() {}
+func (FetchLimitedElements) isSortedSetFetchNumResults() {}
 
 type SortedSetFetchRequest struct {
 	CacheName       string
@@ -53,21 +53,21 @@ type SortedSetGetScoreRequest struct {
 type SortedSetRemoveRequest struct {
 	CacheName        string
 	SetName          []byte
-	ElementsToRemove SortedSetRemoveNumItems
+	ElementsToRemove SortedSetRemoveNumElements
 }
-type SortedSetRemoveNumItems interface {
-	isSortedSetRemoveNumItem()
+type SortedSetRemoveNumElements interface {
+	isSortedSetRemoveNumElement()
 }
 
-type RemoveAllItems struct{}
+type RemoveAllElements struct{}
 
-func (RemoveAllItems) isSortedSetRemoveNumItem() {}
+func (RemoveAllElements) isSortedSetRemoveNumElement() {}
 
-type RemoveSomeItems struct {
+type RemoveSomeElements struct {
 	ElementsToRemove [][]byte
 }
 
-func (RemoveSomeItems) isSortedSetRemoveNumItem() {}
+func (RemoveSomeElements) isSortedSetRemoveNumElement() {}
 
 type SortedSetGetRankRequest struct {
 	CacheName   string

--- a/internal/services/scs_data_sorted_set_service.go
+++ b/internal/services/scs_data_sorted_set_service.go
@@ -38,9 +38,9 @@ func (client *ScsDataClient) SortedSetFetch(ctx context.Context, request *models
 		Order:   pb.XSortedSetFetchRequest_Order(request.Order),
 	}
 	switch r := request.NumberOfResults.(type) {
-	case *models.FetchAllItems:
+	case *models.FetchAllElements:
 		requestToMake.NumResults = &pb.XSortedSetFetchRequest_All{}
-	case *models.FetchLimitedItems:
+	case *models.FetchLimitedElements:
 		requestToMake.NumResults = &pb.XSortedSetFetchRequest_Limit{
 			Limit: &pb.XSortedSetFetchRequest_XLimit{
 				Limit: r.Limit,
@@ -138,9 +138,9 @@ func (client *ScsDataClient) SortedSetRemove(ctx context.Context, request *model
 		SetName: request.SetName,
 	}
 	switch r := request.ElementsToRemove.(type) {
-	case *models.RemoveAllItems:
+	case *models.RemoveAllElements:
 		requestToMake.RemoveElements = &pb.XSortedSetRemoveRequest_All{}
-	case *models.RemoveSomeItems:
+	case *models.RemoveSomeElements:
 		requestToMake.RemoveElements = &pb.XSortedSetRemoveRequest_Some{
 			Some: &pb.XSortedSetRemoveRequest_XSome{
 				ElementName: r.ElementsToRemove,


### PR DESCRIPTION
Our official naming convention requires `elements` to be put into a `collection`.
Therefore, I updated the word `item(s)` to `element(s)` in the types used in `sorted set`.
Also, I updated some wording in the sorted set demo. 