### PR TITLE
chore: rename `CollectionTtl` to `Ttl` in request types

### DIFF
--- a/momento/dictionary_increment.go
+++ b/momento/dictionary_increment.go
@@ -34,7 +34,7 @@ type DictionaryIncrementRequest struct {
 	DictionaryName string
 	Field          Value
 	Amount         int64
-	CollectionTtl  utils.CollectionTtl
+	Ttl            utils.CollectionTtl
 
 	grpcRequest  *pb.XDictionaryIncrementRequest
 	grpcResponse *pb.XDictionaryIncrementResponse
@@ -45,7 +45,7 @@ func (r *DictionaryIncrementRequest) cacheName() string { return r.CacheName }
 
 func (r *DictionaryIncrementRequest) field() Value { return r.Field }
 
-func (r *DictionaryIncrementRequest) ttl() time.Duration { return r.CollectionTtl.Ttl }
+func (r *DictionaryIncrementRequest) ttl() time.Duration { return r.Ttl.Ttl }
 
 func (r *DictionaryIncrementRequest) requestName() string { return "DictionaryFetch" }
 
@@ -79,7 +79,7 @@ func (r *DictionaryIncrementRequest) initGrpcRequest(client scsDataClient) error
 		Field:           field,
 		Amount:          r.Amount,
 		TtlMilliseconds: ttl,
-		RefreshTtl:      r.CollectionTtl.RefreshTtl,
+		RefreshTtl:      r.Ttl.RefreshTtl,
 	}
 
 	return nil

--- a/momento/dictionary_set_field.go
+++ b/momento/dictionary_set_field.go
@@ -21,5 +21,5 @@ type DictionarySetFieldRequest struct {
 	DictionaryName string
 	Field          Value
 	Value          Value
-	CollectionTtl  utils.CollectionTtl
+	Ttl            utils.CollectionTtl
 }

--- a/momento/dictionary_set_fields.go
+++ b/momento/dictionary_set_fields.go
@@ -25,7 +25,7 @@ type DictionarySetFieldsRequest struct {
 	CacheName      string
 	DictionaryName string
 	Elements       map[string]Value
-	CollectionTtl  utils.CollectionTtl
+	Ttl            utils.CollectionTtl
 
 	grpcRequest  *pb.XDictionarySetRequest
 	grpcResponse *pb.XDictionarySetResponse
@@ -36,7 +36,7 @@ func (r *DictionarySetFieldsRequest) cacheName() string { return r.CacheName }
 
 func (r *DictionarySetFieldsRequest) elements() map[string]Value { return r.Elements }
 
-func (r *DictionarySetFieldsRequest) ttl() time.Duration { return r.CollectionTtl.Ttl }
+func (r *DictionarySetFieldsRequest) ttl() time.Duration { return r.Ttl.Ttl }
 
 func (r *DictionarySetFieldsRequest) requestName() string { return "DictionarySetFields" }
 
@@ -69,7 +69,7 @@ func (r *DictionarySetFieldsRequest) initGrpcRequest(client scsDataClient) error
 		DictionaryName:  []byte(r.DictionaryName),
 		Items:           pbElements,
 		TtlMilliseconds: ttl,
-		RefreshTtl:      r.CollectionTtl.RefreshTtl,
+		RefreshTtl:      r.Ttl.RefreshTtl,
 	}
 
 	return nil

--- a/momento/dictionary_test.go
+++ b/momento/dictionary_test.go
@@ -80,7 +80,7 @@ var _ = Describe("Dictionary methods", func() {
 					DictionaryName: dictionaryName,
 					Field:          String("hi"),
 					Value:          String("hi"),
-					CollectionTtl:  utils.CollectionTtl{},
+					Ttl:            utils.CollectionTtl{},
 				}),
 			).Error().To(HaveMomentoErrorCode(expectedErrorCode))
 
@@ -89,7 +89,7 @@ var _ = Describe("Dictionary methods", func() {
 					CacheName:      cacheName,
 					DictionaryName: dictionaryName,
 					Elements:       nil,
-					CollectionTtl:  utils.CollectionTtl{},
+					Ttl:            utils.CollectionTtl{},
 				}),
 			).Error().To(HaveMomentoErrorCode(expectedErrorCode))
 		},
