### PR TITLE
refactor: common.go -> requester.co

### DIFF
--- a/momento/requester.go
+++ b/momento/requester.go
@@ -1,5 +1,10 @@
 package momento
 
+// The requester interface is implemented by individual
+// method request objects, for example SetRequest.
+// requester.template is a template file to help implement
+// a requester.
+
 import (
 	"context"
 	"errors"


### PR DESCRIPTION
Make it clear the file is all about the requester interface, not a jumble of common functions. Document it for internal use.

Closes #113 