### PR TITLE
fix: navigable auth and config packages

### DIFF
--- a/auth/credential_provider.go
+++ b/auth/credential_provider.go
@@ -57,10 +57,15 @@ func FromString(authToken string) (CredentialProvider, error) {
 }
 
 // WithEndpoints overrides the cache and control endpoint URIs with those provided by the supplied Endpoints struct
-// and returns a CredentialProvider with the new endpoint values
+// and returns a CredentialProvider with the new endpoint values. An endpoint supplied as an empty string is ignored
+// and the existing value for that endpoint is retained.
 func (credentialProvider defaultCredentialProvider) WithEndpoints(endpoints Endpoints) (CredentialProvider, error) {
-	credentialProvider.cacheEndpoint = endpoints.CacheEndpoint
-	credentialProvider.controlEndpoint = endpoints.ControlEndpoint
+	if credentialProvider.cacheEndpoint != "" {
+		credentialProvider.cacheEndpoint = endpoints.CacheEndpoint
+	}
+	if credentialProvider.controlEndpoint != "" {
+		credentialProvider.controlEndpoint = endpoints.ControlEndpoint
+	}
 	return credentialProvider, nil
 }
 

--- a/auth/credential_provider.go
+++ b/auth/credential_provider.go
@@ -56,6 +56,8 @@ func FromString(authToken string) (CredentialProvider, error) {
 	return credentialProvider, nil
 }
 
