### PR TITLE
fix: Make sure the pubsub tests clean up after themselves even if they fail.

### DIFF
--- a/momento/pub_sub_test.go
+++ b/momento/pub_sub_test.go
@@ -16,8 +16,8 @@ var cacheName = os.Getenv("TEST_CACHE_NAME")
 
 func TestMain(m *testing.M) {
 	setup()
+	defer teardown(client)
 	m.Run()
-	teardown(client)
 }
 
 func getClient() SimpleCacheClient {


### PR DESCRIPTION
I'm trying to track down what's still leaving caches around.