### PR TITLE
chore: update a few names

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ func main() {
 
 ### Error Handling
 
-The preferred way of interpreting the return values from `SimpleCacheClient` methods is using a `switch` statement to match and handle the specific response type. 
+The preferred way of interpreting the return values from `CacheClient` methods is using a `switch` statement to match and handle the specific response type. 
 Here's a quick example:
 
 ```go

--- a/README.template.md
+++ b/README.template.md
@@ -30,7 +30,7 @@ Here is a quickstart you can use in your own project:
 
 ### Error Handling
 
-The preferred way of interpreting the return values from `SimpleCacheClient` methods is using a `switch` statement to match and handle the specific response type. 
+The preferred way of interpreting the return values from `CacheClient` methods is using a `switch` statement to match and handle the specific response type. 
 Here's a quick example:
 
 ```go

--- a/examples/dictionary-example/main.go
+++ b/examples/dictionary-example/main.go
@@ -31,7 +31,7 @@ func setup() {
 	}
 
 	// Initializes Momento
-	client, err = momento.NewSimpleCacheClient(&momento.SimpleCacheClientProps{
+	client, err = momento.NewCacheClient(&momento.CacheClientProps{
 		Configuration:      config.LatestLaptopConfig(),
 		CredentialProvider: credentialProvider,
 		DefaultTTL:         itemDefaultTTLSeconds * time.Second,

--- a/examples/dictionary-example/main.go
+++ b/examples/dictionary-example/main.go
@@ -20,7 +20,7 @@ const (
 
 var (
 	ctx    context.Context
-	client momento.SimpleCacheClient
+	client momento.CacheClient
 )
 
 func setup() {

--- a/examples/dictionary-example/main.go
+++ b/examples/dictionary-example/main.go
@@ -103,11 +103,11 @@ func setField(field momento.Value, value momento.Value) {
 	}
 }
 
-func setItems(items map[string]momento.Value) {
+func setElements(elements map[string]momento.Value) {
 	resp, err := client.DictionarySetFields(ctx, &momento.DictionarySetFieldsRequest{
 		CacheName:      cacheName,
 		DictionaryName: dictionaryName,
-		Items:          items,
+		Elements:       elements,
 	})
 	if err != nil {
 		panic(err)
@@ -216,13 +216,13 @@ func main() {
 	setField(momento.String(field), momento.String(value))
 	printDict()
 
-	items := make(map[string]momento.Value)
+	elements := make(map[string]momento.Value)
 	for i := 1; i < 11; i++ {
 		numField := fmt.Sprintf("%s %d", field, i)
 		numValue := fmt.Sprintf("%s %d", value, i)
-		items[numField] = momento.String(numValue)
+		elements[numField] = momento.String(numValue)
 	}
-	setItems(items)
+	setElements(elements)
 	printDict()
 
 	printField(momento.String("my-field 6"))

--- a/examples/dictionary-example/main.go
+++ b/examples/dictionary-example/main.go
@@ -144,7 +144,7 @@ func incrementField(counterField momento.Value, amount int64) {
 		DictionaryName: dictionaryName,
 		Field:          counterField,
 		Amount:         amount,
-		CollectionTTL: utils.CollectionTTL{
+		CollectionTtl: utils.CollectionTtl{
 			Ttl:        time.Second * 30,
 			RefreshTtl: true,
 		},

--- a/examples/list-example/main.go
+++ b/examples/list-example/main.go
@@ -20,7 +20,7 @@ const (
 
 var (
 	ctx    context.Context
-	client momento.SimpleCacheClient
+	client momento.CacheClient
 )
 
 func pushFrontToList(value string) {

--- a/examples/list-example/main.go
+++ b/examples/list-example/main.go
@@ -30,7 +30,7 @@ func pushFrontToList(value string) {
 		ListName:           listName,
 		Value:              momento.String(value),
 		TruncateBackToSize: 0,
-		CollectionTTL: utils.CollectionTTL{
+		CollectionTtl: utils.CollectionTtl{
 			Ttl:        5 * time.Second,
 			RefreshTtl: true,
 		},
@@ -52,7 +52,7 @@ func pushBackToList(value string) {
 		ListName:            listName,
 		Value:               momento.String(value),
 		TruncateFrontToSize: 0,
-		CollectionTTL: utils.CollectionTTL{
+		CollectionTtl: utils.CollectionTtl{
 			Ttl:        5 * time.Second,
 			RefreshTtl: true,
 		},

--- a/examples/pubsub-example/main.go
+++ b/examples/pubsub-example/main.go
@@ -53,7 +53,7 @@ func pollForMessages(ctx context.Context, sub momento.TopicSubscription) {
 	}
 }
 
-func getClient() momento.SimpleCacheClient {
+func getClient() momento.CacheClient {
 	credProvider, err := auth.NewEnvMomentoTokenProvider("MOMENTO_AUTH_TOKEN")
 	if err != nil {
 		panic(err)
@@ -69,7 +69,7 @@ func getClient() momento.SimpleCacheClient {
 	return client
 }
 
-func setupCache(client momento.SimpleCacheClient, ctx context.Context) {
+func setupCache(client momento.CacheClient, ctx context.Context) {
 	_, err := client.CreateCache(ctx, &momento.CreateCacheRequest{
 		CacheName: "test-cache",
 	})
@@ -78,7 +78,7 @@ func setupCache(client momento.SimpleCacheClient, ctx context.Context) {
 	}
 }
 
-func publishMessages(client momento.SimpleCacheClient, ctx context.Context) {
+func publishMessages(client momento.CacheClient, ctx context.Context) {
 	for i := 0; i < 10; i++ {
 		fmt.Printf("publishing message %d\n", i)
 		_, err := client.TopicPublish(ctx, &momento.TopicPublishRequest{

--- a/examples/set-example/main.go
+++ b/examples/set-example/main.go
@@ -19,7 +19,7 @@ const (
 
 var (
 	ctx    context.Context
-	client momento.SimpleCacheClient
+	client momento.CacheClient
 )
 
 func setup() {

--- a/examples/sortedset-example/main.go
+++ b/examples/sortedset-example/main.go
@@ -69,7 +69,7 @@ func main() {
 	displayElements(setName, top5Rsp)
 }
 
-func getClient() momento.SimpleCacheClient {
+func getClient() momento.CacheClient {
 	credProvider, err := auth.NewEnvMomentoTokenProvider("MOMENTO_AUTH_TOKEN")
 	if err != nil {
 		panic(err)
@@ -85,7 +85,7 @@ func getClient() momento.SimpleCacheClient {
 	return client
 }
 
-func setupCache(client momento.SimpleCacheClient, ctx context.Context) {
+func setupCache(client momento.CacheClient, ctx context.Context) {
 	_, err := client.CreateCache(ctx, &momento.CreateCacheRequest{
 		CacheName: "test-cache",
 	})

--- a/momento/dictionary_fetch.go
+++ b/momento/dictionary_fetch.go
@@ -13,8 +13,8 @@ type DictionaryFetchResponse interface {
 }
 
 type DictionaryFetchHit struct {
-	elements          map[string][]byte
-	itemsStringString map[string]string
+	elementsStringByte   map[string][]byte
+	elementsStringString map[string]string
 }
 
 func (DictionaryFetchHit) isDictionaryFetchResponse() {}
@@ -24,17 +24,17 @@ func (resp DictionaryFetchHit) ValueMap() map[string]string {
 }
 
 func (resp DictionaryFetchHit) ValueMapStringString() map[string]string {
-	if resp.itemsStringString == nil {
-		resp.itemsStringString = make(map[string]string)
-		for k, v := range resp.elements {
-			resp.itemsStringString[k] = string(v)
+	if resp.elementsStringString == nil {
+		resp.elementsStringString = make(map[string]string)
+		for k, v := range resp.elementsStringByte {
+			resp.elementsStringString[k] = string(v)
 		}
 	}
-	return resp.itemsStringString
+	return resp.elementsStringString
 }
 
 func (resp DictionaryFetchHit) ValueMapStringByte() map[string][]byte {
-	return resp.elements
+	return resp.elementsStringByte
 }
 
 type DictionaryFetchMiss struct{}
@@ -84,7 +84,7 @@ func (r *DictionaryFetchRequest) interpretGrpcResponse() error {
 		for _, i := range rtype.Found.Items {
 			elements[(string(i.Field))] = i.Value
 		}
-		r.response = &DictionaryFetchHit{elements: elements}
+		r.response = &DictionaryFetchHit{elementsStringByte: elements}
 	case *pb.XDictionaryFetchResponse_Missing:
 		r.response = &DictionaryFetchMiss{}
 	default:

--- a/momento/dictionary_fetch.go
+++ b/momento/dictionary_fetch.go
@@ -13,7 +13,7 @@ type DictionaryFetchResponse interface {
 }
 
 type DictionaryFetchHit struct {
-	items             map[string][]byte
+	elements          map[string][]byte
 	itemsStringString map[string]string
 }
 
@@ -26,7 +26,7 @@ func (resp DictionaryFetchHit) ValueMap() map[string]string {
 func (resp DictionaryFetchHit) ValueMapStringString() map[string]string {
 	if resp.itemsStringString == nil {
 		resp.itemsStringString = make(map[string]string)
-		for k, v := range resp.items {
+		for k, v := range resp.elements {
 			resp.itemsStringString[k] = string(v)
 		}
 	}
@@ -34,7 +34,7 @@ func (resp DictionaryFetchHit) ValueMapStringString() map[string]string {
 }
 
 func (resp DictionaryFetchHit) ValueMapStringByte() map[string][]byte {
-	return resp.items
+	return resp.elements
 }
 
 type DictionaryFetchMiss struct{}
@@ -80,11 +80,11 @@ func (r *DictionaryFetchRequest) makeGrpcRequest(metadata context.Context, clien
 func (r *DictionaryFetchRequest) interpretGrpcResponse() error {
 	switch rtype := r.grpcResponse.Dictionary.(type) {
 	case *pb.XDictionaryFetchResponse_Found:
-		items := make(map[string][]byte)
+		elements := make(map[string][]byte)
 		for _, i := range rtype.Found.Items {
-			items[(string(i.Field))] = i.Value
+			elements[(string(i.Field))] = i.Value
 		}
-		r.response = &DictionaryFetchHit{items: items}
+		r.response = &DictionaryFetchHit{elements: elements}
 	case *pb.XDictionaryFetchResponse_Missing:
 		r.response = &DictionaryFetchMiss{}
 	default:

--- a/momento/dictionary_get_fields.go
+++ b/momento/dictionary_get_fields.go
@@ -13,7 +13,7 @@ type DictionaryGetFieldsResponse interface {
 }
 
 type DictionaryGetFieldsHit struct {
-	items     []*pb.XDictionaryGetResponse_XDictionaryGetResponsePart
+	elements  []*pb.XDictionaryGetResponse_XDictionaryGetResponsePart
 	fields    [][]byte
 	responses []DictionaryGetFieldResponse
 }
@@ -26,7 +26,7 @@ func (resp DictionaryGetFieldsHit) ValueMap() map[string]string {
 
 func (resp DictionaryGetFieldsHit) ValueMapStringString() map[string]string {
 	ret := make(map[string]string)
-	for idx, item := range resp.items {
+	for idx, item := range resp.elements {
 		if item.Result == pb.ECacheResult_Hit {
 			ret[string(resp.fields[idx])] = string(item.CacheBody)
 		}
@@ -36,7 +36,7 @@ func (resp DictionaryGetFieldsHit) ValueMapStringString() map[string]string {
 
 func (resp DictionaryGetFieldsHit) ValueMapStringBytes() map[string][]byte {
 	ret := make(map[string][]byte)
-	for idx, item := range resp.items {
+	for idx, item := range resp.elements {
 		if item.Result == pb.ECacheResult_Hit {
 			ret[string(resp.fields[idx])] = item.CacheBody
 		}
@@ -117,7 +117,7 @@ func (r *DictionaryGetFieldsRequest) interpretGrpcResponse() error {
 			}
 			fields = append(fields, field)
 		}
-		r.response = &DictionaryGetFieldsHit{fields: fields, items: rtype.Found.Items, responses: responses}
+		r.response = &DictionaryGetFieldsHit{fields: fields, elements: rtype.Found.Items, responses: responses}
 	default:
 		return errUnexpectedGrpcResponse(r, r.grpcResponse)
 	}

--- a/momento/dictionary_get_fields.go
+++ b/momento/dictionary_get_fields.go
@@ -26,9 +26,9 @@ func (resp DictionaryGetFieldsHit) ValueMap() map[string]string {
 
 func (resp DictionaryGetFieldsHit) ValueMapStringString() map[string]string {
 	ret := make(map[string]string)
-	for idx, item := range resp.elements {
-		if item.Result == pb.ECacheResult_Hit {
-			ret[string(resp.fields[idx])] = string(item.CacheBody)
+	for idx, element := range resp.elements {
+		if element.Result == pb.ECacheResult_Hit {
+			ret[string(resp.fields[idx])] = string(element.CacheBody)
 		}
 	}
 	return ret
@@ -36,9 +36,9 @@ func (resp DictionaryGetFieldsHit) ValueMapStringString() map[string]string {
 
 func (resp DictionaryGetFieldsHit) ValueMapStringBytes() map[string][]byte {
 	ret := make(map[string][]byte)
-	for idx, item := range resp.elements {
-		if item.Result == pb.ECacheResult_Hit {
-			ret[string(resp.fields[idx])] = item.CacheBody
+	for idx, element := range resp.elements {
+		if element.Result == pb.ECacheResult_Hit {
+			ret[string(resp.fields[idx])] = element.CacheBody
 		}
 	}
 	return ret

--- a/momento/dictionary_increment.go
+++ b/momento/dictionary_increment.go
@@ -34,7 +34,7 @@ type DictionaryIncrementRequest struct {
 	DictionaryName string
 	Field          Value
 	Amount         int64
-	CollectionTTL  utils.CollectionTTL
+	CollectionTtl  utils.CollectionTtl
 
 	grpcRequest  *pb.XDictionaryIncrementRequest
 	grpcResponse *pb.XDictionaryIncrementResponse
@@ -45,7 +45,7 @@ func (r *DictionaryIncrementRequest) cacheName() string { return r.CacheName }
 
 func (r *DictionaryIncrementRequest) field() Value { return r.Field }
 
-func (r *DictionaryIncrementRequest) ttl() time.Duration { return r.CollectionTTL.Ttl }
+func (r *DictionaryIncrementRequest) ttl() time.Duration { return r.CollectionTtl.Ttl }
 
 func (r *DictionaryIncrementRequest) requestName() string { return "DictionaryFetch" }
 
@@ -79,7 +79,7 @@ func (r *DictionaryIncrementRequest) initGrpcRequest(client scsDataClient) error
 		Field:           field,
 		Amount:          r.Amount,
 		TtlMilliseconds: ttl,
-		RefreshTtl:      r.CollectionTTL.RefreshTtl,
+		RefreshTtl:      r.CollectionTtl.RefreshTtl,
 	}
 
 	return nil

--- a/momento/dictionary_set_field.go
+++ b/momento/dictionary_set_field.go
@@ -21,5 +21,5 @@ type DictionarySetFieldRequest struct {
 	DictionaryName string
 	Field          Value
 	Value          Value
-	CollectionTTL  utils.CollectionTTL
+	CollectionTtl  utils.CollectionTtl
 }

--- a/momento/dictionary_set_fields.go
+++ b/momento/dictionary_set_fields.go
@@ -25,7 +25,7 @@ type DictionarySetFieldsRequest struct {
 	CacheName      string
 	DictionaryName string
 	Elements       map[string]Value
-	CollectionTTL  utils.CollectionTTL
+	CollectionTtl  utils.CollectionTtl
 
 	grpcRequest  *pb.XDictionarySetRequest
 	grpcResponse *pb.XDictionarySetResponse
@@ -36,7 +36,7 @@ func (r *DictionarySetFieldsRequest) cacheName() string { return r.CacheName }
 
 func (r *DictionarySetFieldsRequest) elements() map[string]Value { return r.Elements }
 
-func (r *DictionarySetFieldsRequest) ttl() time.Duration { return r.CollectionTTL.Ttl }
+func (r *DictionarySetFieldsRequest) ttl() time.Duration { return r.CollectionTtl.Ttl }
 
 func (r *DictionarySetFieldsRequest) requestName() string { return "DictionarySetFields" }
 
@@ -69,7 +69,7 @@ func (r *DictionarySetFieldsRequest) initGrpcRequest(client scsDataClient) error
 		DictionaryName:  []byte(r.DictionaryName),
 		Items:           pbItems,
 		TtlMilliseconds: ttl,
-		RefreshTtl:      r.CollectionTTL.RefreshTtl,
+		RefreshTtl:      r.CollectionTtl.RefreshTtl,
 	}
 
 	return nil

--- a/momento/dictionary_set_fields.go
+++ b/momento/dictionary_set_fields.go
@@ -24,7 +24,7 @@ func (DictionarySetFieldsSuccess) isDictionarySetFieldsResponse() {}
 type DictionarySetFieldsRequest struct {
 	CacheName      string
 	DictionaryName string
-	Items          map[string]Value
+	Elements       map[string]Value
 	CollectionTTL  utils.CollectionTTL
 
 	grpcRequest  *pb.XDictionarySetRequest
@@ -34,7 +34,7 @@ type DictionarySetFieldsRequest struct {
 
 func (r *DictionarySetFieldsRequest) cacheName() string { return r.CacheName }
 
-func (r *DictionarySetFieldsRequest) items() map[string]Value { return r.Items }
+func (r *DictionarySetFieldsRequest) elements() map[string]Value { return r.Elements }
 
 func (r *DictionarySetFieldsRequest) ttl() time.Duration { return r.CollectionTTL.Ttl }
 
@@ -47,13 +47,13 @@ func (r *DictionarySetFieldsRequest) initGrpcRequest(client scsDataClient) error
 		return err
 	}
 
-	var items map[string][]byte
-	if items, err = prepareItems(r); err != nil {
+	var elements map[string][]byte
+	if elements, err = prepareItems(r); err != nil {
 		return err
 	}
 
 	var pbItems []*pb.XDictionaryFieldValuePair
-	for k, v := range items {
+	for k, v := range elements {
 		pbItems = append(pbItems, &pb.XDictionaryFieldValuePair{
 			Field: []byte(k),
 			Value: v,

--- a/momento/dictionary_set_fields.go
+++ b/momento/dictionary_set_fields.go
@@ -48,13 +48,13 @@ func (r *DictionarySetFieldsRequest) initGrpcRequest(client scsDataClient) error
 	}
 
 	var elements map[string][]byte
-	if elements, err = prepareItems(r); err != nil {
+	if elements, err = prepareElements(r); err != nil {
 		return err
 	}
 
-	var pbItems []*pb.XDictionaryFieldValuePair
+	var pbElements []*pb.XDictionaryFieldValuePair
 	for k, v := range elements {
-		pbItems = append(pbItems, &pb.XDictionaryFieldValuePair{
+		pbElements = append(pbElements, &pb.XDictionaryFieldValuePair{
 			Field: []byte(k),
 			Value: v,
 		})
@@ -67,7 +67,7 @@ func (r *DictionarySetFieldsRequest) initGrpcRequest(client scsDataClient) error
 
 	r.grpcRequest = &pb.XDictionarySetRequest{
 		DictionaryName:  []byte(r.DictionaryName),
-		Items:           pbItems,
+		Items:           pbElements,
 		TtlMilliseconds: ttl,
 		RefreshTtl:      r.CollectionTtl.RefreshTtl,
 	}

--- a/momento/dictionary_test.go
+++ b/momento/dictionary_test.go
@@ -4,10 +4,13 @@ import (
 	"reflect"
 	"time"
 
-	"github.com/google/uuid"
 	. "github.com/momentohq/client-sdk-go/momento"
 	. "github.com/momentohq/client-sdk-go/momento/test_helpers"
 	"github.com/momentohq/client-sdk-go/utils"
+
+	"github.com/google/uuid"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("Dictionary methods", func() {

--- a/momento/dictionary_test.go
+++ b/momento/dictionary_test.go
@@ -77,7 +77,7 @@ var _ = Describe("Dictionary methods", func() {
 					DictionaryName: dictionaryName,
 					Field:          String("hi"),
 					Value:          String("hi"),
-					CollectionTTL:  utils.CollectionTTL{},
+					CollectionTtl:  utils.CollectionTtl{},
 				}),
 			).Error().To(HaveMomentoErrorCode(expectedErrorCode))
 
@@ -86,7 +86,7 @@ var _ = Describe("Dictionary methods", func() {
 					CacheName:      cacheName,
 					DictionaryName: dictionaryName,
 					Elements:       nil,
-					CollectionTTL:  utils.CollectionTTL{},
+					CollectionTtl:  utils.CollectionTtl{},
 				}),
 			).Error().To(HaveMomentoErrorCode(expectedErrorCode))
 		},
@@ -600,7 +600,7 @@ var _ = Describe("Dictionary methods", func() {
 						DictionaryName: sharedContext.CollectionName,
 						Field:          String("foo"),
 						Value:          String("bar"),
-						CollectionTTL:  utils.CollectionTTL{},
+						CollectionTtl:  utils.CollectionTtl{},
 					}),
 				).To(BeAssignableToTypeOf(&DictionarySetFieldSuccess{}))
 
@@ -625,7 +625,7 @@ var _ = Describe("Dictionary methods", func() {
 						DictionaryName: sharedContext.CollectionName,
 						Field:          String("myField3"),
 						Value:          String("myValue3"),
-						CollectionTTL: utils.CollectionTTL{
+						CollectionTtl: utils.CollectionTtl{
 							Ttl:        sharedContext.DefaultTTL + time.Second*60,
 							RefreshTtl: false,
 						},
@@ -649,7 +649,7 @@ var _ = Describe("Dictionary methods", func() {
 						DictionaryName: sharedContext.CollectionName,
 						Field:          String("myField3"),
 						Value:          String("myValue3"),
-						CollectionTTL: utils.CollectionTTL{
+						CollectionTtl: utils.CollectionTtl{
 							Ttl:        sharedContext.DefaultTTL + time.Second*60,
 							RefreshTtl: true,
 						},

--- a/momento/dictionary_test.go
+++ b/momento/dictionary_test.go
@@ -5,9 +5,6 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
-
 	. "github.com/momentohq/client-sdk-go/momento"
 	. "github.com/momentohq/client-sdk-go/momento/test_helpers"
 	"github.com/momentohq/client-sdk-go/utils"
@@ -88,7 +85,7 @@ var _ = Describe("Dictionary methods", func() {
 				sharedContext.Client.DictionarySetFields(sharedContext.Ctx, &DictionarySetFieldsRequest{
 					CacheName:      cacheName,
 					DictionaryName: dictionaryName,
-					Items:          nil,
+					Elements:       nil,
 					CollectionTTL:  utils.CollectionTTL{},
 				}),
 			).Error().To(HaveMomentoErrorCode(expectedErrorCode))
@@ -141,12 +138,12 @@ var _ = Describe("Dictionary methods", func() {
 	})
 
 	DescribeTable("add string fields and string and bytes values for set fields happy path",
-		func(items map[string]Value, expectedItemsStringValue map[string]string, expectedItemsByteValue map[string][]byte) {
+		func(elements map[string]Value, expectedItemsStringValue map[string]string, expectedItemsByteValue map[string][]byte) {
 			Expect(
 				sharedContext.Client.DictionarySetFields(sharedContext.Ctx, &DictionarySetFieldsRequest{
 					CacheName:      sharedContext.CacheName,
 					DictionaryName: sharedContext.CollectionName,
-					Items:          items,
+					Elements:       elements,
 				}),
 			).To(BeAssignableToTypeOf(&DictionarySetFieldsSuccess{}))
 			fetchResp, err := sharedContext.Client.DictionaryFetch(sharedContext.Ctx, &DictionaryFetchRequest{
@@ -188,7 +185,7 @@ var _ = Describe("Dictionary methods", func() {
 			sharedContext.Client.DictionarySetFields(sharedContext.Ctx, &DictionarySetFieldsRequest{
 				CacheName:      sharedContext.CacheName,
 				DictionaryName: sharedContext.CollectionName,
-				Items:          map[string]Value{"myField": String("myValue"), "": String("myOtherValue")},
+				Elements:       map[string]Value{"myField": String("myValue"), "": String("myOtherValue")},
 			}),
 		).Error().To(HaveMomentoErrorCode(InvalidArgumentError))
 	})
@@ -275,7 +272,7 @@ var _ = Describe("Dictionary methods", func() {
 				sharedContext.Client.DictionarySetFields(sharedContext.Ctx, &DictionarySetFieldsRequest{
 					CacheName:      sharedContext.CacheName,
 					DictionaryName: sharedContext.CollectionName,
-					Items:          map[string]Value{"myField1": String("myValue1"), "myField2": Bytes("myValue2")},
+					Elements:       map[string]Value{"myField1": String("myValue1"), "myField2": Bytes("myValue2")},
 				}),
 			).To(BeAssignableToTypeOf(&DictionarySetFieldsSuccess{}))
 		})
@@ -403,7 +400,7 @@ var _ = Describe("Dictionary methods", func() {
 				sharedContext.Client.DictionarySetFields(sharedContext.Ctx, &DictionarySetFieldsRequest{
 					CacheName:      sharedContext.CacheName,
 					DictionaryName: sharedContext.CollectionName,
-					Items:          map[string]Value{"myField1": String("myValue1"), "myField2": Bytes("myValue2")},
+					Elements:       map[string]Value{"myField1": String("myValue1"), "myField2": Bytes("myValue2")},
 				}),
 			).To(BeAssignableToTypeOf(&DictionarySetFieldsSuccess{}))
 		})
@@ -440,7 +437,7 @@ var _ = Describe("Dictionary methods", func() {
 				sharedContext.Client.DictionarySetFields(sharedContext.Ctx, &DictionarySetFieldsRequest{
 					CacheName:      sharedContext.CacheName,
 					DictionaryName: sharedContext.CollectionName,
-					Items: map[string]Value{
+					Elements: map[string]Value{
 						"myField1": String("myValue1"),
 						"myField2": Bytes("myValue2"),
 						"myField3": String("myValue3"),
@@ -556,7 +553,7 @@ var _ = Describe("Dictionary methods", func() {
 					sharedContext.Client.DictionarySetFields(sharedContext.Ctx, &DictionarySetFieldsRequest{
 						CacheName:      sharedContext.CacheName,
 						DictionaryName: sharedContext.CollectionName,
-						Items:          map[string]Value{"myField1": String("myValue1"), "myField2": String("myValue2")},
+						Elements:       map[string]Value{"myField1": String("myValue1"), "myField2": String("myValue2")},
 					}),
 				).Error().To(BeNil())
 
@@ -588,7 +585,7 @@ var _ = Describe("Dictionary methods", func() {
 				sharedContext.Client.DictionarySetFields(sharedContext.Ctx, &DictionarySetFieldsRequest{
 					CacheName:      sharedContext.CacheName,
 					DictionaryName: sharedContext.CollectionName,
-					Items:          map[string]Value{"myField1": String("myValue1"), "myField2": String("myValue2")},
+					Elements:       map[string]Value{"myField1": String("myValue1"), "myField2": String("myValue2")},
 				}),
 			).Error().To(BeNil())
 		})

--- a/momento/list_concatenate_back.go
+++ b/momento/list_concatenate_back.go
@@ -31,7 +31,7 @@ type ListConcatenateBackRequest struct {
 	ListName            string
 	Values              []Value
 	TruncateFrontToSize uint32
-	CollectionTTL       utils.CollectionTTL
+	CollectionTtl       utils.CollectionTtl
 
 	grpcRequest  *pb.XListConcatenateBackRequest
 	grpcResponse *pb.XListConcatenateBackResponse
@@ -42,7 +42,7 @@ func (r *ListConcatenateBackRequest) cacheName() string { return r.CacheName }
 
 func (r *ListConcatenateBackRequest) values() []Value { return r.Values }
 
-func (r *ListConcatenateBackRequest) ttl() time.Duration { return r.CollectionTTL.Ttl }
+func (r *ListConcatenateBackRequest) ttl() time.Duration { return r.CollectionTtl.Ttl }
 
 func (r *ListConcatenateBackRequest) requestName() string { return "ListConcatenateBack" }
 
@@ -67,7 +67,7 @@ func (r *ListConcatenateBackRequest) initGrpcRequest(client scsDataClient) error
 		ListName:            []byte(r.ListName),
 		Values:              values,
 		TtlMilliseconds:     ttl,
-		RefreshTtl:          r.CollectionTTL.RefreshTtl,
+		RefreshTtl:          r.CollectionTtl.RefreshTtl,
 		TruncateFrontToSize: r.TruncateFrontToSize,
 	}
 

--- a/momento/list_concatenate_front.go
+++ b/momento/list_concatenate_front.go
@@ -31,7 +31,7 @@ type ListConcatenateFrontRequest struct {
 	ListName           string
 	Values             []Value
 	TruncateBackToSize uint32
-	CollectionTTL      utils.CollectionTTL
+	CollectionTtl      utils.CollectionTtl
 
 	grpcRequest  *pb.XListConcatenateFrontRequest
 	grpcResponse *pb.XListConcatenateFrontResponse
@@ -42,7 +42,7 @@ func (r *ListConcatenateFrontRequest) cacheName() string { return r.CacheName }
 
 func (r *ListConcatenateFrontRequest) values() []Value { return r.Values }
 
-func (r *ListConcatenateFrontRequest) ttl() time.Duration { return r.CollectionTTL.Ttl }
+func (r *ListConcatenateFrontRequest) ttl() time.Duration { return r.CollectionTtl.Ttl }
 
 func (r *ListConcatenateFrontRequest) requestName() string { return "ListConcatenateFront" }
 
@@ -67,7 +67,7 @@ func (r *ListConcatenateFrontRequest) initGrpcRequest(client scsDataClient) erro
 		ListName:           []byte(r.ListName),
 		Values:             values,
 		TtlMilliseconds:    ttl,
-		RefreshTtl:         r.CollectionTTL.RefreshTtl,
+		RefreshTtl:         r.CollectionTtl.RefreshTtl,
 		TruncateBackToSize: r.TruncateBackToSize,
 	}
 

--- a/momento/list_push_back.go
+++ b/momento/list_push_back.go
@@ -32,7 +32,7 @@ type ListPushBackRequest struct {
 	ListName            string
 	Value               Value
 	TruncateFrontToSize uint32
-	CollectionTTL       utils.CollectionTTL
+	CollectionTtl       utils.CollectionTtl
 
 	grpcRequest  *pb.XListPushBackRequest
 	grpcResponse *pb.XListPushBackResponse
@@ -43,7 +43,7 @@ func (r *ListPushBackRequest) cacheName() string { return r.CacheName }
 
 func (r *ListPushBackRequest) value() Value { return r.Value }
 
-func (r *ListPushBackRequest) ttl() time.Duration { return r.CollectionTTL.Ttl }
+func (r *ListPushBackRequest) ttl() time.Duration { return r.CollectionTtl.Ttl }
 
 func (r *ListPushBackRequest) requestName() string { return "ListPushBack" }
 
@@ -68,7 +68,7 @@ func (r *ListPushBackRequest) initGrpcRequest(client scsDataClient) error {
 		ListName:            []byte(r.ListName),
 		Value:               value,
 		TtlMilliseconds:     ttl,
-		RefreshTtl:          r.CollectionTTL.RefreshTtl,
+		RefreshTtl:          r.CollectionTtl.RefreshTtl,
 		TruncateFrontToSize: r.TruncateFrontToSize,
 	}
 

--- a/momento/list_push_front.go
+++ b/momento/list_push_front.go
@@ -32,7 +32,7 @@ type ListPushFrontRequest struct {
 	ListName           string
 	Value              Value
 	TruncateBackToSize uint32
-	CollectionTTL      utils.CollectionTTL
+	CollectionTtl      utils.CollectionTtl
 
 	grpcRequest  *pb.XListPushFrontRequest
 	grpcResponse *pb.XListPushFrontResponse
@@ -43,7 +43,7 @@ func (r *ListPushFrontRequest) cacheName() string { return r.CacheName }
 
 func (r *ListPushFrontRequest) value() Value { return r.Value }
 
-func (r *ListPushFrontRequest) ttl() time.Duration { return r.CollectionTTL.Ttl }
+func (r *ListPushFrontRequest) ttl() time.Duration { return r.CollectionTtl.Ttl }
 
 func (r *ListPushFrontRequest) requestName() string { return "ListPushFront" }
 
@@ -68,7 +68,7 @@ func (r *ListPushFrontRequest) initGrpcRequest(client scsDataClient) error {
 		ListName:           []byte(r.ListName),
 		Value:              value,
 		TtlMilliseconds:    ttl,
-		RefreshTtl:         r.CollectionTTL.RefreshTtl,
+		RefreshTtl:         r.CollectionTtl.RefreshTtl,
 		TruncateBackToSize: r.TruncateBackToSize,
 	}
 

--- a/momento/requester.go
+++ b/momento/requester.go
@@ -62,8 +62,8 @@ type hasFields interface {
 	fields() []Value
 }
 
-type hasItems interface {
-	items() map[string]Value
+type hasElements interface {
+	elements() map[string]Value
 }
 
 type hasTTL interface {
@@ -131,9 +131,9 @@ func prepareValues(r hasValues) ([][]byte, momentoerrors.MomentoSvcErr) {
 	return values, nil
 }
 
-func prepareItems(r hasItems) (map[string][]byte, error) {
+func prepareItems(r hasElements) (map[string][]byte, error) {
 	retMap := make(map[string][]byte)
-	for k, v := range r.items() {
+	for k, v := range r.elements() {
 		if v == nil {
 			return map[string][]byte{}, momentoerrors.NewMomentoSvcErr(
 				momentoerrors.InvalidArgumentError,

--- a/momento/requester.go
+++ b/momento/requester.go
@@ -131,7 +131,7 @@ func prepareValues(r hasValues) ([][]byte, momentoerrors.MomentoSvcErr) {
 	return values, nil
 }
 
-func prepareItems(r hasElements) (map[string][]byte, error) {
+func prepareElements(r hasElements) (map[string][]byte, error) {
 	retMap := make(map[string][]byte)
 	for k, v := range r.elements() {
 		if v == nil {

--- a/momento/requester.template
+++ b/momento/requester.template
@@ -1,9 +1,9 @@
 // This is a template for making a new requester.
-// Each SimpleCacheClient method should have a corresponding requester.
+// Each CacheClient method should have a corresponding requester.
 // The requester is used in scsDataClient.makeRequest().
 //
 // For this example we'll be assuming you'r writing
-// SimpleCacheClient.DictionaryIterate()
+// CacheClient.DictionaryIterate()
 //
 // 1. Copy this file and give it the appropriate name. (momento/dictionary-iterate.go)
 // 2. Search and replace "Template" with the name of your method. (DictionaryIterate)
@@ -77,7 +77,7 @@ func (r *TemplateRequest) makeGrpcRequest(metadata context.Context, client scsDa
 }
 
 // Translate the GRPC response in r.grpcResponse into a Momento response.
-// Store the result in r.repsonse. This response will be returned from SimpleCacheClient.
+// Store the result in r.repsonse. This response will be returned from CacheClient.
 func (r *TemplateRequest) interpretGrpcResponse() error {
 	r.response = TemplateSuccess{}
 	return nil

--- a/momento/set_add_element.go
+++ b/momento/set_add_element.go
@@ -20,5 +20,5 @@ type SetAddElementRequest struct {
 	CacheName     string
 	SetName       string
 	Element       Value
-	CollectionTTL utils.CollectionTTL
+	CollectionTtl utils.CollectionTtl
 }

--- a/momento/set_add_elements.go
+++ b/momento/set_add_elements.go
@@ -24,7 +24,7 @@ type SetAddElementsRequest struct {
 	CacheName     string
 	SetName       string
 	Elements      []Value
-	CollectionTTL utils.CollectionTTL
+	CollectionTtl utils.CollectionTtl
 
 	grpcRequest  *pb.XSetUnionRequest
 	grpcResponse *pb.XSetUnionResponse
@@ -34,7 +34,7 @@ type SetAddElementsRequest struct {
 func (r *SetAddElementsRequest) cacheName() string { return r.CacheName }
 
 func (r *SetAddElementsRequest) ttl() time.Duration {
-	return r.CollectionTTL.Ttl
+	return r.CollectionTtl.Ttl
 }
 
 func (r *SetAddElementsRequest) requestName() string { return "SetAddElements" }
@@ -60,7 +60,7 @@ func (r *SetAddElementsRequest) initGrpcRequest(client scsDataClient) error {
 		SetName:         []byte(r.SetName),
 		Elements:        elements,
 		TtlMilliseconds: ttl,
-		RefreshTtl:      r.CollectionTTL.RefreshTtl,
+		RefreshTtl:      r.CollectionTtl.RefreshTtl,
 	}
 
 	return nil

--- a/momento/set_test.go
+++ b/momento/set_test.go
@@ -4,11 +4,13 @@ import (
 	"fmt"
 	"time"
 
+	. "github.com/momentohq/client-sdk-go/momento"
+	. "github.com/momentohq/client-sdk-go/momento/test_helpers"
 	"github.com/momentohq/client-sdk-go/utils"
 
 	"github.com/google/uuid"
-	. "github.com/momentohq/client-sdk-go/momento"
-	. "github.com/momentohq/client-sdk-go/momento/test_helpers"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 )
 
 func getElements(numElements int) []Value {

--- a/momento/set_test.go
+++ b/momento/set_test.go
@@ -7,9 +7,6 @@ import (
 	"github.com/momentohq/client-sdk-go/utils"
 
 	"github.com/google/uuid"
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
-
 	. "github.com/momentohq/client-sdk-go/momento"
 	. "github.com/momentohq/client-sdk-go/momento/test_helpers"
 )
@@ -292,7 +289,7 @@ var _ = Describe("Set methods", func() {
 						CacheName: sharedContext.CacheName,
 						SetName:   sharedContext.CollectionName,
 						Element:   String("hello"),
-						CollectionTTL: utils.CollectionTTL{
+						CollectionTtl: utils.CollectionTtl{
 							Ttl:        sharedContext.DefaultTTL + time.Second*60,
 							RefreshTtl: true,
 						},
@@ -322,7 +319,7 @@ var _ = Describe("Set methods", func() {
 						CacheName: sharedContext.CacheName,
 						SetName:   sharedContext.CollectionName,
 						Element:   String("hello"),
-						CollectionTTL: utils.CollectionTTL{
+						CollectionTtl: utils.CollectionTtl{
 							Ttl:        sharedContext.DefaultTTL + 1*time.Second,
 							RefreshTtl: false,
 						},
@@ -352,7 +349,7 @@ var _ = Describe("Set methods", func() {
 						CacheName: sharedContext.CacheName,
 						SetName:   sharedContext.CollectionName,
 						Element:   String("hello"),
-						CollectionTTL: utils.CollectionTTL{
+						CollectionTtl: utils.CollectionTtl{
 							Ttl:        time.Millisecond * 20,
 							RefreshTtl: false,
 						},
@@ -382,7 +379,7 @@ var _ = Describe("Set methods", func() {
 						CacheName: sharedContext.CacheName,
 						SetName:   sharedContext.CollectionName,
 						Element:   String("hello"),
-						CollectionTTL: utils.CollectionTTL{
+						CollectionTtl: utils.CollectionTtl{
 							Ttl:        time.Millisecond * 200,
 							RefreshTtl: true,
 						},

--- a/momento/simple_cache_client.go
+++ b/momento/simple_cache_client.go
@@ -1,4 +1,4 @@
-// Package momento represents API SimpleCacheClient interface accessors including control/data operations, errors, operation requests and responses for the SDK.
+// Package momento represents API CacheClient interface accessors including control/data operations, errors, operation requests and responses for the SDK.
 package momento
 
 import (
@@ -13,7 +13,7 @@ import (
 	"github.com/momentohq/client-sdk-go/internal/services"
 )
 
-type SimpleCacheClient interface {
+type CacheClient interface {
 	CreateCache(ctx context.Context, request *CreateCacheRequest) (CreateCacheResponse, error)
 	DeleteCache(ctx context.Context, request *DeleteCacheRequest) (DeleteCacheResponse, error)
 	ListCaches(ctx context.Context, request *ListCachesRequest) (ListCachesResponse, error)
@@ -74,8 +74,8 @@ type SimpleCacheClientProps struct {
 	DefaultTTL         time.Duration
 }
 
-// NewSimpleCacheClient returns a new SimpleCacheClient with provided authToken, DefaultTTLSeconds, and opts arguments.
-func NewSimpleCacheClient(props *SimpleCacheClientProps) (SimpleCacheClient, error) {
+// NewSimpleCacheClient returns a new CacheClient with provided authToken, DefaultTTLSeconds, and opts arguments.
+func NewSimpleCacheClient(props *SimpleCacheClientProps) (CacheClient, error) {
 	if props.Configuration.GetClientSideTimeout() < 1 {
 		return nil, momentoerrors.NewMomentoSvcErr(momentoerrors.InvalidArgumentError, "request timeout must not be 0", nil)
 	}

--- a/momento/simple_cache_client.go
+++ b/momento/simple_cache_client.go
@@ -371,12 +371,12 @@ func (c defaultScsClient) ListRemoveValue(ctx context.Context, r *ListRemoveValu
 }
 
 func (c defaultScsClient) DictionarySetField(ctx context.Context, r *DictionarySetFieldRequest) (DictionarySetFieldResponse, error) {
-	items := make(map[string]Value)
-	items[string(r.Field.asBytes())] = r.Value
+	elements := make(map[string]Value)
+	elements[string(r.Field.asBytes())] = r.Value
 	newRequest := &DictionarySetFieldsRequest{
 		CacheName:      r.CacheName,
 		DictionaryName: r.DictionaryName,
-		Items:          items,
+		Elements:       elements,
 		CollectionTTL:  r.CollectionTTL,
 	}
 	if err := c.dataClient.makeRequest(ctx, newRequest); err != nil {
@@ -416,7 +416,7 @@ func (c defaultScsClient) DictionaryGetField(ctx context.Context, r *DictionaryG
 		case *DictionaryGetFieldHit:
 			return &DictionaryGetFieldHit{
 				field: rtype.fields[0],
-				body:  rtype.items[0].CacheBody,
+				body:  rtype.elements[0].CacheBody,
 			}, nil
 		case *DictionaryGetFieldMiss:
 			return &DictionaryGetFieldMiss{}, nil

--- a/momento/simple_cache_client.go
+++ b/momento/simple_cache_client.go
@@ -273,7 +273,7 @@ func (c defaultScsClient) SetAddElement(ctx context.Context, r *SetAddElementReq
 		CacheName:     r.CacheName,
 		SetName:       r.SetName,
 		Elements:      []Value{r.Element},
-		CollectionTTL: r.CollectionTTL,
+		CollectionTtl: r.CollectionTtl,
 	}
 	if err := c.dataClient.makeRequest(ctx, newRequest); err != nil {
 		return nil, err
@@ -377,7 +377,7 @@ func (c defaultScsClient) DictionarySetField(ctx context.Context, r *DictionaryS
 		CacheName:      r.CacheName,
 		DictionaryName: r.DictionaryName,
 		Elements:       elements,
-		CollectionTTL:  r.CollectionTTL,
+		CollectionTtl:  r.CollectionTtl,
 	}
 	if err := c.dataClient.makeRequest(ctx, newRequest); err != nil {
 		return nil, err

--- a/momento/simple_cache_client.go
+++ b/momento/simple_cache_client.go
@@ -68,14 +68,14 @@ type defaultScsClient struct {
 	pubSubClient       *pubSubClient
 }
 
-type SimpleCacheClientProps struct {
+type CacheClientProps struct {
 	Configuration      config.Configuration
 	CredentialProvider auth.CredentialProvider
 	DefaultTTL         time.Duration
 }
 
-// NewSimpleCacheClient returns a new CacheClient with provided authToken, DefaultTTLSeconds, and opts arguments.
-func NewSimpleCacheClient(props *SimpleCacheClientProps) (CacheClient, error) {
+// NewCacheClient returns a new CacheClient with provided authToken, DefaultTTLSeconds, and opts arguments.
+func NewCacheClient(props *CacheClientProps) (CacheClient, error) {
 	if props.Configuration.GetClientSideTimeout() < 1 {
 		return nil, momentoerrors.NewMomentoSvcErr(momentoerrors.InvalidArgumentError, "request timeout must not be 0", nil)
 	}

--- a/momento/simple_cache_client_test.go
+++ b/momento/simple_cache_client_test.go
@@ -21,7 +21,7 @@ var _ = Describe("CacheClient", func() {
 
 	It(`errors on an invalid TTL`, func() {
 		sharedContext.ClientProps.DefaultTTL = 0 * time.Second
-		client, err := NewSimpleCacheClient(sharedContext.ClientProps)
+		client, err := NewCacheClient(sharedContext.ClientProps)
 
 		Expect(client).To(BeNil())
 		Expect(err).NotTo(BeNil())
@@ -35,7 +35,7 @@ var _ = Describe("CacheClient", func() {
 		badRequestTimeout := 0 * time.Second
 		sharedContext.ClientProps.Configuration = config.LatestLaptopConfig().WithClientTimeout(badRequestTimeout)
 		Expect(
-			NewSimpleCacheClient(sharedContext.ClientProps),
+			NewCacheClient(sharedContext.ClientProps),
 		).Error().To(HaveMomentoErrorCode(InvalidArgumentError))
 	})
 })

--- a/momento/simple_cache_client_test.go
+++ b/momento/simple_cache_client_test.go
@@ -4,15 +4,12 @@ import (
 	"errors"
 	"time"
 
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
-
 	"github.com/momentohq/client-sdk-go/config"
 	. "github.com/momentohq/client-sdk-go/momento"
 	. "github.com/momentohq/client-sdk-go/momento/test_helpers"
 )
 
-var _ = Describe("SimpleCacheClient", func() {
+var _ = Describe("CacheClient", func() {
 	var sharedContext SharedContext
 
 	BeforeEach(func() {

--- a/momento/simple_cache_client_test.go
+++ b/momento/simple_cache_client_test.go
@@ -7,6 +7,9 @@ import (
 	"github.com/momentohq/client-sdk-go/config"
 	. "github.com/momentohq/client-sdk-go/momento"
 	. "github.com/momentohq/client-sdk-go/momento/test_helpers"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("CacheClient", func() {

--- a/momento/sorted_set_increment_score.go
+++ b/momento/sorted_set_increment_score.go
@@ -29,7 +29,7 @@ type SortedSetIncrementScoreRequest struct {
 	SetName       string
 	ElementName   Value
 	Amount        float64
-	CollectionTTL utils.CollectionTTL
+	CollectionTtl utils.CollectionTtl
 
 	grpcRequest  *pb.XSortedSetIncrementRequest
 	grpcResponse *pb.XSortedSetIncrementResponse
@@ -40,7 +40,7 @@ func (r *SortedSetIncrementScoreRequest) cacheName() string { return r.CacheName
 
 func (r *SortedSetIncrementScoreRequest) requestName() string { return "Sorted set increment" }
 
-func (r *SortedSetIncrementScoreRequest) ttl() time.Duration { return r.CollectionTTL.Ttl }
+func (r *SortedSetIncrementScoreRequest) ttl() time.Duration { return r.CollectionTtl.Ttl }
 
 func (r *SortedSetIncrementScoreRequest) initGrpcRequest(client scsDataClient) error {
 	var err error
@@ -67,7 +67,7 @@ func (r *SortedSetIncrementScoreRequest) initGrpcRequest(client scsDataClient) e
 		ElementName:     r.ElementName.asBytes(),
 		Amount:          r.Amount,
 		TtlMilliseconds: ttlMillis,
-		RefreshTtl:      r.CollectionTTL.RefreshTtl,
+		RefreshTtl:      r.CollectionTtl.RefreshTtl,
 	}
 	return nil
 }

--- a/momento/sorted_set_put.go
+++ b/momento/sorted_set_put.go
@@ -29,7 +29,7 @@ type SortedSetPutRequest struct {
 	CacheName     string
 	SetName       string
 	Elements      []*SortedSetPutElement
-	CollectionTTL utils.CollectionTTL
+	CollectionTtl utils.CollectionTtl
 
 	grpcRequest  *pb.XSortedSetPutRequest
 	grpcResponse *pb.XSortedSetPutResponse
@@ -40,7 +40,7 @@ func (r *SortedSetPutRequest) cacheName() string { return r.CacheName }
 
 func (r *SortedSetPutRequest) requestName() string { return "Sorted set put" }
 
-func (r *SortedSetPutRequest) ttl() time.Duration { return r.CollectionTTL.Ttl }
+func (r *SortedSetPutRequest) ttl() time.Duration { return r.CollectionTtl.Ttl }
 
 func (r *SortedSetPutRequest) initGrpcRequest(client scsDataClient) error {
 	var err error
@@ -60,7 +60,7 @@ func (r *SortedSetPutRequest) initGrpcRequest(client scsDataClient) error {
 		SetName:         []byte(r.SetName),
 		Elements:        elements,
 		TtlMilliseconds: ttlMills,
-		RefreshTtl:      r.CollectionTTL.RefreshTtl,
+		RefreshTtl:      r.CollectionTtl.RefreshTtl,
 	}
 	return nil
 }

--- a/momento/sorted_set_test.go
+++ b/momento/sorted_set_test.go
@@ -7,8 +7,6 @@ import (
 	. "github.com/momentohq/client-sdk-go/momento"
 	. "github.com/momentohq/client-sdk-go/momento/test_helpers"
 	"github.com/momentohq/client-sdk-go/utils"
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("SortedSet", func() {
@@ -99,9 +97,9 @@ var _ = Describe("SortedSet", func() {
 		Entry("Non-existant cache", uuid.NewString(), uuid.NewString(), NotFoundError),
 	)
 
-	DescribeTable(`Honors CollectionTTL`,
+	DescribeTable(`Honors CollectionTtl  `,
 		func(
-			changer func(SortedSetPutElement, *utils.CollectionTTL),
+			changer func(SortedSetPutElement, *utils.CollectionTtl),
 		) {
 			value := "foo"
 			element := SortedSetPutElement{
@@ -129,7 +127,7 @@ var _ = Describe("SortedSet", func() {
 			putElements([]*SortedSetPutElement{{Value: String(value), Score: 0}})
 			changer(
 				element,
-				&utils.CollectionTTL{
+				&utils.CollectionTtl{
 					Ttl:        5 * time.Hour,
 					RefreshTtl: false,
 				},
@@ -145,7 +143,7 @@ var _ = Describe("SortedSet", func() {
 			putElements([]*SortedSetPutElement{{Value: String(value), Score: 0}})
 			changer(
 				element,
-				&utils.CollectionTTL{
+				&utils.CollectionTtl{
 					Ttl:        sharedContext.DefaultTTL + 1*time.Second,
 					RefreshTtl: true,
 				},
@@ -163,7 +161,7 @@ var _ = Describe("SortedSet", func() {
 		},
 		Entry(
 			`SortedSetIncrementScore`,
-			func(element SortedSetPutElement, ttl *utils.CollectionTTL) {
+			func(element SortedSetPutElement, ttl *utils.CollectionTtl) {
 				request := &SortedSetIncrementScoreRequest{
 					CacheName:   sharedContext.CacheName,
 					SetName:     sharedContext.CollectionName,
@@ -171,7 +169,7 @@ var _ = Describe("SortedSet", func() {
 					Amount:      element.Score,
 				}
 				if ttl != nil {
-					request.CollectionTTL = *ttl
+					request.CollectionTtl = *ttl
 				}
 
 				Expect(
@@ -180,14 +178,14 @@ var _ = Describe("SortedSet", func() {
 			},
 		),
 		Entry(`SortedSetPut`,
-			func(element SortedSetPutElement, ttl *utils.CollectionTTL) {
+			func(element SortedSetPutElement, ttl *utils.CollectionTtl) {
 				request := &SortedSetPutRequest{
 					CacheName: sharedContext.CacheName,
 					SetName:   sharedContext.CollectionName,
 					Elements:  []*SortedSetPutElement{&element},
 				}
 				if ttl != nil {
-					request.CollectionTTL = *ttl
+					request.CollectionTtl = *ttl
 				}
 
 				Expect(

--- a/momento/sorted_set_test.go
+++ b/momento/sorted_set_test.go
@@ -3,10 +3,13 @@ package momento_test
 import (
 	"time"
 
-	"github.com/google/uuid"
 	. "github.com/momentohq/client-sdk-go/momento"
 	. "github.com/momentohq/client-sdk-go/momento/test_helpers"
 	"github.com/momentohq/client-sdk-go/utils"
+
+	"github.com/google/uuid"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("SortedSet", func() {

--- a/momento/test_helpers/shared_context.go
+++ b/momento/test_helpers/shared_context.go
@@ -12,7 +12,7 @@ import (
 
 type SharedContext struct {
 	ClientProps        *momento.SimpleCacheClientProps
-	Client             momento.SimpleCacheClient
+	Client             momento.CacheClient
 	CacheName          string
 	CollectionName     string
 	Ctx                context.Context

--- a/momento/test_helpers/shared_context.go
+++ b/momento/test_helpers/shared_context.go
@@ -11,7 +11,7 @@ import (
 )
 
 type SharedContext struct {
-	ClientProps        *momento.SimpleCacheClientProps
+	ClientProps        *momento.CacheClientProps
 	Client             momento.CacheClient
 	CacheName          string
 	CollectionName     string
@@ -30,14 +30,14 @@ func NewSharedContext() SharedContext {
 	shared.Configuration = config.LatestLaptopConfig()
 	shared.DefaultTTL = 3 * time.Second
 
-	shared.ClientProps = &momento.SimpleCacheClientProps{
+	shared.ClientProps = &momento.CacheClientProps{
 		CredentialProvider: shared.CredentialProvider,
 		Configuration:      shared.Configuration,
 		DefaultTTL:         shared.DefaultTTL,
 	}
 
 	var err error
-	client, err := momento.NewSimpleCacheClient(shared.ClientProps)
+	client, err := momento.NewCacheClient(shared.ClientProps)
 	if err != nil {
 		panic(err)
 	}

--- a/utils/collection_ttl.go
+++ b/utils/collection_ttl.go
@@ -2,36 +2,36 @@ package utils
 
 import "time"
 
-type CollectionTTL struct {
+type CollectionTtl struct {
 	Ttl        time.Duration
 	RefreshTtl bool
 }
 
-func FromCacheTtl() CollectionTTL {
-	return CollectionTTL{RefreshTtl: true}
+func FromCacheTtl() CollectionTtl {
+	return CollectionTtl{RefreshTtl: true}
 }
 
-func Of(ttl time.Duration) CollectionTTL {
-	return CollectionTTL{Ttl: ttl}
+func Of(ttl time.Duration) CollectionTtl {
+	return CollectionTtl{Ttl: ttl}
 }
 
-func RefreshTtlIfProvided(ttl ...time.Duration) CollectionTTL {
+func RefreshTtlIfProvided(ttl ...time.Duration) CollectionTtl {
 	if len(ttl) > 0 {
-		return CollectionTTL{Ttl: ttl[0], RefreshTtl: true}
+		return CollectionTtl{Ttl: ttl[0], RefreshTtl: true}
 	}
-	return CollectionTTL{RefreshTtl: false}
+	return CollectionTtl{RefreshTtl: false}
 }
 
-func WithRefreshTtlOnUpdates(currentCollectionTtl CollectionTTL) CollectionTTL {
-	return CollectionTTL{
-		Ttl:        currentCollectionTtl.Ttl,
+func WithRefreshTtlOnUpdates(currentTtl CollectionTtl) CollectionTtl {
+	return CollectionTtl{
+		Ttl:        currentTtl.Ttl,
 		RefreshTtl: true,
 	}
 }
 
-func WithNoRefreshTtlOnUpdates(currentCollectionTtl CollectionTTL) CollectionTTL {
-	return CollectionTTL{
-		Ttl:        currentCollectionTtl.Ttl,
+func WithNoRefreshTtlOnUpdates(currentTtl CollectionTtl) CollectionTtl {
+	return CollectionTtl{
+		Ttl:        currentTtl.Ttl,
 		RefreshTtl: false,
 	}
 }


### PR DESCRIPTION
Rename the following:
- `SimpleCacheClient` to `CacheClient`
- dictionary `items` to `elements`
- `CollectionTTL` to `CollectionTtl` 

Closes #183 
Closes #184 
Closes #185 