### PR TITLE
feat!: Make TopicValue easier to work with.

### DIFF
--- a/examples/pubsub-example/main.go
+++ b/examples/pubsub-example/main.go
@@ -79,7 +79,7 @@ func publishMessages(client momento.CacheClient, ctx context.Context) {
 		_, err := client.TopicPublish(ctx, &momento.TopicPublishRequest{
 			CacheName: cacheName,
 			TopicName: topicName,
-			Value:     momento.TopicValueString(fmt.Sprintf("hello %d", i)),
+			Value:     momento.String(fmt.Sprintf("hello %d", i)),
 		})
 		if err != nil {
 			panic(err)

--- a/examples/pubsub-example/main.go
+++ b/examples/pubsub-example/main.go
@@ -44,12 +44,7 @@ func pollForMessages(ctx context.Context, sub momento.TopicSubscription) {
 		if err != nil {
 			panic(err)
 		}
-		switch msg := item.(type) {
-		case *momento.TopicValueString:
-			fmt.Printf("received message: '%s'\n", msg.Text)
-		case *momento.TopicValueBytes:
-			fmt.Printf("received message: '%s'\n", msg.Bytes)
-		}
+		fmt.Printf("received message: '%v'\n", item)
 	}
 }
 
@@ -84,9 +79,7 @@ func publishMessages(client momento.CacheClient, ctx context.Context) {
 		_, err := client.TopicPublish(ctx, &momento.TopicPublishRequest{
 			CacheName: cacheName,
 			TopicName: topicName,
-			Value: &momento.TopicValueString{
-				Text: fmt.Sprintf("hello %d", i),
-			},
+			Value:     momento.TopicValueString(fmt.Sprintf("hello %d", i)),
 		})
 		if err != nil {
 			panic(err)

--- a/momento/pubsub_client.go
+++ b/momento/pubsub_client.go
@@ -51,7 +51,7 @@ func (client *pubSubClient) TopicSubscribe(ctx context.Context, request *TopicSu
 }
 func (client *pubSubClient) TopicPublish(ctx context.Context, request *TopicPublishRequest) error {
 	switch value := request.Value.(type) {
-	case TopicValueString:
+	case String:
 		_, err := client.unaryGrpcClient.Publish(ctx, &pb.XPublishRequest{
 			CacheName: request.CacheName,
 			Topic:     request.TopicName,
@@ -62,7 +62,7 @@ func (client *pubSubClient) TopicPublish(ctx context.Context, request *TopicPubl
 			},
 		})
 		return err
-	case TopicValueBytes:
+	case Bytes:
 		_, err := client.unaryGrpcClient.Publish(ctx, &pb.XPublishRequest{
 			CacheName: request.CacheName,
 			Topic:     request.TopicName,

--- a/momento/pubsub_client.go
+++ b/momento/pubsub_client.go
@@ -51,24 +51,24 @@ func (client *pubSubClient) TopicSubscribe(ctx context.Context, request *TopicSu
 }
 func (client *pubSubClient) TopicPublish(ctx context.Context, request *TopicPublishRequest) error {
 	switch value := request.Value.(type) {
-	case *TopicValueString:
+	case TopicValueString:
 		_, err := client.unaryGrpcClient.Publish(ctx, &pb.XPublishRequest{
 			CacheName: request.CacheName,
 			Topic:     request.TopicName,
 			Value: &pb.XTopicValue{
 				Kind: &pb.XTopicValue_Text{
-					Text: value.Text,
+					Text: value.asString(),
 				},
 			},
 		})
 		return err
-	case *TopicValueBytes:
+	case TopicValueBytes:
 		_, err := client.unaryGrpcClient.Publish(ctx, &pb.XPublishRequest{
 			CacheName: request.CacheName,
 			Topic:     request.TopicName,
 			Value: &pb.XTopicValue{
 				Kind: &pb.XTopicValue_Binary{
-					Binary: value.Bytes,
+					Binary: value.asBytes(),
 				},
 			},
 		})

--- a/momento/pubsub_test.go
+++ b/momento/pubsub_test.go
@@ -28,7 +28,7 @@ var _ = Describe("Pubsub", func() {
 		func(cacheName string, collectionName string, expectedError string) {
 			ctx := sharedContext.Ctx
 			client := sharedContext.Client
-			value := &TopicValueString{Text: "foo"}
+			value := TopicValueString("foo")
 
 			Expect(
 				client.TopicSubscribe(ctx, &TopicSubscribeRequest{
@@ -51,8 +51,8 @@ var _ = Describe("Pubsub", func() {
 
 	It(`Publishes and receives`, func() {
 		publishedValues := []TopicValue{
-			&TopicValueString{Text: "aaa"},
-			&TopicValueBytes{Bytes: []byte{1, 2, 3}},
+			TopicValueString("aaa"),
+			TopicValueBytes([]byte{1, 2, 3}),
 		}
 
 		sub, err := sharedContext.Client.TopicSubscribe(sharedContext.Ctx, &TopicSubscribeRequest{

--- a/momento/pubsub_test.go
+++ b/momento/pubsub_test.go
@@ -28,7 +28,7 @@ var _ = Describe("Pubsub", func() {
 		func(cacheName string, collectionName string, expectedError string) {
 			ctx := sharedContext.Ctx
 			client := sharedContext.Client
-			value := TopicValueString("foo")
+			value := String("foo")
 
 			Expect(
 				client.TopicSubscribe(ctx, &TopicSubscribeRequest{
@@ -51,8 +51,8 @@ var _ = Describe("Pubsub", func() {
 
 	It(`Publishes and receives`, func() {
 		publishedValues := []TopicValue{
-			TopicValueString("aaa"),
-			TopicValueBytes([]byte{1, 2, 3}),
+			String("aaa"),
+			Bytes([]byte{1, 2, 3}),
 		}
 
 		sub, err := sharedContext.Client.TopicSubscribe(sharedContext.Ctx, &TopicSubscribeRequest{

--- a/momento/topic_publish.go
+++ b/momento/topic_publish.go
@@ -13,9 +13,3 @@ type TopicPublishResponse interface {
 type TopicPublishSuccess struct{}
 
 func (TopicPublishSuccess) isTopicPublishResponse() {}
-
-type TopicValue = Value
-
-type TopicValueBytes = Bytes
-
-type TopicValueString = String

--- a/momento/topic_publish.go
+++ b/momento/topic_publish.go
@@ -14,18 +14,8 @@ type TopicPublishSuccess struct{}
 
 func (TopicPublishSuccess) isTopicPublishResponse() {}
 
-type TopicValue interface {
-	isTopicValue()
-}
+type TopicValue = Value
 
-type TopicValueBytes struct {
-	Bytes []byte
-}
+type TopicValueBytes = Bytes
 
-func (TopicValueBytes) isTopicValue() {}
-
-type TopicValueString struct {
-	Text string
-}
-
-func (TopicValueString) isTopicValue() {}
+type TopicValueString = String

--- a/momento/topic_subscription.go
+++ b/momento/topic_subscription.go
@@ -38,13 +38,9 @@ func (s *topicSubscription) Item(ctx context.Context) (TopicValue, error) {
 			case *pb.XSubscriptionItem_Item:
 				switch subscriptionItem := typedMsg.Item.Value.Kind.(type) {
 				case *pb.XTopicValue_Text:
-					return &TopicValueString{
-						Text: subscriptionItem.Text,
-					}, nil
+					return TopicValueString(subscriptionItem.Text), nil
 				case *pb.XTopicValue_Binary:
-					return &TopicValueBytes{
-						Bytes: subscriptionItem.Binary,
-					}, nil
+					return TopicValueBytes(subscriptionItem.Binary), nil
 				}
 			case *pb.XSubscriptionItem_Heartbeat:
 				// FIXME add warning logging here

--- a/momento/topic_subscription.go
+++ b/momento/topic_subscription.go
@@ -38,9 +38,9 @@ func (s *topicSubscription) Item(ctx context.Context) (TopicValue, error) {
 			case *pb.XSubscriptionItem_Item:
 				switch subscriptionItem := typedMsg.Item.Value.Kind.(type) {
 				case *pb.XTopicValue_Text:
-					return TopicValueString(subscriptionItem.Text), nil
+					return String(subscriptionItem.Text), nil
 				case *pb.XTopicValue_Binary:
-					return TopicValueBytes(subscriptionItem.Binary), nil
+					return Bytes(subscriptionItem.Binary), nil
 				}
 			case *pb.XSubscriptionItem_Heartbeat:
 				// FIXME add warning logging here

--- a/momento/topic_value.go
+++ b/momento/topic_value.go
@@ -1,0 +1,16 @@
+package momento
+
+// For now, topics take the same types as normal methods.
+// In the future this might not be so, topics might take
+// different types than methods.
+//
+// The TopicValue interface alias future proofs us. Topics
+// still take the normal String and Bytes, but in the future
+// we can add types that other methods might not take.
+type TopicValue interface {
+	isTopicValue()
+}
+
+func (String) isTopicValue() {}
+
+func (Bytes) isTopicValue() {}

--- a/momento/value.go
+++ b/momento/value.go
@@ -3,7 +3,10 @@ package momento
 // Interface to help users deal with passing us values as strings or bytes.
 // Value: momento.Bytes([]bytes("abc"))
 // Value: momento.String("abc")
-type Value interface{ asBytes() []byte }
+type Value interface {
+	asBytes() []byte
+	asString() string
+}
 
 // Type alias to future proof passing in keys.
 type Key = Value
@@ -11,11 +14,19 @@ type Key = Value
 // Bytes plain old []byte
 type Bytes []byte
 
-func (r Bytes) asBytes() []byte { return r }
+func (v Bytes) asBytes() []byte { return v }
+
+func (v Bytes) asString() string {
+	return string(v)
+}
 
 // String string type that will be converted to []byte
 type String string
 
-func (r String) asBytes() []byte {
-	return []byte(r)
+func (v String) asBytes() []byte {
+	return []byte(v)
+}
+
+func (v String) asString() string {
+	return string(v)
 }


### PR DESCRIPTION
We need TopicValue because in the future topics may accept more value types than normal methods. But there's no need for different string and bytes types.

* Replace TopicValueString and TopicValueBytes with the existing String and Bytes.
* String and Bypes implement TopicValue.

Closes #171 