### PR TITLE
chore: revert Lint the example code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,3 @@
-LINTER_ARGS=./... ./examples/...
-
 .PHONY: install-devtools
 install-devtools:
 	go install golang.org/x/tools/cmd/goimports@latest
@@ -20,11 +18,11 @@ tidy:
 
 .PHONY: vet
 vet:
-	go vet $(LINTER_ARGS)
+	go vet ./...
 
 .PHONY: staticcheck
 staticcheck:
-	staticcheck $(LINTER_ARGS)
+	staticcheck ./...
 
 .PHONY: lint
 lint: format imports tidy vet staticcheck


### PR DESCRIPTION
This reverts commit f2c2397be875cde9a4018f0bf76ee62a90ecf3d9.

@schwern going to revert this for time being causing some churn on prs. Im going to come back will try re-add back in tomorrow and come up w/ better flow for updating examples and running linting.