### PR TITLE
fix: Topic name and cache validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .idea
 .DS_Store
 vendor
+.env
+.vscode

--- a/momento/pubsub_test.go
+++ b/momento/pubsub_test.go
@@ -28,7 +28,7 @@ var _ = Describe("Pubsub", func() {
 		func(cacheName string, collectionName string, expectedError string) {
 			ctx := sharedContext.Ctx
 			client := sharedContext.Client
-			value := TopicValueString{Text: "foo"}
+			value := &TopicValueString{Text: "foo"}
 
 			Expect(
 				client.TopicSubscribe(ctx, &TopicSubscribeRequest{
@@ -46,6 +46,7 @@ var _ = Describe("Pubsub", func() {
 		Entry("Blank cache name", "  ", sharedContext.CollectionName, InvalidArgumentError),
 		Entry("Empty collection name", sharedContext.CacheName, "", InvalidArgumentError),
 		Entry("Blank collection name", sharedContext.CacheName, "  ", InvalidArgumentError),
+		Entry("Non-existent cache", uuid.NewString(), uuid.NewString(), NotFoundError),
 	)
 
 	It(`Publishes and receives`, func() {
@@ -100,34 +101,13 @@ var _ = Describe("Pubsub", func() {
 	})
 
 	Describe(`TopicSubscribe`, func() {
-		It(`Errors on a non-existant cache`, func() {
-			Expect(
-				sharedContext.Client.TopicSubscribe(sharedContext.Ctx, &TopicSubscribeRequest{
-					CacheName: uuid.NewString(),
-					TopicName: sharedContext.CollectionName,
-				}),
-			).Error().To(HaveMomentoErrorCode(NotFoundError))
-		})
-
-		It(`Does not error on a non-existant topic`, func() {
+		It(`Does not error on a non-existent topic`, func() {
 			Expect(
 				sharedContext.Client.TopicSubscribe(sharedContext.Ctx, &TopicSubscribeRequest{
 					CacheName: sharedContext.CacheName,
 					TopicName: sharedContext.CollectionName,
 				}),
 			).Error().NotTo(HaveOccurred())
-		})
-	})
-
-	Describe(`TopicPublish`, func() {
-		It(`Errors on a non-existant cache`, func() {
-			Expect(
-				sharedContext.Client.TopicPublish(sharedContext.Ctx, &TopicPublishRequest{
-					CacheName: uuid.NewString(),
-					TopicName: sharedContext.CollectionName,
-					Value:     &TopicValueString{Text: "foo"},
-				}),
-			).Error().To(HaveMomentoErrorCode(NotFoundError))
 		})
 	})
 })


### PR DESCRIPTION
Testing topic name validation revealed some problems.

* TopicSubscribe and TopicPublish were not validating names.
* TopicSubscribe did not error when the cache did not exist.
* TopicPublish was not wrapping its error.

Closes #198 