### PR TITLE
feat: Improve the "unexpected GRPC response error"

### DIFF
--- a/momento/get.go
+++ b/momento/get.go
@@ -89,6 +89,6 @@ func (r *GetRequest) interpretGrpcResponse() error {
 		r.response = &GetMiss{}
 		return nil
 	} else {
-		return errUnexpectedGrpcResponse
+		return errUnexpectedGrpcResponse(r, r.grpcResponse)
 	}
 }

--- a/momento/list_fetch.go
+++ b/momento/list_fetch.go
@@ -87,7 +87,7 @@ func (r *ListFetchRequest) interpretGrpcResponse() error {
 	case *pb.XListFetchResponse_Missing:
 		r.response = &ListFetchMiss{}
 	default:
-		return errUnexpectedGrpcResponse
+		return errUnexpectedGrpcResponse(r, r.grpcResponse)
 	}
 	return nil
 }

--- a/momento/list_length.go
+++ b/momento/list_length.go
@@ -70,7 +70,7 @@ func (r *ListLengthRequest) interpretGrpcResponse() error {
 	case *pb.XListLengthResponse_Missing:
 		r.response = &ListLengthMiss{}
 	default:
-		return errUnexpectedGrpcResponse
+		return errUnexpectedGrpcResponse(r, r.grpcResponse)
 	}
 	return nil
 }

--- a/momento/list_pop_back.go
+++ b/momento/list_pop_back.go
@@ -71,7 +71,7 @@ func (r *ListPopBackRequest) interpretGrpcResponse() error {
 	case *pb.XListPopBackResponse_Missing:
 		r.response = &ListPopBackMiss{}
 	default:
-		return errUnexpectedGrpcResponse
+		return errUnexpectedGrpcResponse(r, r.grpcResponse)
 	}
 	return nil
 }

--- a/momento/list_pop_front.go
+++ b/momento/list_pop_front.go
@@ -71,7 +71,7 @@ func (r *ListPopFrontRequest) interpretGrpcResponse() error {
 	case *pb.XListPopFrontResponse_Missing:
 		r.response = &ListPopFrontMiss{}
 	default:
-		return errUnexpectedGrpcResponse
+		return errUnexpectedGrpcResponse(r, r.grpcResponse)
 	}
 	return nil
 }

--- a/momento/requester.go
+++ b/momento/requester.go
@@ -7,7 +7,6 @@ package momento
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -16,7 +15,16 @@ import (
 	"github.com/momentohq/client-sdk-go/utils"
 )
 
-var errUnexpectedGrpcResponse = errors.New("unexpected gRPC response")
+func errUnexpectedGrpcResponse(r requester, grpcResp grpcResponse) momentoerrors.MomentoSvcErr {
+	return momentoerrors.NewMomentoSvcErr(
+		momentoerrors.InternalServerError,
+		fmt.Sprintf(
+			"%s request got an unexpected response %T '%s'",
+			r.requestName(), grpcResp, grpcResp,
+		),
+		nil,
+	)
+}
 
 type requester interface {
 	hasCacheName

--- a/momento/scs_data_client.go
+++ b/momento/scs_data_client.go
@@ -2,7 +2,6 @@ package momento
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"github.com/momentohq/client-sdk-go/internal/grpcmanagers"
@@ -68,24 +67,13 @@ func (client scsDataClient) makeRequest(ctx context.Context, r requester) error 
 		ctx, client.CreateNewMetadata(r.cacheName()),
 	)
 
-	grpcResp, err := r.makeGrpcRequest(requestMetadata, client)
+	_, err := r.makeGrpcRequest(requestMetadata, client)
 	if err != nil {
 		return momentoerrors.ConvertSvcErr(err)
 	}
 
 	if err := r.interpretGrpcResponse(); err != nil {
-		if err == errUnexpectedGrpcResponse {
-			return momentoerrors.NewMomentoSvcErr(
-				momentoerrors.InternalServerError,
-				fmt.Sprintf(
-					"%s request: %v. Request returned '%s'",
-					r.requestName(), err, grpcResp,
-				),
-				nil,
-			)
-		} else {
-			return err
-		}
+		return err
 	}
 
 	return nil

--- a/momento/sorted_set_fetch.go
+++ b/momento/sorted_set_fetch.go
@@ -118,18 +118,15 @@ func (r *SortedSetFetchRequest) makeGrpcRequest(metadata context.Context, client
 }
 
 func (r *SortedSetFetchRequest) interpretGrpcResponse() error {
-	grpcResp := r.grpcResponse
-
-	// Convert from grpc struct to internal struct
-	switch rsp := grpcResp.SortedSet.(type) {
+	switch grpcResp := r.grpcResponse.SortedSet.(type) {
 	case *pb.XSortedSetFetchResponse_Found:
 		r.response = &SortedSetFetchHit{
-			Elements: sortedSetGrpcElementToModel(rsp.Found.GetElements()),
+			Elements: sortedSetGrpcElementToModel(grpcResp.Found.GetElements()),
 		}
 	case *pb.XSortedSetFetchResponse_Missing:
 		r.response = &SortedSetFetchMiss{}
 	default:
-		return errUnexpectedGrpcResponse
+		return errUnexpectedGrpcResponse(r, r.grpcResponse)
 	}
 	return nil
 }

--- a/momento/sorted_set_get_rank.go
+++ b/momento/sorted_set_get_rank.go
@@ -80,7 +80,7 @@ func (r *SortedSetGetRankRequest) interpretGrpcResponse() error {
 	case *pb.XSortedSetGetRankResponse_Missing:
 		resp = &SortedSetGetRankMiss{}
 	default:
-		return errUnexpectedGrpcResponse
+		return errUnexpectedGrpcResponse(r, r.grpcResponse)
 	}
 
 	r.response = resp

--- a/momento/sorted_set_get_score.go
+++ b/momento/sorted_set_get_score.go
@@ -87,21 +87,16 @@ func (r *SortedSetGetScoreRequest) makeGrpcRequest(metadata context.Context, cli
 }
 
 func (r *SortedSetGetScoreRequest) interpretGrpcResponse() error {
-	grpcResp := r.grpcResponse
-
-	var resp SortedSetGetScoreResponse
-	switch r := grpcResp.SortedSet.(type) {
+	switch grpcResp := r.grpcResponse.SortedSet.(type) {
 	case *pb.XSortedSetGetScoreResponse_Found:
-		resp = &SortedSetGetScoreHit{
-			Elements: convertSortedSetScoreElement(r.Found.GetElements()),
+		r.response = &SortedSetGetScoreHit{
+			Elements: convertSortedSetScoreElement(grpcResp.Found.GetElements()),
 		}
 	case *pb.XSortedSetGetScoreResponse_Missing:
-		resp = &SortedSetGetScoreMiss{}
+		r.response = &SortedSetGetScoreMiss{}
 	default:
-		return errUnexpectedGrpcResponse
+		return errUnexpectedGrpcResponse(r, r.grpcResponse)
 	}
-
-	r.response = resp
 
 	return nil
 }


### PR DESCRIPTION
Unfortunately I can't figure out how to get the actual type of the response. At least now it's wrapped in a function so it can be easily improved, and it eliminates the special case in makeRequest().

Close #114 