### PR TITLE
fix: make sure context is the first argument when it's passed

### DIFF
--- a/momento/common.go
+++ b/momento/common.go
@@ -16,7 +16,7 @@ var errUnexpectedGrpcResponse = errors.New("unexpected gRPC response")
 type requester interface {
 	hasCacheName
 	initGrpcRequest(client scsDataClient) error
-	makeGrpcRequest(client scsDataClient, metadata context.Context) (grpcResponse, error)
+	makeGrpcRequest(metadata context.Context, client scsDataClient) (grpcResponse, error)
 	interpretGrpcResponse() error
 	requestName() string
 }

--- a/momento/delete.go
+++ b/momento/delete.go
@@ -48,7 +48,7 @@ func (r *DeleteRequest) initGrpcRequest(scsDataClient) error {
 	return nil
 }
 
-func (r *DeleteRequest) makeGrpcRequest(client scsDataClient, metadata context.Context) (grpcResponse, error) {
+func (r *DeleteRequest) makeGrpcRequest(metadata context.Context, client scsDataClient) (grpcResponse, error) {
 	resp, err := client.grpcClient.Delete(metadata, r.grpcRequest)
 	if err != nil {
 		return nil, err

--- a/momento/get.go
+++ b/momento/get.go
@@ -68,7 +68,7 @@ func (r *GetRequest) initGrpcRequest(scsDataClient) error {
 	return nil
 }
 
-func (r *GetRequest) makeGrpcRequest(client scsDataClient, metadata context.Context) (grpcResponse, error) {
+func (r *GetRequest) makeGrpcRequest(metadata context.Context, client scsDataClient) (grpcResponse, error) {
 	resp, err := client.grpcClient.Get(metadata, r.grpcRequest)
 	if err != nil {
 		return nil, err

--- a/momento/list_concatenate_back.go
+++ b/momento/list_concatenate_back.go
@@ -74,8 +74,8 @@ func (r *ListConcatenateBackRequest) initGrpcRequest(client scsDataClient) error
 	return nil
 }
 
-func (r *ListConcatenateBackRequest) makeGrpcRequest(client scsDataClient, ctx context.Context) (grpcResponse, error) {
-	resp, err := client.grpcClient.ListConcatenateBack(ctx, r.grpcRequest)
+func (r *ListConcatenateBackRequest) makeGrpcRequest(metadata context.Context, client scsDataClient) (grpcResponse, error) {
+	resp, err := client.grpcClient.ListConcatenateBack(metadata, r.grpcRequest)
 	if err != nil {
 		return nil, err
 	}

--- a/momento/list_concatenate_front.go
+++ b/momento/list_concatenate_front.go
@@ -74,8 +74,8 @@ func (r *ListConcatenateFrontRequest) initGrpcRequest(client scsDataClient) erro
 	return nil
 }
 
-func (r *ListConcatenateFrontRequest) makeGrpcRequest(client scsDataClient, ctx context.Context) (grpcResponse, error) {
-	resp, err := client.grpcClient.ListConcatenateFront(ctx, r.grpcRequest)
+func (r *ListConcatenateFrontRequest) makeGrpcRequest(metadata context.Context, client scsDataClient) (grpcResponse, error) {
+	resp, err := client.grpcClient.ListConcatenateFront(metadata, r.grpcRequest)
 	if err != nil {
 		return nil, err
 	}

--- a/momento/list_fetch.go
+++ b/momento/list_fetch.go
@@ -69,8 +69,8 @@ func (r *ListFetchRequest) initGrpcRequest(client scsDataClient) error {
 	return nil
 }
 
-func (r *ListFetchRequest) makeGrpcRequest(client scsDataClient, ctx context.Context) (grpcResponse, error) {
-	resp, err := client.grpcClient.ListFetch(ctx, r.grpcRequest)
+func (r *ListFetchRequest) makeGrpcRequest(metadata context.Context, client scsDataClient) (grpcResponse, error) {
+	resp, err := client.grpcClient.ListFetch(metadata, r.grpcRequest)
 	if err != nil {
 		return nil, err
 	}

--- a/momento/list_length.go
+++ b/momento/list_length.go
@@ -53,8 +53,8 @@ func (r *ListLengthRequest) initGrpcRequest(client scsDataClient) error {
 	return nil
 }
 
-func (r *ListLengthRequest) makeGrpcRequest(client scsDataClient, ctx context.Context) (grpcResponse, error) {
-	resp, err := client.grpcClient.ListLength(ctx, r.grpcRequest)
+func (r *ListLengthRequest) makeGrpcRequest(metadata context.Context, client scsDataClient) (grpcResponse, error) {
+	resp, err := client.grpcClient.ListLength(metadata, r.grpcRequest)
 	if err != nil {
 		return nil, err
 	}

--- a/momento/list_pop_back.go
+++ b/momento/list_pop_back.go
@@ -55,8 +55,8 @@ func (r *ListPopBackRequest) initGrpcRequest(client scsDataClient) error {
 	return nil
 }
 
-func (r *ListPopBackRequest) makeGrpcRequest(client scsDataClient, ctx context.Context) (grpcResponse, error) {
-	resp, err := client.grpcClient.ListPopBack(ctx, r.grpcRequest)
+func (r *ListPopBackRequest) makeGrpcRequest(metadata context.Context, client scsDataClient) (grpcResponse, error) {
+	resp, err := client.grpcClient.ListPopBack(metadata, r.grpcRequest)
 	if err != nil {
 		return nil, err
 	}

--- a/momento/list_pop_front.go
+++ b/momento/list_pop_front.go
@@ -55,8 +55,8 @@ func (r *ListPopFrontRequest) initGrpcRequest(client scsDataClient) error {
 	return nil
 }
 
-func (r *ListPopFrontRequest) makeGrpcRequest(client scsDataClient, ctx context.Context) (grpcResponse, error) {
-	resp, err := client.grpcClient.ListPopFront(ctx, r.grpcRequest)
+func (r *ListPopFrontRequest) makeGrpcRequest(metadata context.Context, client scsDataClient) (grpcResponse, error) {
+	resp, err := client.grpcClient.ListPopFront(metadata, r.grpcRequest)
 	if err != nil {
 		return nil, err
 	}

--- a/momento/list_push_back.go
+++ b/momento/list_push_back.go
@@ -70,8 +70,8 @@ func (r *ListPushBackRequest) initGrpcRequest(client scsDataClient) error {
 	return nil
 }
 
-func (r *ListPushBackRequest) makeGrpcRequest(client scsDataClient, ctx context.Context) (grpcResponse, error) {
-	resp, err := client.grpcClient.ListPushBack(ctx, r.grpcRequest)
+func (r *ListPushBackRequest) makeGrpcRequest(metadata context.Context, client scsDataClient) (grpcResponse, error) {
+	resp, err := client.grpcClient.ListPushBack(metadata, r.grpcRequest)
 	if err != nil {
 		return nil, err
 	}

--- a/momento/list_push_front.go
+++ b/momento/list_push_front.go
@@ -75,8 +75,8 @@ func (r *ListPushFrontRequest) initGrpcRequest(client scsDataClient) error {
 	return nil
 }
 
-func (r *ListPushFrontRequest) makeGrpcRequest(client scsDataClient, ctx context.Context) (grpcResponse, error) {
-	resp, err := client.grpcClient.ListPushFront(ctx, r.grpcRequest)
+func (r *ListPushFrontRequest) makeGrpcRequest(metadata context.Context, client scsDataClient) (grpcResponse, error) {
+	resp, err := client.grpcClient.ListPushFront(metadata, r.grpcRequest)
 	if err != nil {
 		return nil, err
 	}

--- a/momento/list_remove_value.go
+++ b/momento/list_remove_value.go
@@ -54,8 +54,8 @@ func (r *ListRemoveValueRequest) initGrpcRequest(client scsDataClient) error {
 	return nil
 }
 
-func (r *ListRemoveValueRequest) makeGrpcRequest(client scsDataClient, ctx context.Context) (grpcResponse, error) {
-	resp, err := client.grpcClient.ListRemove(ctx, r.grpcRequest)
+func (r *ListRemoveValueRequest) makeGrpcRequest(metadata context.Context, client scsDataClient) (grpcResponse, error) {
+	resp, err := client.grpcClient.ListRemove(metadata, r.grpcRequest)
 	if err != nil {
 		return nil, err
 	}

--- a/momento/requester.template
+++ b/momento/requester.template
@@ -67,7 +67,7 @@ func (r *TemplateRequest) initGrpcRequest(client scsDataClient) error {
 
 // Call the appropriate method on the GRPC client. Pass it your GRPC request from initGrpcRequest().
 // and the metadata. Store the response in r.grpcResponse use in interpretGrpcResponse().
-func (r *TemplateRequest) makeGrpcRequest(client scsDataClient, metadata context.Context) (grpcResponse, error) {
+func (r *TemplateRequest) makeGrpcRequest(metadata context.Context, client scsDataClient) (grpcResponse, error) {
 	resp, err := client.grpcClient.Template(metadata, r.grpcRequest)
 	if err != nil {
 		return nil, err

--- a/momento/scs_data_client.go
+++ b/momento/scs_data_client.go
@@ -64,11 +64,11 @@ func (client scsDataClient) makeRequest(ctx context.Context, r requester) error 
 	ctx, cancel := context.WithTimeout(ctx, client.requestTimeout)
 	defer cancel()
 
-	request_metadata := metadata.NewOutgoingContext(
+	requestMetadata := metadata.NewOutgoingContext(
 		ctx, client.CreateNewMetadata(r.cacheName()),
 	)
 
-	grpcResp, err := r.makeGrpcRequest(client, request_metadata)
+	grpcResp, err := r.makeGrpcRequest(requestMetadata, client)
 	if err != nil {
 		return momentoerrors.ConvertSvcErr(err)
 	}

--- a/momento/set.go
+++ b/momento/set.go
@@ -72,7 +72,7 @@ func (r *SetRequest) initGrpcRequest(client scsDataClient) error {
 	return nil
 }
 
-func (r *SetRequest) makeGrpcRequest(client scsDataClient, metadata context.Context) (grpcResponse, error) {
+func (r *SetRequest) makeGrpcRequest(metadata context.Context, client scsDataClient) (grpcResponse, error) {
 	resp, err := client.grpcClient.Set(metadata, r.grpcRequest)
 	if err != nil {
 		return nil, err

--- a/momento/sorted_set_fetch.go
+++ b/momento/sorted_set_fetch.go
@@ -97,7 +97,7 @@ func (r *SortedSetFetchRequest) initGrpcRequest(scsDataClient) error {
 	return nil
 }
 
-func (r *SortedSetFetchRequest) makeGrpcRequest(client scsDataClient, metadata context.Context) (grpcResponse, error) {
+func (r *SortedSetFetchRequest) makeGrpcRequest(metadata context.Context, client scsDataClient) (grpcResponse, error) {
 	resp, err := client.grpcClient.SortedSetFetch(metadata, r.grpcRequest)
 	if err != nil {
 		return nil, err

--- a/momento/sorted_set_get_rank.go
+++ b/momento/sorted_set_get_rank.go
@@ -57,7 +57,7 @@ func (r *SortedSetGetRankRequest) initGrpcRequest(scsDataClient) error {
 	return nil
 }
 
-func (r *SortedSetGetRankRequest) makeGrpcRequest(client scsDataClient, metadata context.Context) (grpcResponse, error) {
+func (r *SortedSetGetRankRequest) makeGrpcRequest(metadata context.Context, client scsDataClient) (grpcResponse, error) {
 	resp, err := client.grpcClient.SortedSetGetRank(metadata, r.grpcRequest)
 	if err != nil {
 		return nil, err

--- a/momento/sorted_set_get_score.go
+++ b/momento/sorted_set_get_score.go
@@ -75,7 +75,7 @@ func (r *SortedSetGetScoreRequest) initGrpcRequest(scsDataClient) error {
 	return nil
 }
 
-func (r *SortedSetGetScoreRequest) makeGrpcRequest(client scsDataClient, metadata context.Context) (grpcResponse, error) {
+func (r *SortedSetGetScoreRequest) makeGrpcRequest(metadata context.Context, client scsDataClient) (grpcResponse, error) {
 	resp, err := client.grpcClient.SortedSetGetScore(metadata, r.grpcRequest)
 	if err != nil {
 		return nil, err

--- a/momento/sorted_set_increment.go
+++ b/momento/sorted_set_increment.go
@@ -55,7 +55,7 @@ func (r *SortedSetIncrementRequest) initGrpcRequest(client scsDataClient) error 
 	return nil
 }
 
-func (r *SortedSetIncrementRequest) makeGrpcRequest(client scsDataClient, metadata context.Context) (grpcResponse, error) {
+func (r *SortedSetIncrementRequest) makeGrpcRequest(metadata context.Context, client scsDataClient) (grpcResponse, error) {
 	resp, err := client.grpcClient.SortedSetIncrement(metadata, r.grpcRequest)
 	if err != nil {
 		return nil, err

--- a/momento/sorted_set_put.go
+++ b/momento/sorted_set_put.go
@@ -59,7 +59,7 @@ func (r *SortedSetPutRequest) initGrpcRequest(client scsDataClient) error {
 	return nil
 }
 
-func (r *SortedSetPutRequest) makeGrpcRequest(client scsDataClient, metadata context.Context) (grpcResponse, error) {
+func (r *SortedSetPutRequest) makeGrpcRequest(metadata context.Context, client scsDataClient) (grpcResponse, error) {
 	resp, err := client.grpcClient.SortedSetPut(metadata, r.grpcRequest)
 	if err != nil {
 		return nil, err

--- a/momento/sorted_set_remove.go
+++ b/momento/sorted_set_remove.go
@@ -80,7 +80,7 @@ func (r *SortedSetRemoveRequest) initGrpcRequest(scsDataClient) error {
 	return nil
 }
 
-func (r *SortedSetRemoveRequest) makeGrpcRequest(client scsDataClient, metadata context.Context) (grpcResponse, error) {
+func (r *SortedSetRemoveRequest) makeGrpcRequest(metadata context.Context, client scsDataClient) (grpcResponse, error) {
 	resp, err := client.grpcClient.SortedSetRemove(metadata, r.grpcRequest)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This commit corrects the argument order to `makeGrpcRequest()` such that the context is passed first.