+// WithEndpoints overrides the cache and control endpoint URIs with those provided by the supplied Endpoints struct
+// and returns a CredentialProvider with the new endpoint values
 func (credentialProvider defaultCredentialProvider) WithEndpoints(endpoints *Endpoints) (CredentialProvider, error) {
 	if endpoints == nil {
 		return nil, momentoerrors.NewMomentoSvcErr(

--- a/auth/credential_provider.go
+++ b/auth/credential_provider.go
@@ -19,7 +19,7 @@ type CredentialProvider interface {
 	GetAuthToken() string
 	GetControlEndpoint() string
 	GetCacheEndpoint() string
-	WithEndpoints(endpoints *Endpoints) (CredentialProvider, error)
+	WithEndpoints(endpoints Endpoints) (CredentialProvider, error)
 }
 
 type defaultCredentialProvider struct {
@@ -58,14 +58,7 @@ func FromString(authToken string) (CredentialProvider, error) {
 
 // WithEndpoints overrides the cache and control endpoint URIs with those provided by the supplied Endpoints struct
 // and returns a CredentialProvider with the new endpoint values
-func (credentialProvider defaultCredentialProvider) WithEndpoints(endpoints *Endpoints) (CredentialProvider, error) {
-	if endpoints == nil {
-		return nil, momentoerrors.NewMomentoSvcErr(
-			momentoerrors.InvalidArgumentError,
-			"endpoints cannot be nil",
-			errors.New("invalid argument"),
-		)
-	}
+func (credentialProvider defaultCredentialProvider) WithEndpoints(endpoints Endpoints) (CredentialProvider, error) {
 	credentialProvider.cacheEndpoint = endpoints.CacheEndpoint
 	credentialProvider.controlEndpoint = endpoints.ControlEndpoint
 	return credentialProvider, nil

--- a/auth/credential_provider_test.go
+++ b/auth/credential_provider_test.go
@@ -59,7 +59,7 @@ var _ = Describe("CredentialProvider", func() {
 		controlEndpoint = fmt.Sprintf("%s-overridden", controlEndpoint)
 		cacheEndpoint = fmt.Sprintf("%s-overridden", cacheEndpoint)
 		credentialProvider, err = credentialProvider.WithEndpoints(
-			&auth.Endpoints{
+			auth.Endpoints{
 				ControlEndpoint: controlEndpoint,
 				CacheEndpoint:   cacheEndpoint,
 			},

--- a/auth/credential_provider_test.go
+++ b/auth/credential_provider_test.go
@@ -2,6 +2,8 @@ package auth_test
 
 import (
 	"errors"
+	"fmt"
+	"os"
 
 	"github.com/momentohq/client-sdk-go/auth"
 	"github.com/momentohq/client-sdk-go/internal/momentoerrors"
@@ -21,4 +23,51 @@ var _ = Describe("CredentialProvider", func() {
 			Expect(momentoErr.Code()).To(Equal(momentoerrors.InvalidArgumentError))
 		}
 	})
+
+	It("returns a credential provider from an environment variable via constructor", func() {
+		credentialProvider, err := auth.NewEnvMomentoTokenProvider("TEST_AUTH_TOKEN")
+		Expect(err).To(BeNil())
+		Expect(credentialProvider.GetAuthToken()).To(Equal(os.Getenv("TEST_AUTH_TOKEN")))
+	})
+
+	It("returns a credential provider from a string via constructor", func() {
+		credentialProvider, err := auth.NewStringMomentoTokenProvider(os.Getenv("TEST_AUTH_TOKEN"))
+		Expect(err).To(BeNil())
+		Expect(credentialProvider.GetAuthToken()).To(Equal(os.Getenv("TEST_AUTH_TOKEN")))
+	})
+
+	It("returns a credential provider from an environment variable via method", func() {
+		credentialProvider, err := auth.FromEnvironmentVariable("TEST_AUTH_TOKEN")
+		Expect(err).To(BeNil())
+		Expect(credentialProvider.GetAuthToken()).To(Equal(os.Getenv("TEST_AUTH_TOKEN")))
+	})
+
+	It("returns a credential provider from a string via method", func() {
+		credentialProvider, err := auth.FromString(os.Getenv("TEST_AUTH_TOKEN"))
+		Expect(err).To(BeNil())
+		Expect(credentialProvider.GetAuthToken()).To(Equal(os.Getenv("TEST_AUTH_TOKEN")))
+	})
+
+	It("overrides endpoints", func() {
+		var err error
+		var credentialProvider auth.CredentialProvider
+		credentialProvider, err = auth.NewEnvMomentoTokenProvider("TEST_AUTH_TOKEN")
+		Expect(err).To(BeNil())
+		controlEndpoint := credentialProvider.GetControlEndpoint()
+		cacheEndpoint := credentialProvider.GetCacheEndpoint()
+		Expect(controlEndpoint).ToNot(BeEmpty())
+		Expect(cacheEndpoint).ToNot(BeEmpty())
+
+		controlEndpoint = fmt.Sprintf("%s-overridden", controlEndpoint)
+		cacheEndpoint = fmt.Sprintf("%s-overridden", cacheEndpoint)
+		credentialProvider, err = credentialProvider.WithEndpoints(
+			&auth.Endpoints{
+				ControlEndpoint: controlEndpoint,
+				CacheEndpoint:   cacheEndpoint,
+			},
+		)
+		Expect(credentialProvider.GetControlEndpoint()).To(Equal(controlEndpoint))
+		Expect(credentialProvider.GetCacheEndpoint()).To(Equal(cacheEndpoint))
+	})
+
 })

--- a/auth/credential_provider_test.go
+++ b/auth/credential_provider_test.go
@@ -49,9 +49,7 @@ var _ = Describe("CredentialProvider", func() {
 	})
 
 	It("overrides endpoints", func() {
-		var err error
-		var credentialProvider auth.CredentialProvider
-		credentialProvider, err = auth.NewEnvMomentoTokenProvider("TEST_AUTH_TOKEN")
+		credentialProvider, err := auth.NewEnvMomentoTokenProvider("TEST_AUTH_TOKEN")
 		Expect(err).To(BeNil())
 		controlEndpoint := credentialProvider.GetControlEndpoint()
 		cacheEndpoint := credentialProvider.GetCacheEndpoint()

--- a/auth/credential_provider_test.go
+++ b/auth/credential_provider_test.go
@@ -66,6 +66,7 @@ var _ = Describe("CredentialProvider", func() {
 				CacheEndpoint:   cacheEndpoint,
 			},
 		)
+		Expect(err).To(BeNil())
 		Expect(credentialProvider.GetControlEndpoint()).To(Equal(controlEndpoint))
 		Expect(credentialProvider.GetCacheEndpoint()).To(Equal(cacheEndpoint))
 	})

--- a/config/config.go
+++ b/config/config.go
@@ -30,39 +30,39 @@ type Configuration interface {
 	WithClientTimeout(clientTimeout time.Duration) Configuration
 }
 
-type SimpleCacheConfiguration struct {
+type simpleCacheConfiguration struct {
 	loggerFactory     logger.MomentoLoggerFactory
 	transportStrategy TransportStrategy
 }
 
-func (s *SimpleCacheConfiguration) GetLoggerFactory() logger.MomentoLoggerFactory {
+func (s *simpleCacheConfiguration) GetLoggerFactory() logger.MomentoLoggerFactory {
 	return s.loggerFactory
 }
 
-func (s *SimpleCacheConfiguration) GetClientSideTimeout() time.Duration {
+func (s *simpleCacheConfiguration) GetClientSideTimeout() time.Duration {
 	return s.transportStrategy.GetClientSideTimeout()
 }
 
 func NewSimpleCacheConfiguration(props *ConfigurationProps) Configuration {
-	return &SimpleCacheConfiguration{
+	return &simpleCacheConfiguration{
 		loggerFactory:     props.LoggerFactory,
 		transportStrategy: props.TransportStrategy,
 	}
 }
 
-func (s *SimpleCacheConfiguration) GetTransportStrategy() TransportStrategy {
+func (s *simpleCacheConfiguration) GetTransportStrategy() TransportStrategy {
 	return s.transportStrategy
 }
 
-func (s *SimpleCacheConfiguration) WithTransportStrategy(transportStrategy TransportStrategy) Configuration {
-	return &SimpleCacheConfiguration{
+func (s *simpleCacheConfiguration) WithTransportStrategy(transportStrategy TransportStrategy) Configuration {
+	return &simpleCacheConfiguration{
 		loggerFactory:     s.loggerFactory,
 		transportStrategy: transportStrategy,
 	}
 }
 
-func (s *SimpleCacheConfiguration) WithClientTimeout(clientTimeout time.Duration) Configuration {
-	return &SimpleCacheConfiguration{
+func (s *simpleCacheConfiguration) WithClientTimeout(clientTimeout time.Duration) Configuration {
+	return &simpleCacheConfiguration{
 		loggerFactory:     s.loggerFactory,
 		transportStrategy: s.transportStrategy.WithClientTimeout(clientTimeout),
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -30,39 +30,39 @@ type Configuration interface {
 	WithClientTimeout(clientTimeout time.Duration) Configuration
 }
 
-type simpleCacheConfiguration struct {
+type cacheConfiguration struct {
 	loggerFactory     logger.MomentoLoggerFactory
 	transportStrategy TransportStrategy
 }
 
-func (s *simpleCacheConfiguration) GetLoggerFactory() logger.MomentoLoggerFactory {
+func (s *cacheConfiguration) GetLoggerFactory() logger.MomentoLoggerFactory {
 	return s.loggerFactory
 }
 
-func (s *simpleCacheConfiguration) GetClientSideTimeout() time.Duration {
+func (s *cacheConfiguration) GetClientSideTimeout() time.Duration {
 	return s.transportStrategy.GetClientSideTimeout()
 }
 
-func NewSimpleCacheConfiguration(props *ConfigurationProps) Configuration {
-	return &simpleCacheConfiguration{
+func NewCacheConfiguration(props *ConfigurationProps) Configuration {
+	return &cacheConfiguration{
 		loggerFactory:     props.LoggerFactory,
 		transportStrategy: props.TransportStrategy,
 	}
 }
 
-func (s *simpleCacheConfiguration) GetTransportStrategy() TransportStrategy {
+func (s *cacheConfiguration) GetTransportStrategy() TransportStrategy {
 	return s.transportStrategy
 }
 
-func (s *simpleCacheConfiguration) WithTransportStrategy(transportStrategy TransportStrategy) Configuration {
-	return &simpleCacheConfiguration{
+func (s *cacheConfiguration) WithTransportStrategy(transportStrategy TransportStrategy) Configuration {
+	return &cacheConfiguration{
 		loggerFactory:     s.loggerFactory,
 		transportStrategy: transportStrategy,
 	}
 }
 
-func (s *simpleCacheConfiguration) WithClientTimeout(clientTimeout time.Duration) Configuration {
-	return &simpleCacheConfiguration{
+func (s *cacheConfiguration) WithClientTimeout(clientTimeout time.Duration) Configuration {
+	return &cacheConfiguration{
 		loggerFactory:     s.loggerFactory,
 		transportStrategy: s.transportStrategy.WithClientTimeout(clientTimeout),
 	}

--- a/config/configurations.go
+++ b/config/configurations.go
@@ -6,44 +6,34 @@ import (
 	"github.com/momentohq/client-sdk-go/config/logger"
 )
 
-type Laptop struct {
-	Configuration
-}
-
-func LatestLaptopConfig(loggerFactory ...logger.MomentoLoggerFactory) *Laptop {
+func LaptopLatest(loggerFactory ...logger.MomentoLoggerFactory) *Laptop {
 	defaultLoggerFactory := logger.NewNoopMomentoLoggerFactory()
 	if len(loggerFactory) != 0 {
 		defaultLoggerFactory = loggerFactory[0]
 	}
-	return &Laptop{
-		Configuration: NewSimpleCacheConfiguration(&ConfigurationProps{
-			LoggerFactory: defaultLoggerFactory,
-			TransportStrategy: NewStaticTransportStrategy(&TransportStrategyProps{
-				GrpcConfiguration: NewStaticGrpcConfiguration(&GrpcConfigurationProps{
-					deadline: 5 * time.Second,
-				}),
+	return NewSimpleCacheConfiguration(&ConfigurationProps{
+		LoggerFactory: defaultLoggerFactory,
+		TransportStrategy: NewStaticTransportStrategy(&TransportStrategyProps{
+			GrpcConfiguration: NewStaticGrpcConfiguration(&GrpcConfigurationProps{
+				deadline:           5 * time.Second,
 			}),
 		}),
-	}
+	})
 }
 
-type InRegion struct {
-	Configuration
-}
-
-func LatestInRegionConfig(loggerFactory ...logger.MomentoLoggerFactory) *InRegion {
+func InRegionLatest(loggerFactory ...logger.MomentoLoggerFactory) Configuration {
 	defaultLoggerFactory := logger.NewNoopMomentoLoggerFactory()
 	if len(loggerFactory) != 0 {
 		defaultLoggerFactory = loggerFactory[0]
 	}
-	return &InRegion{
-		Configuration: NewSimpleCacheConfiguration(&ConfigurationProps{
+	return NewSimpleCacheConfiguration(
+		&ConfigurationProps{
 			LoggerFactory: defaultLoggerFactory,
 			TransportStrategy: NewStaticTransportStrategy(&TransportStrategyProps{
 				GrpcConfiguration: NewStaticGrpcConfiguration(&GrpcConfigurationProps{
 					deadline: 1100 * time.Millisecond,
 				}),
 			}),
-		}),
-	}
+		},
+	)
 }

--- a/config/configurations.go
+++ b/config/configurations.go
@@ -6,7 +6,7 @@ import (
 	"github.com/momentohq/client-sdk-go/config/logger"
 )
 
-func LaptopLatest(loggerFactory ...logger.MomentoLoggerFactory) *Laptop {
+func LaptopLatest(loggerFactory ...logger.MomentoLoggerFactory) Configuration {
 	defaultLoggerFactory := logger.NewNoopMomentoLoggerFactory()
 	if len(loggerFactory) != 0 {
 		defaultLoggerFactory = loggerFactory[0]
@@ -15,7 +15,7 @@ func LaptopLatest(loggerFactory ...logger.MomentoLoggerFactory) *Laptop {
 		LoggerFactory: defaultLoggerFactory,
 		TransportStrategy: NewStaticTransportStrategy(&TransportStrategyProps{
 			GrpcConfiguration: NewStaticGrpcConfiguration(&GrpcConfigurationProps{
-				deadline:           5 * time.Second,
+				deadline: 5 * time.Second,
 			}),
 		}),
 	})

--- a/config/configurations.go
+++ b/config/configurations.go
@@ -11,7 +11,7 @@ func LaptopLatest(loggerFactory ...logger.MomentoLoggerFactory) *Laptop {
 	if len(loggerFactory) != 0 {
 		defaultLoggerFactory = loggerFactory[0]
 	}
-	return NewSimpleCacheConfiguration(&ConfigurationProps{
+	return NewCacheConfiguration(&ConfigurationProps{
 		LoggerFactory: defaultLoggerFactory,
 		TransportStrategy: NewStaticTransportStrategy(&TransportStrategyProps{
 			GrpcConfiguration: NewStaticGrpcConfiguration(&GrpcConfigurationProps{
@@ -26,7 +26,7 @@ func InRegionLatest(loggerFactory ...logger.MomentoLoggerFactory) Configuration 
 	if len(loggerFactory) != 0 {
 		defaultLoggerFactory = loggerFactory[0]
 	}
-	return NewSimpleCacheConfiguration(
+	return NewCacheConfiguration(
 		&ConfigurationProps{
 			LoggerFactory: defaultLoggerFactory,
 			TransportStrategy: NewStaticTransportStrategy(&TransportStrategyProps{

--- a/go.work
+++ b/go.work
@@ -2,5 +2,4 @@ go 1.19
 
 use (
 	.
-	./examples
 )

--- a/go.work
+++ b/go.work
@@ -2,4 +2,5 @@ go 1.19
 
 use (
 	.
+	./examples
 )

--- a/momento/simple_cache_client_test.go
+++ b/momento/simple_cache_client_test.go
@@ -33,7 +33,7 @@ var _ = Describe("CacheClient", func() {
 
 	It(`errors on invalid timeout`, func() {
 		badRequestTimeout := 0 * time.Second
-		sharedContext.Configuration = config.LatestLaptopConfig().WithClientTimeout(badRequestTimeout)
+		sharedContext.Configuration = config.LaptopLatest().WithClientTimeout(badRequestTimeout)
 		Expect(
 			NewCacheClient(sharedContext.Configuration, sharedContext.CredentialProvider, sharedContext.DefaultTtl),
 		).Error().To(HaveMomentoErrorCode(InvalidArgumentError))

--- a/momento/test_helpers/shared_context.go
+++ b/momento/test_helpers/shared_context.go
@@ -27,7 +27,7 @@ func NewSharedContext() SharedContext {
 	shared.Ctx = context.Background()
 	credentialProvider, _ := auth.NewEnvMomentoTokenProvider("TEST_AUTH_TOKEN")
 	shared.CredentialProvider = credentialProvider
-	shared.Configuration = config.LatestLaptopConfig()
+	shared.Configuration = config.LaptopLatest()
 	shared.DefaultTtl = 3 * time.Second
 
 	client, err := momento.NewCacheClient(shared.Configuration, shared.CredentialProvider, shared.DefaultTtl)

--- a/momento/test_helpers/shared_context.go
+++ b/momento/test_helpers/shared_context.go
@@ -25,7 +25,10 @@ func NewSharedContext() SharedContext {
 	shared := SharedContext{}
 
 	shared.Ctx = context.Background()
-	credentialProvider, _ := auth.NewEnvMomentoTokenProvider("TEST_AUTH_TOKEN")
+	credentialProvider, err := auth.NewEnvMomentoTokenProvider("TEST_AUTH_TOKEN")
+	if err != nil {
+		panic(err)
+	}
 	shared.CredentialProvider = credentialProvider
 	shared.Configuration = config.LaptopLatest()
 	shared.DefaultTtl = 3 * time.Second


### PR DESCRIPTION
This commit reduces the set of exported symbols from the `auth` and `config` packages down to only those that users need to interact with. It also panics on an error that it was previously swallowing when constructing the CredentialProvider for the tests so users will now see a clear explanation of the failure. 

Addresses #176 and #187 