### PR TITLE
fix: Remove references to TEST_CACHE_NAME

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,12 +4,11 @@ on:
   workflow_call:
     secrets:
       auth-token:
-        description: 'Auth token used for live testing'
+        description: "Auth token used for live testing"
         required: true
       github-token:
-        description: 'Token for running Github actions'
+        description: "Token for running Github actions"
         required: true
-
 
 jobs:
   test:
@@ -19,7 +18,6 @@ jobs:
       pull-requests: read
     env:
       TEST_AUTH_TOKEN: ${{ secrets.auth-token }}
-      TEST_CACHE_NAME: client-sdk-go-test-${{github.sha}}
     steps:
       - name: Setup repo
         uses: actions/checkout@v3
@@ -54,5 +52,3 @@ jobs:
 
       - name: Run test
         run: make test
-
-

--- a/CONTRIBUTING.template.md
+++ b/CONTRIBUTING.template.md
@@ -39,8 +39,7 @@ Running `make precommit` will run all formatters, linters, and the tests. Run th
 
 We use [Ginkgo](https://onsi.github.io/ginkgo/) and [Gomega](https://onsi.github.io/gomega/) to write our tests.
 
-Integration tests require an auth token for testing. Set the env var `TEST_AUTH_TOKEN` to
-provide it, you can get this from your `~/.momento/credentials` file. The env `TEST_CACHE_NAME` is also required, but for now any string value works.
+Integration tests require an auth token for testing. Set the env var `TEST_AUTH_TOKEN` to provide it, you can get this from your `~/.momento/credentials` file.
 
 Then run `make test`.
 


### PR DESCRIPTION
It's no longer used by the tests, it chooses its own unique cache names to enable parallel testing.

For #187