### PR TITLE
fix: add validation to 'prepare' methods in requestor

### DIFF
--- a/momento/list_push_back.go
+++ b/momento/list_push_back.go
@@ -54,6 +54,11 @@ func (r *ListPushBackRequest) initGrpcRequest(client scsDataClient) error {
 		return err
 	}
 
+	var value []byte
+	if value, err = prepareValue(r); err != nil {
+		return err
+	}
+
 	var ttl uint64
 	if ttl, err = prepareTTL(r, client.defaultTtl); err != nil {
 		return err
@@ -61,7 +66,7 @@ func (r *ListPushBackRequest) initGrpcRequest(client scsDataClient) error {
 
 	r.grpcRequest = &pb.XListPushBackRequest{
 		ListName:            []byte(r.ListName),
-		Value:               r.Value.asBytes(),
+		Value:               value,
 		TtlMilliseconds:     ttl,
 		RefreshTtl:          r.CollectionTTL.RefreshTtl,
 		TruncateFrontToSize: r.TruncateFrontToSize,

--- a/momento/requester.go
+++ b/momento/requester.go
@@ -113,16 +113,34 @@ func prepareFields(r hasFields) ([][]byte, error) {
 }
 
 func prepareValue(r hasValue) ([]byte, momentoerrors.MomentoSvcErr) {
+	if r.value() == nil {
+		return []byte{}, momentoerrors.NewMomentoSvcErr(
+			momentoerrors.InvalidArgumentError,
+			"value may not be nil",
+			nil,
+		)
+	}
 	return r.value().asBytes(), nil
 }
 
 func prepareValues(r hasValues) ([][]byte, momentoerrors.MomentoSvcErr) {
-	return momentoValuesToPrimitiveByteList(r.values()), nil
+	values, err := momentoValuesToPrimitiveByteList(r.values())
+	if err != nil {
+		return [][]byte{}, err
+	}
+	return values, nil
 }
 
 func prepareItems(r hasItems) (map[string][]byte, error) {
 	retMap := make(map[string][]byte)
 	for k, v := range r.items() {
+		if v == nil {
+			return map[string][]byte{}, momentoerrors.NewMomentoSvcErr(
+				momentoerrors.InvalidArgumentError,
+				"item values may not be nil",
+				nil,
+			)
+		}
 		if err := validateNotEmpty([]byte(k), "item keys"); err != nil {
 			return nil, err
 		}
@@ -146,12 +164,19 @@ func prepareTTL(r hasTTL, defaultTtl time.Duration) (uint64, error) {
 	return uint64(ttl.Milliseconds()), nil
 }
 
-func momentoValuesToPrimitiveByteList(i []Value) [][]byte {
+func momentoValuesToPrimitiveByteList(i []Value) ([][]byte, momentoerrors.MomentoSvcErr) {
 	var rList [][]byte
 	for _, mb := range i {
+		if mb == nil {
+			return [][]byte{}, momentoerrors.NewMomentoSvcErr(
+				momentoerrors.InvalidArgumentError,
+				"values may not be nil",
+				nil,
+			)
+		}
 		rList = append(rList, mb.asBytes())
 	}
-	return rList
+	return rList, nil
 }
 
 func validateNotEmpty(field []byte, label string) error {

--- a/momento/set_add_elements.go
+++ b/momento/set_add_elements.go
@@ -51,9 +51,14 @@ func (r *SetAddElementsRequest) initGrpcRequest(client scsDataClient) error {
 		return err
 	}
 
+	elements, err := momentoValuesToPrimitiveByteList(r.Elements)
+	if err != nil {
+		return err
+	}
+
 	r.grpcRequest = &pb.XSetUnionRequest{
 		SetName:         []byte(r.SetName),
-		Elements:        momentoValuesToPrimitiveByteList(r.Elements),
+		Elements:        elements,
 		TtlMilliseconds: ttl,
 		RefreshTtl:      r.CollectionTTL.RefreshTtl,
 	}

--- a/momento/set_remove_elements.go
+++ b/momento/set_remove_elements.go
@@ -39,13 +39,18 @@ func (r *SetRemoveElementsRequest) initGrpcRequest(client scsDataClient) error {
 		return err
 	}
 
+	elements, err := momentoValuesToPrimitiveByteList(r.Elements)
+	if err != nil {
+		return err
+	}
+
 	r.grpcRequest = &pb.XSetDifferenceRequest{
 		SetName: []byte(r.SetName),
 		Difference: &pb.XSetDifferenceRequest_Subtrahend{
 			Subtrahend: &pb.XSetDifferenceRequest_XSubtrahend{
 				SubtrahendSet: &pb.XSetDifferenceRequest_XSubtrahend_Set{
 					Set: &pb.XSetDifferenceRequest_XSubtrahend_XSet{
-						Elements: momentoValuesToPrimitiveByteList(r.Elements),
+						Elements: elements,
 					},
 				},
 			},

--- a/momento/sorted_set_get_score.go
+++ b/momento/sorted_set_get_score.go
@@ -65,9 +65,14 @@ func (r *SortedSetGetScoreRequest) initGrpcRequest(scsDataClient) error {
 		return err
 	}
 
+	elementNames, err := momentoValuesToPrimitiveByteList(r.ElementNames)
+	if err != nil {
+		return err
+	}
+
 	resp := &pb.XSortedSetGetScoreRequest{
 		SetName:     []byte(r.SetName),
-		ElementName: momentoValuesToPrimitiveByteList(r.ElementNames),
+		ElementName: elementNames,
 	}
 
 	r.grpcRequest = resp

--- a/momento/sorted_set_remove.go
+++ b/momento/sorted_set_remove.go
@@ -68,15 +68,23 @@ func (r *SortedSetRemoveRequest) initGrpcRequest(scsDataClient) error {
 	case *RemoveAllElements:
 		grpcReq.RemoveElements = &pb.XSortedSetRemoveRequest_All{}
 	case RemoveSomeElements:
+		elemToRemove, err := momentoValuesToPrimitiveByteList(toRemove.Elements)
+		if err != nil {
+			return err
+		}
 		grpcReq.RemoveElements = &pb.XSortedSetRemoveRequest_Some{
 			Some: &pb.XSortedSetRemoveRequest_XSome{
-				ElementName: momentoValuesToPrimitiveByteList(toRemove.Elements),
+				ElementName: elemToRemove,
 			},
 		}
 	case *RemoveSomeElements:
+		elemToRemove, err := momentoValuesToPrimitiveByteList(toRemove.Elements)
+		if err != nil {
+			return err
+		}
 		grpcReq.RemoveElements = &pb.XSortedSetRemoveRequest_Some{
 			Some: &pb.XSortedSetRemoveRequest_XSome{
-				ElementName: momentoValuesToPrimitiveByteList(toRemove.Elements),
+				ElementName: elemToRemove,
 			},
 		}
 	default:


### PR DESCRIPTION
This commit validates values in the `process` methods (e.g., `processValue`) to ensure they are not `nil` and, if they are, returns an `InvalidArgument` error.