### PR TITLE
chore: standardize receivers for request type functions

### DIFF
--- a/momento/delete.go
+++ b/momento/delete.go
@@ -29,11 +29,11 @@ type DeleteRequest struct {
 	response     DeleteResponse
 }
 
-func (r DeleteRequest) cacheName() string { return r.CacheName }
+func (r *DeleteRequest) cacheName() string { return r.CacheName }
 
-func (r DeleteRequest) key() Bytes { return r.Key }
+func (r *DeleteRequest) key() Bytes { return r.Key }
 
-func (r DeleteRequest) requestName() string { return "Delete" }
+func (r *DeleteRequest) requestName() string { return "Delete" }
 
 func (r *DeleteRequest) initGrpcRequest(scsDataClient) error {
 	var err error

--- a/momento/get.go
+++ b/momento/get.go
@@ -12,12 +12,12 @@ type GetResponse interface {
 	isGetResponse()
 }
 
-// Miss response to a cache Get api request.
+// GetMiss Miss response to a cache Get api request.
 type GetMiss struct{}
 
 func (GetMiss) isGetResponse() {}
 
-// Hit response to a cache Get api request.
+// GetHit Hit response to a cache Get api request.
 type GetHit struct {
 	value []byte
 }
@@ -47,11 +47,11 @@ type GetRequest struct {
 	response     GetResponse
 }
 
-func (r GetRequest) cacheName() string { return r.CacheName }
+func (r *GetRequest) cacheName() string { return r.CacheName }
 
-func (r GetRequest) key() Bytes { return r.Key }
+func (r *GetRequest) key() Bytes { return r.Key }
 
-func (r GetRequest) requestName() string { return "Get" }
+func (r *GetRequest) requestName() string { return "Get" }
 
 func (r *GetRequest) initGrpcRequest(scsDataClient) error {
 	var err error

--- a/momento/list_caches.go
+++ b/momento/list_caches.go
@@ -6,7 +6,7 @@ type ListCachesResponse interface {
 	isListCachesResponse()
 }
 
-// ListCachesResponse Output of the List caches operation.
+// ListCachesSuccess Output of the List caches operation.
 type ListCachesSuccess struct {
 	nextToken string
 	caches    []CacheInfo

--- a/momento/list_concatenate_back.go
+++ b/momento/list_concatenate_back.go
@@ -38,13 +38,13 @@ type ListConcatenateBackRequest struct {
 	response     ListConcatenateBackResponse
 }
 
-func (r ListConcatenateBackRequest) cacheName() string { return r.CacheName }
+func (r *ListConcatenateBackRequest) cacheName() string { return r.CacheName }
 
-func (r ListConcatenateBackRequest) values() []Bytes { return r.Values }
+func (r *ListConcatenateBackRequest) values() []Bytes { return r.Values }
 
-func (r ListConcatenateBackRequest) ttl() time.Duration { return r.CollectionTTL.Ttl }
+func (r *ListConcatenateBackRequest) ttl() time.Duration { return r.CollectionTTL.Ttl }
 
-func (r ListConcatenateBackRequest) requestName() string { return "ListConcatenateBack" }
+func (r *ListConcatenateBackRequest) requestName() string { return "ListConcatenateBack" }
 
 func (r *ListConcatenateBackRequest) initGrpcRequest(client scsDataClient) error {
 	var err error

--- a/momento/list_concatenate_front.go
+++ b/momento/list_concatenate_front.go
@@ -38,13 +38,13 @@ type ListConcatenateFrontRequest struct {
 	response     ListConcatenateFrontResponse
 }
 
-func (r ListConcatenateFrontRequest) cacheName() string { return r.CacheName }
+func (r *ListConcatenateFrontRequest) cacheName() string { return r.CacheName }
 
-func (r ListConcatenateFrontRequest) values() []Bytes { return r.Values }
+func (r *ListConcatenateFrontRequest) values() []Bytes { return r.Values }
 
-func (r ListConcatenateFrontRequest) ttl() time.Duration { return r.CollectionTTL.Ttl }
+func (r *ListConcatenateFrontRequest) ttl() time.Duration { return r.CollectionTTL.Ttl }
 
-func (r ListConcatenateFrontRequest) requestName() string { return "ListConcatenateFront" }
+func (r *ListConcatenateFrontRequest) requestName() string { return "ListConcatenateFront" }
 
 func (r *ListConcatenateFrontRequest) initGrpcRequest(client scsDataClient) error {
 	var err error

--- a/momento/list_fetch.go
+++ b/momento/list_fetch.go
@@ -51,11 +51,11 @@ type ListFetchRequest struct {
 	response     ListFetchResponse
 }
 
-func (r ListFetchRequest) cacheName() string { return r.CacheName }
+func (r *ListFetchRequest) cacheName() string { return r.CacheName }
 
-func (r ListFetchRequest) requestName() string { return "ListFetch" }
+func (r *ListFetchRequest) requestName() string { return "ListFetch" }
 
-func (r *ListFetchRequest) initGrpcRequest(client scsDataClient) error {
+func (r *ListFetchRequest) initGrpcRequest(scsDataClient) error {
 	var err error
 
 	if _, err = prepareName(r.ListName, "List name"); err != nil {

--- a/momento/list_length.go
+++ b/momento/list_length.go
@@ -37,11 +37,11 @@ type ListLengthRequest struct {
 	response     ListLengthResponse
 }
 
-func (r ListLengthRequest) cacheName() string { return r.CacheName }
+func (r *ListLengthRequest) cacheName() string { return r.CacheName }
 
-func (r ListLengthRequest) requestName() string { return "ListLength" }
+func (r *ListLengthRequest) requestName() string { return "ListLength" }
 
-func (r *ListLengthRequest) initGrpcRequest(client scsDataClient) error {
+func (r *ListLengthRequest) initGrpcRequest(scsDataClient) error {
 	if _, err := prepareName(r.ListName, "List name"); err != nil {
 		return err
 	}

--- a/momento/list_pop_back.go
+++ b/momento/list_pop_back.go
@@ -41,11 +41,11 @@ type ListPopBackRequest struct {
 	response     ListPopBackResponse
 }
 
-func (r ListPopBackRequest) cacheName() string { return r.CacheName }
+func (r *ListPopBackRequest) cacheName() string { return r.CacheName }
 
-func (r ListPopBackRequest) requestName() string { return "ListPopBack" }
+func (r *ListPopBackRequest) requestName() string { return "ListPopBack" }
 
-func (r *ListPopBackRequest) initGrpcRequest(client scsDataClient) error {
+func (r *ListPopBackRequest) initGrpcRequest(scsDataClient) error {
 	if _, err := prepareName(r.ListName, "List name"); err != nil {
 		return err
 	}

--- a/momento/list_pop_front.go
+++ b/momento/list_pop_front.go
@@ -41,11 +41,11 @@ type ListPopFrontRequest struct {
 	response     ListPopFrontResponse
 }
 
-func (r ListPopFrontRequest) cacheName() string { return r.CacheName }
+func (r *ListPopFrontRequest) cacheName() string { return r.CacheName }
 
-func (r ListPopFrontRequest) requestName() string { return "ListPopFront" }
+func (r *ListPopFrontRequest) requestName() string { return "ListPopFront" }
 
-func (r *ListPopFrontRequest) initGrpcRequest(client scsDataClient) error {
+func (r *ListPopFrontRequest) initGrpcRequest(scsDataClient) error {
 	if _, err := prepareName(r.ListName, "List name"); err != nil {
 		return err
 	}

--- a/momento/list_push_back.go
+++ b/momento/list_push_back.go
@@ -39,13 +39,13 @@ type ListPushBackRequest struct {
 	response     ListPushBackResponse
 }
 
-func (r ListPushBackRequest) cacheName() string { return r.CacheName }
+func (r *ListPushBackRequest) cacheName() string { return r.CacheName }
 
-func (r ListPushBackRequest) value() Bytes { return r.Value }
+func (r *ListPushBackRequest) value() Bytes { return r.Value }
 
-func (r ListPushBackRequest) ttl() time.Duration { return r.CollectionTTL.Ttl }
+func (r *ListPushBackRequest) ttl() time.Duration { return r.CollectionTTL.Ttl }
 
-func (r ListPushBackRequest) requestName() string { return "ListPushBack" }
+func (r *ListPushBackRequest) requestName() string { return "ListPushBack" }
 
 func (r *ListPushBackRequest) initGrpcRequest(client scsDataClient) error {
 	var err error

--- a/momento/list_push_front.go
+++ b/momento/list_push_front.go
@@ -39,13 +39,13 @@ type ListPushFrontRequest struct {
 	response     ListPushFrontResponse
 }
 
-func (r ListPushFrontRequest) cacheName() string { return r.CacheName }
+func (r *ListPushFrontRequest) cacheName() string { return r.CacheName }
 
-func (r ListPushFrontRequest) value() Bytes { return r.Value }
+func (r *ListPushFrontRequest) value() Bytes { return r.Value }
 
-func (r ListPushFrontRequest) ttl() time.Duration { return r.CollectionTTL.Ttl }
+func (r *ListPushFrontRequest) ttl() time.Duration { return r.CollectionTTL.Ttl }
 
-func (r ListPushFrontRequest) requestName() string { return "ListPushFront" }
+func (r *ListPushFrontRequest) requestName() string { return "ListPushFront" }
 
 func (r *ListPushFrontRequest) initGrpcRequest(client scsDataClient) error {
 	var err error

--- a/momento/list_remove_value.go
+++ b/momento/list_remove_value.go
@@ -28,13 +28,13 @@ type ListRemoveValueRequest struct {
 	response     ListRemoveValueResponse
 }
 
-func (r ListRemoveValueRequest) cacheName() string { return r.CacheName }
+func (r *ListRemoveValueRequest) cacheName() string { return r.CacheName }
 
-func (r ListRemoveValueRequest) value() Bytes { return r.Value }
+func (r *ListRemoveValueRequest) value() Bytes { return r.Value }
 
-func (r ListRemoveValueRequest) requestName() string { return "ListRemoveValue" }
+func (r *ListRemoveValueRequest) requestName() string { return "ListRemoveValue" }
 
-func (r *ListRemoveValueRequest) initGrpcRequest(client scsDataClient) error {
+func (r *ListRemoveValueRequest) initGrpcRequest(scsDataClient) error {
 	var err error
 
 	if _, err = prepareName(r.ListName, "List name"); err != nil {

--- a/momento/set.go
+++ b/momento/set.go
@@ -35,15 +35,15 @@ type SetRequest struct {
 	response     SetResponse
 }
 
-func (r SetRequest) cacheName() string { return r.CacheName }
+func (r *SetRequest) cacheName() string { return r.CacheName }
 
-func (r SetRequest) key() Bytes { return r.Key }
+func (r *SetRequest) key() Bytes { return r.Key }
 
-func (r SetRequest) value() Bytes { return r.Value }
+func (r *SetRequest) value() Bytes { return r.Value }
 
-func (r SetRequest) ttl() time.Duration { return r.TTL }
+func (r *SetRequest) ttl() time.Duration { return r.TTL }
 
-func (r SetRequest) requestName() string { return "Set" }
+func (r *SetRequest) requestName() string { return "Set" }
 
 func (r *SetRequest) initGrpcRequest(client scsDataClient) error {
 	var err error

--- a/momento/sorted_set_fetch.go
+++ b/momento/sorted_set_fetch.go
@@ -63,9 +63,9 @@ type SortedSetFetchRequest struct {
 	response     SortedSetFetchResponse
 }
 
-func (r SortedSetFetchRequest) cacheName() string { return r.CacheName }
+func (r *SortedSetFetchRequest) cacheName() string { return r.CacheName }
 
-func (r SortedSetFetchRequest) requestName() string { return "Sorted set fetch" }
+func (r *SortedSetFetchRequest) requestName() string { return "Sorted set fetch" }
 
 func (r *SortedSetFetchRequest) initGrpcRequest(scsDataClient) error {
 	var err error
@@ -76,17 +76,17 @@ func (r *SortedSetFetchRequest) initGrpcRequest(scsDataClient) error {
 
 	grpcReq := &pb.XSortedSetFetchRequest{
 		SetName: []byte(r.SetName),
-		Order:   pb.XSortedSetFetchRequest_Order(SortedSetOrder(r.Order)),
+		Order:   pb.XSortedSetFetchRequest_Order(r.Order),
 	}
 
-	switch num_results := r.NumberOfResults.(type) {
+	switch numResults := r.NumberOfResults.(type) {
 	case FetchAllElements:
 	case nil:
 		grpcReq.NumResults = &pb.XSortedSetFetchRequest_All{}
 	case FetchLimitedElements:
 		grpcReq.NumResults = &pb.XSortedSetFetchRequest_Limit{
 			Limit: &pb.XSortedSetFetchRequest_XLimit{
-				Limit: num_results.Limit,
+				Limit: numResults.Limit,
 			},
 		}
 	default:

--- a/momento/sorted_set_get_rank.go
+++ b/momento/sorted_set_get_rank.go
@@ -36,9 +36,9 @@ type SortedSetGetRankRequest struct {
 	response     SortedSetGetRankResponse
 }
 
-func (r SortedSetGetRankRequest) cacheName() string { return r.CacheName }
+func (r *SortedSetGetRankRequest) cacheName() string { return r.CacheName }
 
-func (r SortedSetGetRankRequest) requestName() string { return "Sorted set get rank" }
+func (r *SortedSetGetRankRequest) requestName() string { return "Sorted set get rank" }
 
 func (r *SortedSetGetRankRequest) initGrpcRequest(scsDataClient) error {
 	var err error

--- a/momento/sorted_set_get_score.go
+++ b/momento/sorted_set_get_score.go
@@ -54,9 +54,9 @@ type SortedSetGetScoreRequest struct {
 	response     SortedSetGetScoreResponse
 }
 
-func (r SortedSetGetScoreRequest) cacheName() string { return r.CacheName }
+func (r *SortedSetGetScoreRequest) cacheName() string { return r.CacheName }
 
-func (r SortedSetGetScoreRequest) requestName() string { return "Sorted set get score" }
+func (r *SortedSetGetScoreRequest) requestName() string { return "Sorted set get score" }
 
 func (r *SortedSetGetScoreRequest) initGrpcRequest(scsDataClient) error {
 	var err error

--- a/momento/sorted_set_increment.go
+++ b/momento/sorted_set_increment.go
@@ -32,9 +32,9 @@ type SortedSetIncrementRequest struct {
 	response     SortedSetIncrementResponse
 }
 
-func (r SortedSetIncrementRequest) cacheName() string { return r.CacheName }
+func (r *SortedSetIncrementRequest) cacheName() string { return r.CacheName }
 
-func (r SortedSetIncrementRequest) requestName() string { return "Sorted set increment" }
+func (r *SortedSetIncrementRequest) requestName() string { return "Sorted set increment" }
 
 func (r *SortedSetIncrementRequest) initGrpcRequest(client scsDataClient) error {
 	var err error

--- a/momento/sorted_set_put.go
+++ b/momento/sorted_set_put.go
@@ -35,9 +35,9 @@ type SortedSetPutRequest struct {
 	response     SortedSetPutResponse
 }
 
-func (r SortedSetPutRequest) cacheName() string { return r.CacheName }
+func (r *SortedSetPutRequest) cacheName() string { return r.CacheName }
 
-func (r SortedSetPutRequest) requestName() string { return "Sorted set put" }
+func (r *SortedSetPutRequest) requestName() string { return "Sorted set put" }
 
 func (r *SortedSetPutRequest) initGrpcRequest(client scsDataClient) error {
 	var err error

--- a/momento/sorted_set_remove.go
+++ b/momento/sorted_set_remove.go
@@ -47,9 +47,9 @@ type RemoveSomeElements struct {
 
 func (RemoveSomeElements) isSortedSetRemoveNumElement() {}
 
-func (r SortedSetRemoveRequest) cacheName() string { return r.CacheName }
+func (r *SortedSetRemoveRequest) cacheName() string { return r.CacheName }
 
-func (r SortedSetRemoveRequest) requestName() string { return "Sorted set remove" }
+func (r *SortedSetRemoveRequest) requestName() string { return "Sorted set remove" }
 
 func (r *SortedSetRemoveRequest) initGrpcRequest(scsDataClient) error {
 	var err error
@@ -62,13 +62,13 @@ func (r *SortedSetRemoveRequest) initGrpcRequest(scsDataClient) error {
 		SetName: []byte(r.SetName),
 	}
 
-	switch to_remove := r.ElementsToRemove.(type) {
+	switch toRemove := r.ElementsToRemove.(type) {
 	case *RemoveAllElements:
 		grpcReq.RemoveElements = &pb.XSortedSetRemoveRequest_All{}
 	case *RemoveSomeElements:
 		grpcReq.RemoveElements = &pb.XSortedSetRemoveRequest_Some{
 			Some: &pb.XSortedSetRemoveRequest_XSome{
-				ElementName: momentoBytesListToPrimitiveByteList(to_remove.elementsToRemove),
+				ElementName: momentoBytesListToPrimitiveByteList(toRemove.elementsToRemove),
 			},
 		}
 	default:


### PR DESCRIPTION
This commit contains fixes to quiet IDE warnings, particularly warnings about having methods on both pointer and value receivers for a given type.