### PR TITLE
refactor: Extract test shared context

### DIFF
--- a/momento/momento_suite_test.go
+++ b/momento/momento_suite_test.go
@@ -1,13 +1,29 @@
 package momento_test
 
 import (
+	"fmt"
 	"testing"
 
+	"github.com/momentohq/client-sdk-go/momento"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/types"
 )
 
 func TestMomento(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Momento Suite")
+}
+
+func HaveMomentoErrorCode(code string) types.GomegaMatcher {
+	return WithTransform(
+		func(err error) (string, error) {
+			switch mErr := err.(type) {
+			case momento.MomentoError:
+				return mErr.Code(), nil
+			default:
+				return "", fmt.Errorf("Expected MomentoError, but got %T", err)
+			}
+		}, Equal(code),
+	)
 }

--- a/momento/scalar_test.go
+++ b/momento/scalar_test.go
@@ -1,7 +1,6 @@
 package momento_test
 
 import (
-	"context"
 	"fmt"
 	"time"
 
@@ -10,9 +9,8 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/types"
 
-	"github.com/momentohq/client-sdk-go/auth"
-	"github.com/momentohq/client-sdk-go/config"
 	. "github.com/momentohq/client-sdk-go/momento"
+	. "github.com/momentohq/client-sdk-go/momento/test_helpers"
 )
 
 func HaveMomentoErrorCode(code string) types.GomegaMatcher {
@@ -29,57 +27,26 @@ func HaveMomentoErrorCode(code string) types.GomegaMatcher {
 }
 
 var _ = Describe("Scalar methods", func() {
-	var clientProps SimpleCacheClientProps
-	var credentialProvider auth.CredentialProvider
-	var configuration config.Configuration
-	var client SimpleCacheClient
-	var defaultTTL time.Duration
-	var testCacheName string
-	var ctx context.Context
-
+	var sharedContext SharedContext
 	BeforeEach(func() {
-		ctx = context.Background()
-		credentialProvider, _ = auth.NewEnvMomentoTokenProvider("TEST_AUTH_TOKEN")
-		configuration = config.LatestLaptopConfig()
-		defaultTTL = 1 * time.Second
+		sharedContext = NewSharedContext()
+		sharedContext.CreateDefaultCache()
 
-		clientProps = SimpleCacheClientProps{
-			CredentialProvider: credentialProvider,
-			Configuration:      configuration,
-			DefaultTTL:         defaultTTL,
-		}
-
-		var err error
-		client, err = NewSimpleCacheClient(&clientProps)
-		if err != nil {
-			panic(err)
-		}
-		DeferCleanup(func() { client.Close() })
-
-		testCacheName = uuid.NewString()
-		Expect(
-			client.CreateCache(ctx, &CreateCacheRequest{CacheName: testCacheName}),
-		).To(BeAssignableToTypeOf(&CreateCacheSuccess{}))
-		DeferCleanup(func() {
-			_, err := client.DeleteCache(ctx, &DeleteCacheRequest{CacheName: testCacheName})
-			if err != nil {
-				panic(err)
-			}
-		})
+		DeferCleanup(func() { sharedContext.Close() })
 	})
 
 	DescribeTable(`Gets, Sets, and Deletes`,
 		func(key Key, value Value, expectedString string, expectedBytes []byte) {
 			Expect(
-				client.Set(ctx, &SetRequest{
-					CacheName: testCacheName,
+				sharedContext.Client.Set(sharedContext.Ctx, &SetRequest{
+					CacheName: sharedContext.CacheName,
 					Key:       key,
 					Value:     value,
 				}),
 			).To(BeAssignableToTypeOf(&SetSuccess{}))
 
-			getResp, err := client.Get(ctx, &GetRequest{
-				CacheName: testCacheName,
+			getResp, err := sharedContext.Client.Get(sharedContext.Ctx, &GetRequest{
+				CacheName: sharedContext.CacheName,
 				Key:       key,
 			})
 			Expect(err).To(BeNil())
@@ -93,15 +60,15 @@ var _ = Describe("Scalar methods", func() {
 			}
 
 			Expect(
-				client.Delete(ctx, &DeleteRequest{
-					CacheName: testCacheName,
+				sharedContext.Client.Delete(sharedContext.Ctx, &DeleteRequest{
+					CacheName: sharedContext.CacheName,
 					Key:       key,
 				}),
 			).To(BeAssignableToTypeOf(&DeleteSuccess{}))
 
 			Expect(
-				client.Get(ctx, &GetRequest{
-					CacheName: testCacheName,
+				sharedContext.Client.Get(sharedContext.Ctx, &GetRequest{
+					CacheName: sharedContext.CacheName,
 					Key:       key,
 				}),
 			).To(BeAssignableToTypeOf(&GetMiss{}))
@@ -117,14 +84,14 @@ var _ = Describe("Scalar methods", func() {
 		key := String("key")
 		value := String("value")
 
-		getResp, err := client.Get(ctx, &GetRequest{
+		getResp, err := sharedContext.Client.Get(sharedContext.Ctx, &GetRequest{
 			CacheName: cacheName,
 			Key:       key,
 		})
 		Expect(getResp).To(BeNil())
 		Expect(err).To(HaveMomentoErrorCode(NotFoundError))
 
-		setResp, err := client.Set(ctx, &SetRequest{
+		setResp, err := sharedContext.Client.Set(sharedContext.Ctx, &SetRequest{
 			CacheName: cacheName,
 			Key:       key,
 			Value:     value,
@@ -132,7 +99,7 @@ var _ = Describe("Scalar methods", func() {
 		Expect(setResp).To(BeNil())
 		Expect(err).To(HaveMomentoErrorCode(NotFoundError))
 
-		deleteResp, err := client.Delete(ctx, &DeleteRequest{
+		deleteResp, err := sharedContext.Client.Delete(sharedContext.Ctx, &DeleteRequest{
 			CacheName: cacheName,
 			Key:       key,
 		})
@@ -142,14 +109,14 @@ var _ = Describe("Scalar methods", func() {
 
 	DescribeTable(`invalid cache names and keys`,
 		func(cacheName string, key Key, value Key) {
-			getResp, err := client.Get(ctx, &GetRequest{
+			getResp, err := sharedContext.Client.Get(sharedContext.Ctx, &GetRequest{
 				CacheName: cacheName,
 				Key:       key,
 			})
 			Expect(getResp).To(BeNil())
 			Expect(err).To(HaveMomentoErrorCode(InvalidArgumentError))
 
-			setResp, err := client.Set(ctx, &SetRequest{
+			setResp, err := sharedContext.Client.Set(sharedContext.Ctx, &SetRequest{
 				CacheName: cacheName,
 				Key:       key,
 				Value:     value,
@@ -157,7 +124,7 @@ var _ = Describe("Scalar methods", func() {
 			Expect(setResp).To(BeNil())
 			Expect(err).To(HaveMomentoErrorCode(InvalidArgumentError))
 
-			deleteResp, err := client.Delete(ctx, &DeleteRequest{
+			deleteResp, err := sharedContext.Client.Delete(sharedContext.Ctx, &DeleteRequest{
 				CacheName: cacheName,
 				Key:       key,
 			})
@@ -175,27 +142,27 @@ var _ = Describe("Scalar methods", func() {
 			value := String("value")
 
 			Expect(
-				client.Set(ctx, &SetRequest{
-					CacheName: testCacheName,
+				sharedContext.Client.Set(sharedContext.Ctx, &SetRequest{
+					CacheName: sharedContext.CacheName,
 					Key:       key,
 					Value:     value,
 				}),
 			).To(BeAssignableToTypeOf(&SetSuccess{}))
 
-			time.Sleep(defaultTTL / 2)
+			time.Sleep(sharedContext.DefaultTTL / 2)
 
 			Expect(
-				client.Get(ctx, &GetRequest{
-					CacheName: testCacheName,
+				sharedContext.Client.Get(sharedContext.Ctx, &GetRequest{
+					CacheName: sharedContext.CacheName,
 					Key:       key,
 				}),
 			).To(BeAssignableToTypeOf(&GetHit{}))
 
-			time.Sleep(defaultTTL)
+			time.Sleep(sharedContext.DefaultTTL)
 
 			Expect(
-				client.Get(ctx, &GetRequest{
-					CacheName: testCacheName,
+				sharedContext.Client.Get(sharedContext.Ctx, &GetRequest{
+					CacheName: sharedContext.CacheName,
 					Key:       key,
 				}),
 			).To(BeAssignableToTypeOf(&GetMiss{}))
@@ -206,37 +173,37 @@ var _ = Describe("Scalar methods", func() {
 			value := String("value")
 
 			Expect(
-				client.Set(ctx, &SetRequest{
-					CacheName: testCacheName,
+				sharedContext.Client.Set(sharedContext.Ctx, &SetRequest{
+					CacheName: sharedContext.CacheName,
 					Key:       key,
 					Value:     value,
-					TTL:       defaultTTL * 2,
+					TTL:       sharedContext.DefaultTTL * 2,
 				}),
 			).To(BeAssignableToTypeOf(&SetSuccess{}))
 
-			time.Sleep(defaultTTL / 2)
+			time.Sleep(sharedContext.DefaultTTL / 2)
 
 			Expect(
-				client.Get(ctx, &GetRequest{
-					CacheName: testCacheName,
+				sharedContext.Client.Get(sharedContext.Ctx, &GetRequest{
+					CacheName: sharedContext.CacheName,
 					Key:       key,
 				}),
 			).To(BeAssignableToTypeOf(&GetHit{}))
 
-			time.Sleep(defaultTTL)
+			time.Sleep(sharedContext.DefaultTTL)
 
 			Expect(
-				client.Get(ctx, &GetRequest{
-					CacheName: testCacheName,
+				sharedContext.Client.Get(sharedContext.Ctx, &GetRequest{
+					CacheName: sharedContext.CacheName,
 					Key:       key,
 				}),
 			).To(BeAssignableToTypeOf(&GetHit{}))
 
-			time.Sleep(defaultTTL)
+			time.Sleep(sharedContext.DefaultTTL)
 
 			Expect(
-				client.Get(ctx, &GetRequest{
-					CacheName: testCacheName,
+				sharedContext.Client.Get(sharedContext.Ctx, &GetRequest{
+					CacheName: sharedContext.CacheName,
 					Key:       key,
 				}),
 			).To(BeAssignableToTypeOf(&GetMiss{}))

--- a/momento/scalar_test.go
+++ b/momento/scalar_test.go
@@ -1,30 +1,15 @@
 package momento_test
 
 import (
-	"fmt"
 	"time"
 
 	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/onsi/gomega/types"
 
 	. "github.com/momentohq/client-sdk-go/momento"
 	. "github.com/momentohq/client-sdk-go/momento/test_helpers"
 )
-
-func HaveMomentoErrorCode(code string) types.GomegaMatcher {
-	return WithTransform(
-		func(err error) (string, error) {
-			switch mErr := err.(type) {
-			case MomentoError:
-				return mErr.Code(), nil
-			default:
-				return "", fmt.Errorf("Expected MomentoError, but got %T", err)
-			}
-		}, Equal(code),
-	)
-}
 
 var _ = Describe("Scalar methods", func() {
 	var sharedContext SharedContext

--- a/momento/test_helpers/shared_context.go
+++ b/momento/test_helpers/shared_context.go
@@ -1,0 +1,67 @@
+package helpers
+
+import (
+	"context"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/momentohq/client-sdk-go/auth"
+	"github.com/momentohq/client-sdk-go/config"
+	"github.com/momentohq/client-sdk-go/momento"
+)
+
+type SharedContext struct {
+	ClientProps        *momento.SimpleCacheClientProps
+	Client             momento.SimpleCacheClient
+	CacheName          string
+	CollectionName     string
+	Ctx                context.Context
+	DefaultTTL         time.Duration
+	Configuration      config.Configuration
+	CredentialProvider auth.CredentialProvider
+}
+
+func NewSharedContext() SharedContext {
+	shared := SharedContext{}
+
+	shared.Ctx = context.Background()
+	credentialProvider, _ := auth.NewEnvMomentoTokenProvider("TEST_AUTH_TOKEN")
+	shared.CredentialProvider = credentialProvider
+	shared.Configuration = config.LatestLaptopConfig()
+	shared.DefaultTTL = 1 * time.Second
+
+	shared.ClientProps = &momento.SimpleCacheClientProps{
+		CredentialProvider: shared.CredentialProvider,
+		Configuration:      shared.Configuration,
+		DefaultTTL:         shared.DefaultTTL,
+	}
+
+	var err error
+	client, err := momento.NewSimpleCacheClient(shared.ClientProps)
+	if err != nil {
+		panic(err)
+	}
+
+	shared.Client = client
+
+	shared.CacheName = uuid.NewString()
+	shared.CollectionName = uuid.NewString()
+
+	return shared
+}
+
+func (shared SharedContext) CreateDefaultCache() {
+	_, err := shared.Client.CreateCache(shared.Ctx, &momento.CreateCacheRequest{CacheName: shared.CacheName})
+	if err != nil {
+		panic(err)
+	}
+}
+
+func (shared SharedContext) Close() {
+	_, err := shared.Client.DeleteCache(shared.Ctx, &momento.DeleteCacheRequest{CacheName: shared.CacheName})
+	if err != nil {
+		panic(err)
+	}
+
+	shared.Client.Close()
+}


### PR DESCRIPTION
* Extract test setup into SharedContext.
* Extract custom matchers into a shared location.

This makes tests easier to write consistently and understandably. What is shared and what is local is made clear.