@@ -603,7 +603,7 @@ var _ = Describe("Dictionary methods", func() {
 						DictionaryName: sharedContext.CollectionName,
 						Field:          String("foo"),
 						Value:          String("bar"),
-						CollectionTtl:  utils.CollectionTtl{},
+						Ttl:            utils.CollectionTtl{},
 					}),
 				).To(BeAssignableToTypeOf(&DictionarySetFieldSuccess{}))
 
@@ -628,7 +628,7 @@ var _ = Describe("Dictionary methods", func() {
 						DictionaryName: sharedContext.CollectionName,
 						Field:          String("myField3"),
 						Value:          String("myValue3"),
-						CollectionTtl: utils.CollectionTtl{
+						Ttl: utils.CollectionTtl{
 							Ttl:        sharedContext.DefaultTTL + time.Second*60,
 							RefreshTtl: false,
 						},
@@ -652,7 +652,7 @@ var _ = Describe("Dictionary methods", func() {
 						DictionaryName: sharedContext.CollectionName,
 						Field:          String("myField3"),
 						Value:          String("myValue3"),
-						CollectionTtl: utils.CollectionTtl{
+						Ttl: utils.CollectionTtl{
 							Ttl:        sharedContext.DefaultTTL + time.Second*60,
 							RefreshTtl: true,
 						},

--- a/momento/list_concatenate_back.go
+++ b/momento/list_concatenate_back.go
@@ -31,7 +31,7 @@ type ListConcatenateBackRequest struct {
 	ListName            string
 	Values              []Value
 	TruncateFrontToSize uint32
-	CollectionTtl       utils.CollectionTtl
+	Ttl                 utils.CollectionTtl
 
 	grpcRequest  *pb.XListConcatenateBackRequest
 	grpcResponse *pb.XListConcatenateBackResponse
@@ -42,7 +42,7 @@ func (r *ListConcatenateBackRequest) cacheName() string { return r.CacheName }
 
 func (r *ListConcatenateBackRequest) values() []Value { return r.Values }
 
-func (r *ListConcatenateBackRequest) ttl() time.Duration { return r.CollectionTtl.Ttl }
+func (r *ListConcatenateBackRequest) ttl() time.Duration { return r.Ttl.Ttl }
 
 func (r *ListConcatenateBackRequest) requestName() string { return "ListConcatenateBack" }
 
@@ -67,7 +67,7 @@ func (r *ListConcatenateBackRequest) initGrpcRequest(client scsDataClient) error
 		ListName:            []byte(r.ListName),
 		Values:              values,
 		TtlMilliseconds:     ttl,
-		RefreshTtl:          r.CollectionTtl.RefreshTtl,
+		RefreshTtl:          r.Ttl.RefreshTtl,
 		TruncateFrontToSize: r.TruncateFrontToSize,
 	}
 

--- a/momento/list_concatenate_front.go
+++ b/momento/list_concatenate_front.go
@@ -31,7 +31,7 @@ type ListConcatenateFrontRequest struct {
 	ListName           string
 	Values             []Value
 	TruncateBackToSize uint32
-	CollectionTtl      utils.CollectionTtl
+	Ttl                utils.CollectionTtl
 
 	grpcRequest  *pb.XListConcatenateFrontRequest
 	grpcResponse *pb.XListConcatenateFrontResponse
@@ -42,7 +42,7 @@ func (r *ListConcatenateFrontRequest) cacheName() string { return r.CacheName }
 
 func (r *ListConcatenateFrontRequest) values() []Value { return r.Values }
 
-func (r *ListConcatenateFrontRequest) ttl() time.Duration { return r.CollectionTtl.Ttl }
+func (r *ListConcatenateFrontRequest) ttl() time.Duration { return r.Ttl.Ttl }
 
 func (r *ListConcatenateFrontRequest) requestName() string { return "ListConcatenateFront" }
 
@@ -67,7 +67,7 @@ func (r *ListConcatenateFrontRequest) initGrpcRequest(client scsDataClient) erro
 		ListName:           []byte(r.ListName),
 		Values:             values,
 		TtlMilliseconds:    ttl,
-		RefreshTtl:         r.CollectionTtl.RefreshTtl,
+		RefreshTtl:         r.Ttl.RefreshTtl,
 		TruncateBackToSize: r.TruncateBackToSize,
 	}
 

--- a/momento/list_push_back.go
+++ b/momento/list_push_back.go
@@ -32,7 +32,7 @@ type ListPushBackRequest struct {
 	ListName            string
 	Value               Value
 	TruncateFrontToSize uint32
-	CollectionTtl       utils.CollectionTtl
+	Ttl                 utils.CollectionTtl
 
 	grpcRequest  *pb.XListPushBackRequest
 	grpcResponse *pb.XListPushBackResponse
@@ -43,7 +43,7 @@ func (r *ListPushBackRequest) cacheName() string { return r.CacheName }
 
 func (r *ListPushBackRequest) value() Value { return r.Value }
 
-func (r *ListPushBackRequest) ttl() time.Duration { return r.CollectionTtl.Ttl }
+func (r *ListPushBackRequest) ttl() time.Duration { return r.Ttl.Ttl }
 
 func (r *ListPushBackRequest) requestName() string { return "ListPushBack" }
 
@@ -68,7 +68,7 @@ func (r *ListPushBackRequest) initGrpcRequest(client scsDataClient) error {
 		ListName:            []byte(r.ListName),
 		Value:               value,
 		TtlMilliseconds:     ttl,
-		RefreshTtl:          r.CollectionTtl.RefreshTtl,
+		RefreshTtl:          r.Ttl.RefreshTtl,
 		TruncateFrontToSize: r.TruncateFrontToSize,
 	}
 

--- a/momento/list_push_front.go
+++ b/momento/list_push_front.go
@@ -32,7 +32,7 @@ type ListPushFrontRequest struct {
 	ListName           string
 	Value              Value
 	TruncateBackToSize uint32
-	CollectionTtl      utils.CollectionTtl
+	Ttl                utils.CollectionTtl
 
 	grpcRequest  *pb.XListPushFrontRequest
 	grpcResponse *pb.XListPushFrontResponse
@@ -43,7 +43,7 @@ func (r *ListPushFrontRequest) cacheName() string { return r.CacheName }
 
 func (r *ListPushFrontRequest) value() Value { return r.Value }
 
-func (r *ListPushFrontRequest) ttl() time.Duration { return r.CollectionTtl.Ttl }
+func (r *ListPushFrontRequest) ttl() time.Duration { return r.Ttl.Ttl }
 
 func (r *ListPushFrontRequest) requestName() string { return "ListPushFront" }
 
@@ -68,7 +68,7 @@ func (r *ListPushFrontRequest) initGrpcRequest(client scsDataClient) error {
 		ListName:           []byte(r.ListName),
 		Value:              value,
 		TtlMilliseconds:    ttl,
-		RefreshTtl:         r.CollectionTtl.RefreshTtl,
+		RefreshTtl:         r.Ttl.RefreshTtl,
 		TruncateBackToSize: r.TruncateBackToSize,
 	}
 

--- a/momento/set_add_element.go
+++ b/momento/set_add_element.go
@@ -17,8 +17,8 @@ func (SetAddElementSuccess) isSetAddElementResponse() {}
 // SetAddElementRequest
 
 type SetAddElementRequest struct {
-	CacheName     string
-	SetName       string
-	Element       Value
-	CollectionTtl utils.CollectionTtl
+	CacheName string
+	SetName   string
+	Element   Value
+	Ttl       utils.CollectionTtl
 }

--- a/momento/set_add_elements.go
+++ b/momento/set_add_elements.go
@@ -21,10 +21,10 @@ func (SetAddElementsSuccess) isSetAddElementResponse() {}
 // SetAddElementRequest
 
 type SetAddElementsRequest struct {
-	CacheName     string
-	SetName       string
-	Elements      []Value
-	CollectionTtl utils.CollectionTtl
+	CacheName string
+	SetName   string
+	Elements  []Value
+	Ttl       utils.CollectionTtl
 
 	grpcRequest  *pb.XSetUnionRequest
 	grpcResponse *pb.XSetUnionResponse
@@ -34,7 +34,7 @@ type SetAddElementsRequest struct {
 func (r *SetAddElementsRequest) cacheName() string { return r.CacheName }
 
 func (r *SetAddElementsRequest) ttl() time.Duration {
-	return r.CollectionTtl.Ttl
+	return r.Ttl.Ttl
 }
 
 func (r *SetAddElementsRequest) requestName() string { return "SetAddElements" }
@@ -60,7 +60,7 @@ func (r *SetAddElementsRequest) initGrpcRequest(client scsDataClient) error {
 		SetName:         []byte(r.SetName),
 		Elements:        elements,
 		TtlMilliseconds: ttl,
-		RefreshTtl:      r.CollectionTtl.RefreshTtl,
+		RefreshTtl:      r.Ttl.RefreshTtl,
 	}
 
 	return nil

--- a/momento/set_test.go
+++ b/momento/set_test.go
@@ -291,7 +291,7 @@ var _ = Describe("Set methods", func() {
 						CacheName: sharedContext.CacheName,
 						SetName:   sharedContext.CollectionName,
 						Element:   String("hello"),
-						CollectionTtl: utils.CollectionTtl{
+						Ttl: utils.CollectionTtl{
 							Ttl:        sharedContext.DefaultTTL + time.Second*60,
 							RefreshTtl: true,
 						},
@@ -321,7 +321,7 @@ var _ = Describe("Set methods", func() {
 						CacheName: sharedContext.CacheName,
 						SetName:   sharedContext.CollectionName,
 						Element:   String("hello"),
-						CollectionTtl: utils.CollectionTtl{
+						Ttl: utils.CollectionTtl{
 							Ttl:        sharedContext.DefaultTTL + 1*time.Second,
 							RefreshTtl: false,
 						},
@@ -351,7 +351,7 @@ var _ = Describe("Set methods", func() {
 						CacheName: sharedContext.CacheName,
 						SetName:   sharedContext.CollectionName,
 						Element:   String("hello"),
-						CollectionTtl: utils.CollectionTtl{
+						Ttl: utils.CollectionTtl{
 							Ttl:        time.Millisecond * 20,
 							RefreshTtl: false,
 						},
@@ -381,7 +381,7 @@ var _ = Describe("Set methods", func() {
 						CacheName: sharedContext.CacheName,
 						SetName:   sharedContext.CollectionName,
 						Element:   String("hello"),
-						CollectionTtl: utils.CollectionTtl{
+						Ttl: utils.CollectionTtl{
 							Ttl:        time.Millisecond * 200,
 							RefreshTtl: true,
 						},

--- a/momento/simple_cache_client.go
+++ b/momento/simple_cache_client.go
@@ -270,10 +270,10 @@ func (c defaultScsClient) SetAddElements(ctx context.Context, r *SetAddElementsR
 
 func (c defaultScsClient) SetAddElement(ctx context.Context, r *SetAddElementRequest) (SetAddElementResponse, error) {
 	newRequest := &SetAddElementsRequest{
-		CacheName:     r.CacheName,
-		SetName:       r.SetName,
-		Elements:      []Value{r.Element},
-		CollectionTtl: r.CollectionTtl,
+		CacheName: r.CacheName,
+		SetName:   r.SetName,
+		Elements:  []Value{r.Element},
+		Ttl:       r.Ttl,
 	}
 	if err := c.dataClient.makeRequest(ctx, newRequest); err != nil {
 		return nil, err
@@ -377,7 +377,7 @@ func (c defaultScsClient) DictionarySetField(ctx context.Context, r *DictionaryS
 		CacheName:      r.CacheName,
 		DictionaryName: r.DictionaryName,
 		Elements:       elements,
-		CollectionTtl:  r.CollectionTtl,
+		Ttl:            r.Ttl,
 	}
 	if err := c.dataClient.makeRequest(ctx, newRequest); err != nil {
 		return nil, err

--- a/momento/sorted_set_increment_score.go
+++ b/momento/sorted_set_increment_score.go
@@ -25,11 +25,11 @@ func (SortedSetIncrementScoreSuccess) isSortedSetIncrementResponse() {}
 ////// Request
 
 type SortedSetIncrementScoreRequest struct {
-	CacheName     string
-	SetName       string
-	ElementName   Value
-	Amount        float64
-	CollectionTtl utils.CollectionTtl
+	CacheName   string
+	SetName     string
+	ElementName Value
+	Amount      float64
+	Ttl         utils.CollectionTtl
 
 	grpcRequest  *pb.XSortedSetIncrementRequest
 	grpcResponse *pb.XSortedSetIncrementResponse
@@ -40,7 +40,7 @@ func (r *SortedSetIncrementScoreRequest) cacheName() string { return r.CacheName
 
 func (r *SortedSetIncrementScoreRequest) requestName() string { return "Sorted set increment" }
 
-func (r *SortedSetIncrementScoreRequest) ttl() time.Duration { return r.CollectionTtl.Ttl }
+func (r *SortedSetIncrementScoreRequest) ttl() time.Duration { return r.Ttl.Ttl }
 
 func (r *SortedSetIncrementScoreRequest) initGrpcRequest(client scsDataClient) error {
 	var err error
@@ -67,7 +67,7 @@ func (r *SortedSetIncrementScoreRequest) initGrpcRequest(client scsDataClient) e
 		ElementName:     r.ElementName.asBytes(),
 		Amount:          r.Amount,
 		TtlMilliseconds: ttlMillis,
-		RefreshTtl:      r.CollectionTtl.RefreshTtl,
+		RefreshTtl:      r.Ttl.RefreshTtl,
 	}
 	return nil
 }

--- a/momento/sorted_set_put.go
+++ b/momento/sorted_set_put.go
@@ -26,10 +26,10 @@ type SortedSetPutElement struct {
 }
 
 type SortedSetPutRequest struct {
-	CacheName     string
-	SetName       string
-	Elements      []*SortedSetPutElement
-	CollectionTtl utils.CollectionTtl
+	CacheName string
+	SetName   string
+	Elements  []*SortedSetPutElement
+	Ttl       utils.CollectionTtl
 
 	grpcRequest  *pb.XSortedSetPutRequest
 	grpcResponse *pb.XSortedSetPutResponse
@@ -40,7 +40,7 @@ func (r *SortedSetPutRequest) cacheName() string { return r.CacheName }
 
 func (r *SortedSetPutRequest) requestName() string { return "Sorted set put" }
 
-func (r *SortedSetPutRequest) ttl() time.Duration { return r.CollectionTtl.Ttl }
+func (r *SortedSetPutRequest) ttl() time.Duration { return r.Ttl.Ttl }
 
 func (r *SortedSetPutRequest) initGrpcRequest(client scsDataClient) error {
 	var err error
@@ -60,7 +60,7 @@ func (r *SortedSetPutRequest) initGrpcRequest(client scsDataClient) error {
 		SetName:         []byte(r.SetName),
 		Elements:        elements,
 		TtlMilliseconds: ttlMills,
-		RefreshTtl:      r.CollectionTtl.RefreshTtl,
+		RefreshTtl:      r.Ttl.RefreshTtl,
 	}
 	return nil
 }

--- a/momento/sorted_set_test.go
+++ b/momento/sorted_set_test.go
@@ -172,7 +172,7 @@ var _ = Describe("SortedSet", func() {
 					Amount:      element.Score,
 				}
 				if ttl != nil {
-					request.CollectionTtl = *ttl
+					request.Ttl = *ttl
 				}
 
 				Expect(
@@ -188,7 +188,7 @@ var _ = Describe("SortedSet", func() {
 					Elements:  []*SortedSetPutElement{&element},
 				}
 				if ttl != nil {
-					request.CollectionTtl = *ttl
+					request.Ttl = *ttl
 				}
 
 				Expect(


### PR DESCRIPTION
To follow up [this renaming PR](https://github.com/momentohq/client-sdk-go/pull/203), this is to update `CollectionTtl` to `Ttl` in collection request types.
This way, users will pass a `Ttl` struct to a property named `Ttl`.
This decision is to be consistent with other SDKs and this PR's main goal.

Closes #207 