### PR TITLE
chore: spike on map field accepted type

### DIFF
--- a/momento/dictionary_set_field.go
+++ b/momento/dictionary_set_field.go
@@ -19,7 +19,7 @@ func (DictionarySetFieldSuccess) isDictionarySetFieldResponse() {}
 type DictionarySetFieldRequest struct {
 	CacheName      string
 	DictionaryName string
-	Field          Value
+	Field          *Field
 	Value          Value
 	Ttl            utils.CollectionTtl
 }

--- a/momento/dictionary_set_fields.go
+++ b/momento/dictionary_set_fields.go
@@ -24,7 +24,7 @@ func (DictionarySetFieldsSuccess) isDictionarySetFieldsResponse() {}
 type DictionarySetFieldsRequest struct {
 	CacheName      string
 	DictionaryName string
-	Elements       map[string]Value
+	Elements       map[Value]Value
 	Ttl            utils.CollectionTtl
 
 	grpcRequest  *pb.XDictionarySetRequest
@@ -34,7 +34,7 @@ type DictionarySetFieldsRequest struct {
 
 func (r *DictionarySetFieldsRequest) cacheName() string { return r.CacheName }
 
-func (r *DictionarySetFieldsRequest) elements() map[string]Value { return r.Elements }
+func (r *DictionarySetFieldsRequest) elements() map[Value]Value { return r.Elements }
 
 func (r *DictionarySetFieldsRequest) ttl() time.Duration { return r.Ttl.Ttl }
 

--- a/momento/dictionary_set_fields.go
+++ b/momento/dictionary_set_fields.go
@@ -24,7 +24,7 @@ func (DictionarySetFieldsSuccess) isDictionarySetFieldsResponse() {}
 type DictionarySetFieldsRequest struct {
 	CacheName      string
 	DictionaryName string
-	Elements       map[Value]Value
+	Elements       map[*Field]Value
 	Ttl            utils.CollectionTtl
 
 	grpcRequest  *pb.XDictionarySetRequest
@@ -34,7 +34,7 @@ type DictionarySetFieldsRequest struct {
 
 func (r *DictionarySetFieldsRequest) cacheName() string { return r.CacheName }
 
-func (r *DictionarySetFieldsRequest) elements() map[Value]Value { return r.Elements }
+func (r *DictionarySetFieldsRequest) elements() map[*Field]Value { return r.Elements }
 
 func (r *DictionarySetFieldsRequest) ttl() time.Duration { return r.Ttl.Ttl }
 

--- a/momento/dictionary_test.go
+++ b/momento/dictionary_test.go
@@ -77,11 +77,13 @@ var _ = Describe("Dictionary methods", func() {
 				}),
 			).Error().To(HaveMomentoErrorCode(expectedErrorCode))
 
+			var f Field
+			f = String("hi")
 			Expect(
 				sharedContext.Client.DictionarySetField(sharedContext.Ctx, &DictionarySetFieldRequest{
 					CacheName:      cacheName,
 					DictionaryName: dictionaryName,
-					Field:          String("hi"),
+					Field:          &f,
 					Value:          String("hi"),
 					Ttl:            utils.CollectionTtl{},
 				}),
@@ -109,7 +111,7 @@ var _ = Describe("Dictionary methods", func() {
 				sharedContext.Client.DictionarySetField(sharedContext.Ctx, &DictionarySetFieldRequest{
 					CacheName:      sharedContext.CacheName,
 					DictionaryName: sharedContext.CollectionName,
-					Field:          field,
+					Field:          &field,
 					Value:          value,
 				}),
 			).Error().To(BeNil())

--- a/momento/dictionary_test.go
+++ b/momento/dictionary_test.go
@@ -74,8 +74,7 @@ var _ = Describe("Dictionary methods", func() {
 				}),
 			).Error().To(HaveMomentoErrorCode(expectedErrorCode))
 
-			var f Field
-			f = String("hi")
+			var f Field = String("hi")
 			Expect(
 				sharedContext.Client.DictionarySetField(sharedContext.Ctx, &DictionarySetFieldRequest{
 					CacheName:      cacheName,
@@ -147,7 +146,7 @@ var _ = Describe("Dictionary methods", func() {
 	//	Entry("nil value", String("field"), nil),
 	//	Entry("both nil", nil, nil),
 	//)
-    //
+	//
 	//It("errors with a negative ttl for set", func() {
 	//	Expect(
 	//		sharedContext.Client.DictionarySetField(sharedContext.Ctx, &DictionarySetFieldRequest{

--- a/momento/dictionary_test.go
+++ b/momento/dictionary_test.go
@@ -1,14 +1,17 @@
 package momento_test
 
 import (
-	"reflect"
-	"time"
+	//"reflect"
+	//"time"
 
+	"github.com/google/uuid"
 	. "github.com/momentohq/client-sdk-go/momento"
 	. "github.com/momentohq/client-sdk-go/momento/test_helpers"
 	"github.com/momentohq/client-sdk-go/utils"
 
-	"github.com/google/uuid"
+	//"github.com/momentohq/client-sdk-go/utils"
+
+	//"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
@@ -131,625 +134,625 @@ var _ = Describe("Dictionary methods", func() {
 		Entry("using bytes value and field", Bytes("myField"), Bytes("myValue"), "myField", []byte("myField"), "myValue", []byte("myValue")),
 	)
 
-	DescribeTable("try using empty and nil fields and values for set",
-		func(field Value, value Value) {
-			Expect(
-				sharedContext.Client.DictionarySetField(sharedContext.Ctx, &DictionarySetFieldRequest{
-					CacheName:      sharedContext.CacheName,
-					DictionaryName: sharedContext.CollectionName,
-					Field:          field,
-					Value:          value,
-				}),
-			).Error().To(HaveMomentoErrorCode(InvalidArgumentError))
-		},
-		Entry("empty field", String(""), String("value")),
-		Entry("nil field", nil, String("value")),
-		Entry("nil value", String("field"), nil),
-		Entry("both nil", nil, nil),
-	)
-
-	DescribeTable("add string fields and string and bytes values for set fields happy path",
-		func(elements map[string]Value, expectedItemsStringValue map[string]string, expectedItemsByteValue map[string][]byte) {
-			Expect(
-				sharedContext.Client.DictionarySetFields(sharedContext.Ctx, &DictionarySetFieldsRequest{
-					CacheName:      sharedContext.CacheName,
-					DictionaryName: sharedContext.CollectionName,
-					Elements:       elements,
-				}),
-			).To(BeAssignableToTypeOf(&DictionarySetFieldsSuccess{}))
-			fetchResp, err := sharedContext.Client.DictionaryFetch(sharedContext.Ctx, &DictionaryFetchRequest{
-				CacheName:      sharedContext.CacheName,
-				DictionaryName: sharedContext.CollectionName,
-			})
-			Expect(err).To(BeNil())
-			switch result := fetchResp.(type) {
-			case *DictionaryFetchMiss:
-				Fail("got a miss for a dictionary fetch that should have been a hit")
-			case *DictionaryFetchHit:
-				Expect(reflect.DeepEqual(result.ValueMap(), expectedItemsStringValue)).To(BeTrue())
-				Expect(reflect.DeepEqual(result.ValueMapStringString(), expectedItemsStringValue)).To(BeTrue())
-				Expect(reflect.DeepEqual(result.ValueMapStringByte(), expectedItemsByteValue)).To(BeTrue())
-			}
-		},
-		Entry(
-			"with string values",
-			map[string]Value{"myField1": String("myValue1"), "myField2": String("myValue2")},
-			map[string]string{"myField1": "myValue1", "myField2": "myValue2"},
-			map[string][]byte{"myField1": []byte("myValue1"), "myField2": []byte("myValue2")},
-		),
-		Entry(
-			"with byte values",
-			map[string]Value{"myField1": Bytes("myValue1"), "myField2": Bytes("myValue2")},
-			map[string]string{"myField1": "myValue1", "myField2": "myValue2"},
-			map[string][]byte{"myField1": []byte("myValue1"), "myField2": []byte("myValue2")},
-		),
-		Entry(
-			"with mixed values",
-			map[string]Value{"myField1": String("myValue1"), "myField2": Bytes("myValue2")},
-			map[string]string{"myField1": "myValue1", "myField2": "myValue2"},
-			map[string][]byte{"myField1": []byte("myValue1"), "myField2": []byte("myValue2")},
-		),
-	)
-
-	It("returns an error if an item field is empty", func() {
-		Expect(
-			sharedContext.Client.DictionarySetFields(sharedContext.Ctx, &DictionarySetFieldsRequest{
-				CacheName:      sharedContext.CacheName,
-				DictionaryName: sharedContext.CollectionName,
-				Elements:       map[string]Value{"myField": String("myValue"), "": String("myOtherValue")},
-			}),
-		).Error().To(HaveMomentoErrorCode(InvalidArgumentError))
-	})
-
-	It("returns an error if an item value is nil", func() {
-		Expect(
-			sharedContext.Client.DictionarySetFields(sharedContext.Ctx, &DictionarySetFieldsRequest{
-				CacheName:      sharedContext.CacheName,
-				DictionaryName: sharedContext.CollectionName,
-				Elements:       map[string]Value{"myField": String("myValue"), "myOtherField": nil},
-			}),
-		).Error().To(HaveMomentoErrorCode(InvalidArgumentError))
-	})
-
-	Describe("dictionary increment", func() {
-
-		It("populates nonexistent field", func() {
-			incrResp, err := sharedContext.Client.DictionaryIncrement(sharedContext.Ctx, &DictionaryIncrementRequest{
-				CacheName:      sharedContext.CacheName,
-				DictionaryName: sharedContext.CollectionName,
-				Field:          String("myField"),
-				Amount:         3,
-			})
-			Expect(err).To(BeNil())
-			Expect(incrResp).To(BeAssignableToTypeOf(&DictionaryIncrementSuccess{}))
-			switch result := incrResp.(type) {
-			case *DictionaryIncrementSuccess:
-				Expect(result.Value()).To(Equal(int64(3)))
-			}
-		})
-
-		It("returns an error when called on a non-integer field", func() {
-			Expect(
-				sharedContext.Client.DictionarySetField(sharedContext.Ctx, &DictionarySetFieldRequest{
-					CacheName:      sharedContext.CacheName,
-					DictionaryName: sharedContext.CollectionName,
-					Field:          String("notacounter"),
-					Value:          String("notanumber"),
-				}),
-			).To(BeAssignableToTypeOf(&DictionarySetFieldSuccess{}))
-
-			Expect(
-				sharedContext.Client.DictionaryIncrement(sharedContext.Ctx, &DictionaryIncrementRequest{
-					CacheName:      sharedContext.CacheName,
-					DictionaryName: sharedContext.CollectionName,
-					Field:          String("notacounter"),
-					Amount:         1,
-				}),
-			).Error().To(HaveMomentoErrorCode(FailedPreconditionError))
-		})
-
-		It("returns an error when amount is zero", func() {
-			_, err := sharedContext.Client.DictionaryIncrement(sharedContext.Ctx, &DictionaryIncrementRequest{
-				CacheName:      sharedContext.CacheName,
-				DictionaryName: sharedContext.CollectionName,
-				Field:          String("myField"),
-				Amount:         0,
-			})
-			Expect(err).To(HaveMomentoErrorCode(InvalidArgumentError))
-		})
-
-		It("increments on the happy path", func() {
-			field := String("counter")
-			for i := 0; i < 10; i++ {
-				Expect(
-					sharedContext.Client.DictionaryIncrement(sharedContext.Ctx, &DictionaryIncrementRequest{
-						CacheName:      sharedContext.CacheName,
-						DictionaryName: sharedContext.CollectionName,
-						Field:          field,
-						Amount:         1,
-					}),
-				).To(BeAssignableToTypeOf(&DictionaryIncrementSuccess{}))
-			}
-			fetchResp, err := sharedContext.Client.DictionaryGetField(sharedContext.Ctx, &DictionaryGetFieldRequest{
-				CacheName:      sharedContext.CacheName,
-				DictionaryName: sharedContext.CollectionName,
-				Field:          field,
-			})
-			Expect(err).To(BeNil())
-			Expect(fetchResp).To(BeAssignableToTypeOf(&DictionaryGetFieldHit{}))
-			switch result := fetchResp.(type) {
-			case *DictionaryGetFieldHit:
-				Expect(result.ValueString()).To(Equal("10"))
-			default:
-				Fail("expected a hit for get field but got a miss")
-			}
-		})
-
-		It("returns an error when field is nil", func() {
-			Expect(
-				sharedContext.Client.DictionaryIncrement(sharedContext.Ctx, &DictionaryIncrementRequest{
-					CacheName:      sharedContext.CacheName,
-					DictionaryName: sharedContext.CollectionName,
-					Field:          nil,
-					Amount:         1,
-				}),
-			).Error().To(HaveMomentoErrorCode(InvalidArgumentError))
-		})
-	})
-
-	Describe("dictionary get", func() {
-
-		BeforeEach(func() {
-			Expect(
-				sharedContext.Client.DictionarySetFields(sharedContext.Ctx, &DictionarySetFieldsRequest{
-					CacheName:      sharedContext.CacheName,
-					DictionaryName: sharedContext.CollectionName,
-					Elements:       map[string]Value{"myField1": String("myValue1"), "myField2": Bytes("myValue2")},
-				}),
-			).To(BeAssignableToTypeOf(&DictionarySetFieldsSuccess{}))
-		})
-
-		When("getting single field", func() {
-
-			It("returns the correct string and byte values", func() {
-				expected := map[string]string{"myField1": "myValue1", "myField2": "myValue2"}
-
-				for fieldName, valueStr := range expected {
-					getResp, err := sharedContext.Client.DictionaryGetField(sharedContext.Ctx, &DictionaryGetFieldRequest{
-						CacheName:      sharedContext.CacheName,
-						DictionaryName: sharedContext.CollectionName,
-						Field:          String(fieldName),
-					})
-					Expect(err).To(BeNil())
-					Expect(getResp).To(BeAssignableToTypeOf(&DictionaryGetFieldHit{}))
-					switch result := getResp.(type) {
-					case *DictionaryGetFieldHit:
-						Expect(result.FieldString()).To(Equal(fieldName))
-						Expect(result.FieldByte()).To(Equal([]byte(fieldName)))
-						Expect(result.ValueString()).To(Equal(valueStr))
-						Expect(result.ValueByte()).To(Equal([]byte(valueStr)))
-					default:
-						Fail("something really weird happened")
-					}
-				}
-			})
-
-			It("returns a miss for a nonexistent field", func() {
-				getResp, err := sharedContext.Client.DictionaryGetField(sharedContext.Ctx, &DictionaryGetFieldRequest{
-					CacheName:      sharedContext.CacheName,
-					DictionaryName: sharedContext.CollectionName,
-					Field:          String("idontexist"),
-				})
-				Expect(err).To(BeNil())
-				Expect(getResp).To(BeAssignableToTypeOf(&DictionaryGetFieldMiss{}))
-			})
-
-			It("returns a miss for a nonexistent dictionary", func() {
-				getResp, err := sharedContext.Client.DictionaryGetField(sharedContext.Ctx, &DictionaryGetFieldRequest{
-					CacheName:      sharedContext.CacheName,
-					DictionaryName: uuid.NewString(),
-					Field:          String("idontexist"),
-				})
-				Expect(err).To(BeNil())
-				Expect(getResp).To(BeAssignableToTypeOf(&DictionaryGetFieldMiss{}))
-			})
-
-			It("returns an error for a nil field", func() {
-				Expect(
-					sharedContext.Client.DictionaryGetField(sharedContext.Ctx, &DictionaryGetFieldRequest{
-						CacheName:      sharedContext.CacheName,
-						DictionaryName: sharedContext.CollectionName,
-						Field:          nil,
-					}),
-				).Error().To(HaveMomentoErrorCode(InvalidArgumentError))
-			})
-
-		})
-
-		When("getting multiple fields", func() {
-
-			It("returns the correct string and byte values", func() {
-				getResp, err := sharedContext.Client.DictionaryGetFields(sharedContext.Ctx, &DictionaryGetFieldsRequest{
-					CacheName:      sharedContext.CacheName,
-					DictionaryName: sharedContext.CollectionName,
-					Fields:         []Value{String("myField1"), String("myField2")},
-				})
-				Expect(err).To(BeNil())
-				Expect(getResp).To(BeAssignableToTypeOf(&DictionaryGetFieldsHit{}))
-
-				expectedStrings := map[string]string{"myField1": "myValue1", "myField2": "myValue2"}
-				expectedBytes := map[string][]byte{"myField1": []byte("myValue1"), "myField2": []byte("myValue2")}
-				switch result := getResp.(type) {
-				case *DictionaryGetFieldsHit:
-					Expect(result.ValueMapStringString()).To(Equal(expectedStrings))
-					Expect(result.ValueMap()).To(Equal(expectedStrings))
-					Expect(result.ValueMapStringBytes()).To(Equal(expectedBytes))
-				}
-			})
-
-			It("returns a miss for nonexistent dictionary", func() {
-				Expect(
-					sharedContext.Client.DictionaryGetFields(sharedContext.Ctx, &DictionaryGetFieldsRequest{
-						CacheName:      sharedContext.CacheName,
-						DictionaryName: uuid.NewString(),
-						Fields:         []Value{String("myField1")},
-					}),
-				).To(BeAssignableToTypeOf(&DictionaryGetFieldsMiss{}))
-			})
-
-			It("returns misses for nonexistent fields", func() {
-				getResp, err := sharedContext.Client.DictionaryGetFields(sharedContext.Ctx, &DictionaryGetFieldsRequest{
-					CacheName:      sharedContext.CacheName,
-					DictionaryName: sharedContext.CollectionName,
-					Fields:         []Value{String("bogusField1"), String("bogusField2")},
-				})
-				Expect(err).To(BeNil())
-				Expect(getResp).To(BeAssignableToTypeOf(&DictionaryGetFieldsHit{}))
-				switch result := getResp.(type) {
-				case *DictionaryGetFieldsHit:
-					Expect(result.ValueMap()).To(BeEmpty())
-					for _, value := range result.Responses() {
-						switch value.(type) {
-						case *DictionaryGetFieldHit:
-							Fail("got a hit response for a field that should return a miss")
-						}
-					}
-				}
-			})
-
-			It("filters missing fields out of response value maps", func() {
-				getResp, err := sharedContext.Client.DictionaryGetFields(sharedContext.Ctx, &DictionaryGetFieldsRequest{
-					CacheName:      sharedContext.CacheName,
-					DictionaryName: sharedContext.CollectionName,
-					Fields:         []Value{String("bogusField1"), String("myField2")},
-				})
-				Expect(err).To(BeNil())
-				Expect(getResp).To(BeAssignableToTypeOf(&DictionaryGetFieldsHit{}))
-				switch result := getResp.(type) {
-				case *DictionaryGetFieldsHit:
-					Expect(result.ValueMap()).To(Equal(map[string]string{"myField2": "myValue2"}))
-					Expect(len(result.Responses())).To(Equal(2))
-				}
-			})
-
-			It("returns an error for a nil field", func() {
-				Expect(
-					sharedContext.Client.DictionaryGetFields(sharedContext.Ctx, &DictionaryGetFieldsRequest{
-						CacheName:      sharedContext.CacheName,
-						DictionaryName: sharedContext.CollectionName,
-						Fields:         []Value{String("myField"), nil},
-					}),
-				).Error().To(HaveMomentoErrorCode(InvalidArgumentError))
-			})
-
-		})
-	})
-
-	Describe("dictionary fetch", func() {
-
-		BeforeEach(func() {
-			Expect(
-				sharedContext.Client.DictionarySetFields(sharedContext.Ctx, &DictionarySetFieldsRequest{
-					CacheName:      sharedContext.CacheName,
-					DictionaryName: sharedContext.CollectionName,
-					Elements:       map[string]Value{"myField1": String("myValue1"), "myField2": Bytes("myValue2")},
-				}),
-			).To(BeAssignableToTypeOf(&DictionarySetFieldsSuccess{}))
-		})
-
-		It("fetches on the happy path", func() {
-			expected := map[string]string{"myField1": "myValue1", "myField2": "myValue2"}
-			fetchResp, err := sharedContext.Client.DictionaryFetch(sharedContext.Ctx, &DictionaryFetchRequest{
-				CacheName:      sharedContext.CacheName,
-				DictionaryName: sharedContext.CollectionName,
-			})
-			Expect(err).To(BeNil())
-			Expect(fetchResp).To(BeAssignableToTypeOf(&DictionaryFetchHit{}))
-			switch result := fetchResp.(type) {
-			case *DictionaryFetchHit:
-				Expect(result.ValueMap()).To(Equal(expected))
-			}
-		})
-
-		It("returns a miss for nonexistent dictionary", func() {
-			Expect(
-				sharedContext.Client.DictionaryFetch(sharedContext.Ctx, &DictionaryFetchRequest{
-					CacheName:      sharedContext.CacheName,
-					DictionaryName: uuid.NewString(),
-				}),
-			).To(BeAssignableToTypeOf(&DictionaryFetchMiss{}))
-		})
-
-	})
-
-	Describe("dictionary remove", func() {
-
-		BeforeEach(func() {
-			Expect(
-				sharedContext.Client.DictionarySetFields(sharedContext.Ctx, &DictionarySetFieldsRequest{
-					CacheName:      sharedContext.CacheName,
-					DictionaryName: sharedContext.CollectionName,
-					Elements: map[string]Value{
-						"myField1": String("myValue1"),
-						"myField2": Bytes("myValue2"),
-						"myField3": String("myValue3"),
-					},
-				}),
-			).To(BeAssignableToTypeOf(&DictionarySetFieldsSuccess{}))
-		})
-
-		When("removing a single field", func() {
-
-			It("properly removes a field", func() {
-				removeResp, err := sharedContext.Client.DictionaryRemoveField(sharedContext.Ctx, &DictionaryRemoveFieldRequest{
-					CacheName:      sharedContext.CacheName,
-					DictionaryName: sharedContext.CollectionName,
-					Field:          String("myField1"),
-				})
-				Expect(err).To(BeNil())
-				Expect(removeResp).To(BeAssignableToTypeOf(&DictionaryRemoveFieldSuccess{}))
-
-				fetchResp, err := sharedContext.Client.DictionaryFetch(sharedContext.Ctx, &DictionaryFetchRequest{
-					CacheName:      sharedContext.CacheName,
-					DictionaryName: sharedContext.CollectionName,
-				})
-				Expect(err).To(BeNil())
-				switch result := fetchResp.(type) {
-				case *DictionaryFetchHit:
-					Expect(result.ValueMap()).To(Equal(map[string]string{
-						"myField2": "myValue2",
-						"myField3": "myValue3",
-					}))
-				default:
-					Fail("expected a hit from dictionary fetch but got a miss")
-				}
-			})
-
-			It("no-ops when attempting to remove a nonexistent field", func() {
-				removeResp, err := sharedContext.Client.DictionaryRemoveField(sharedContext.Ctx, &DictionaryRemoveFieldRequest{
-					CacheName:      sharedContext.CacheName,
-					DictionaryName: sharedContext.CollectionName,
-					Field:          String("bogusField1"),
-				})
-				Expect(err).To(BeNil())
-				Expect(removeResp).To(BeAssignableToTypeOf(&DictionaryRemoveFieldSuccess{}))
-			})
-
-			It("no-ops when using a nonexistent dictionary", func() {
-				removeResp, err := sharedContext.Client.DictionaryRemoveField(sharedContext.Ctx, &DictionaryRemoveFieldRequest{
-					CacheName:      sharedContext.CacheName,
-					DictionaryName: uuid.NewString(),
-					Field:          String("bogusField1"),
-				})
-				Expect(err).To(BeNil())
-				Expect(removeResp).To(BeAssignableToTypeOf(&DictionaryRemoveFieldSuccess{}))
-			})
-
-			It("returns an error when trying to remove a nil field", func() {
-				Expect(
-					sharedContext.Client.DictionaryRemoveField(sharedContext.Ctx, &DictionaryRemoveFieldRequest{
-						CacheName:      sharedContext.CacheName,
-						DictionaryName: sharedContext.CollectionName,
-						Field:          nil,
-					}),
-				).Error().To(HaveMomentoErrorCode(InvalidArgumentError))
-			})
-
-		})
-
-		When("removing multiple fields", func() {
-
-			It("properly removes multiple fields", func() {
-				removeResp, err := sharedContext.Client.DictionaryRemoveFields(sharedContext.Ctx, &DictionaryRemoveFieldsRequest{
-					CacheName:      sharedContext.CacheName,
-					DictionaryName: sharedContext.CollectionName,
-					Fields:         []Value{String("myField1"), Bytes("myField2")},
-				})
-				Expect(err).To(BeNil())
-				Expect(removeResp).To(BeAssignableToTypeOf(&DictionaryRemoveFieldsSuccess{}))
-
-				fetchResp, err := sharedContext.Client.DictionaryFetch(sharedContext.Ctx, &DictionaryFetchRequest{
-					CacheName:      sharedContext.CacheName,
-					DictionaryName: sharedContext.CollectionName,
-				})
-				Expect(err).To(BeNil())
-				switch result := fetchResp.(type) {
-				case *DictionaryFetchHit:
-					Expect(result.ValueMap()).To(Equal(map[string]string{
-						"myField3": "myValue3",
-					}))
-				default:
-					Fail("expected a hit from dictionary fetch but got a miss")
-				}
-			})
-
-			It("no-ops when attempting to remove a nonexistent field", func() {
-				removeResp, err := sharedContext.Client.DictionaryRemoveFields(sharedContext.Ctx, &DictionaryRemoveFieldsRequest{
-					CacheName:      sharedContext.CacheName,
-					DictionaryName: sharedContext.CollectionName,
-					Fields:         []Value{String("bogusField1"), Bytes("bogusField2")},
-				})
-				Expect(err).To(BeNil())
-				Expect(removeResp).To(BeAssignableToTypeOf(&DictionaryRemoveFieldsSuccess{}))
-			})
-
-			It("no-ops when using a nonexistent dictionary", func() {
-				removeResp, err := sharedContext.Client.DictionaryRemoveFields(sharedContext.Ctx, &DictionaryRemoveFieldsRequest{
-					CacheName:      sharedContext.CacheName,
-					DictionaryName: uuid.NewString(),
-					Fields:         []Value{String("bogusField1"), Bytes("bogusField2")},
-				})
-				Expect(err).To(BeNil())
-				Expect(removeResp).To(BeAssignableToTypeOf(&DictionaryRemoveFieldsSuccess{}))
-			})
-
-			It("returns an error when Fields is nil", func() {
-				Expect(
-					sharedContext.Client.DictionaryRemoveFields(sharedContext.Ctx, &DictionaryRemoveFieldsRequest{
-						CacheName:      sharedContext.CacheName,
-						DictionaryName: sharedContext.CollectionName,
-						Fields:         nil,
-					}),
-				).Error().To(HaveMomentoErrorCode(InvalidArgumentError))
-			})
-
-			It("returns an error when one field is nil", func() {
-				Expect(
-					sharedContext.Client.DictionaryRemoveFields(sharedContext.Ctx, &DictionaryRemoveFieldsRequest{
-						CacheName:      sharedContext.CacheName,
-						DictionaryName: sharedContext.CollectionName,
-						Fields:         []Value{String("myField"), nil, String("myField2")},
-					}),
-				).Error().To(HaveMomentoErrorCode(InvalidArgumentError))
-			})
-
-		})
-	})
-
-	Describe("client TTL", func() {
-
-		When("client TTL is exceeded", func() {
-
-			It("returns a miss for the collection", func() {
-				Expect(
-					sharedContext.Client.DictionarySetFields(sharedContext.Ctx, &DictionarySetFieldsRequest{
-						CacheName:      sharedContext.CacheName,
-						DictionaryName: sharedContext.CollectionName,
-						Elements:       map[string]Value{"myField1": String("myValue1"), "myField2": String("myValue2")},
-					}),
-				).Error().To(BeNil())
-
-				Expect(
-					sharedContext.Client.DictionaryFetch(sharedContext.Ctx, &DictionaryFetchRequest{
-						CacheName:      sharedContext.CacheName,
-						DictionaryName: sharedContext.CollectionName,
-					}),
-				).To(BeAssignableToTypeOf(&DictionaryFetchHit{}))
-
-				time.Sleep(sharedContext.DefaultTtl)
-
-				Expect(
-					sharedContext.Client.DictionaryFetch(sharedContext.Ctx, &DictionaryFetchRequest{
-						CacheName:      sharedContext.CacheName,
-						DictionaryName: sharedContext.CollectionName,
-					}),
-				).To(BeAssignableToTypeOf(&DictionaryFetchMiss{}))
-			})
-
-		})
-
-	})
-
-	Describe("collection TTL", func() {
-
-		BeforeEach(func() {
-			Expect(
-				sharedContext.Client.DictionarySetFields(sharedContext.Ctx, &DictionarySetFieldsRequest{
-					CacheName:      sharedContext.CacheName,
-					DictionaryName: sharedContext.CollectionName,
-					Elements:       map[string]Value{"myField1": String("myValue1"), "myField2": String("myValue2")},
-				}),
-			).Error().To(BeNil())
-		})
-
-		When("collection TTL is empty", func() {
-
-			It("will have a false refreshTTL and fetch will miss after client default ttl", func() {
-				time.Sleep(sharedContext.DefaultTtl / 2)
-				Expect(
-					sharedContext.Client.DictionarySetField(sharedContext.Ctx, &DictionarySetFieldRequest{
-						CacheName:      sharedContext.CacheName,
-						DictionaryName: sharedContext.CollectionName,
-						Field:          String("foo"),
-						Value:          String("bar"),
-						Ttl:            utils.CollectionTtl{},
-					}),
-				).To(BeAssignableToTypeOf(&DictionarySetFieldSuccess{}))
-
-				time.Sleep(sharedContext.DefaultTtl / 2)
-
-				Expect(
-					sharedContext.Client.DictionaryFetch(sharedContext.Ctx, &DictionaryFetchRequest{
-						CacheName:      sharedContext.CacheName,
-						DictionaryName: sharedContext.CollectionName,
-					}),
-				).To(BeAssignableToTypeOf(&DictionaryFetchMiss{}))
-			})
-
-		})
-
-		When("collection TTL is configured", func() {
-
-			It("is ignored if refresh ttl is false", func() {
-				Expect(
-					sharedContext.Client.DictionarySetField(sharedContext.Ctx, &DictionarySetFieldRequest{
-						CacheName:      sharedContext.CacheName,
-						DictionaryName: sharedContext.CollectionName,
-						Field:          String("myField3"),
-						Value:          String("myValue3"),
-						Ttl: utils.CollectionTtl{
-							Ttl:        sharedContext.DefaultTtl + time.Second*60,
-							RefreshTtl: false,
-						},
-					}),
-				).To(BeAssignableToTypeOf(&DictionarySetFieldSuccess{}))
-
-				time.Sleep(sharedContext.DefaultTtl)
-
-				Expect(
-					sharedContext.Client.DictionaryFetch(sharedContext.Ctx, &DictionaryFetchRequest{
-						CacheName:      sharedContext.CacheName,
-						DictionaryName: sharedContext.CollectionName,
-					}),
-				).To(BeAssignableToTypeOf(&DictionaryFetchMiss{}))
-			})
-
-			It("is respected if refresh TTL is true", func() {
-				Expect(
-					sharedContext.Client.DictionarySetField(sharedContext.Ctx, &DictionarySetFieldRequest{
-						CacheName:      sharedContext.CacheName,
-						DictionaryName: sharedContext.CollectionName,
-						Field:          String("myField3"),
-						Value:          String("myValue3"),
-						Ttl: utils.CollectionTtl{
-							Ttl:        sharedContext.DefaultTtl + time.Second*60,
-							RefreshTtl: true,
-						},
-					}),
-				).To(BeAssignableToTypeOf(&DictionarySetFieldSuccess{}))
-
-				time.Sleep(sharedContext.DefaultTtl)
-
-				Expect(
-					sharedContext.Client.DictionaryFetch(sharedContext.Ctx, &DictionaryFetchRequest{
-						CacheName:      sharedContext.CacheName,
-						DictionaryName: sharedContext.CollectionName,
-					}),
-				).To(BeAssignableToTypeOf(&DictionaryFetchHit{}))
-			})
-
-		})
-
-	})
+	//DescribeTable("try using empty and nil fields and values for set",
+	//	func(field Value, value Value) {
+	//		Expect(
+	//			sharedContext.Client.DictionarySetField(sharedContext.Ctx, &DictionarySetFieldRequest{
+	//				CacheName:      sharedContext.CacheName,
+	//				DictionaryName: sharedContext.CollectionName,
+	//				Field:          field,
+	//				Value:          value,
+	//			}),
+	//		).Error().To(HaveMomentoErrorCode(InvalidArgumentError))
+	//	},
+	//	Entry("empty field", String(""), String("value")),
+	//	Entry("nil field", nil, String("value")),
+	//	Entry("nil value", String("field"), nil),
+	//	Entry("both nil", nil, nil),
+	//)
+	//
+	//DescribeTable("add string fields and string and bytes values for set fields happy path",
+	//	func(elements map[Value]Value, expectedItemsStringValue map[string]string, expectedItemsByteValue map[string][]byte) {
+	//		Expect(
+	//			sharedContext.Client.DictionarySetFields(sharedContext.Ctx, &DictionarySetFieldsRequest{
+	//				CacheName:      sharedContext.CacheName,
+	//				DictionaryName: sharedContext.CollectionName,
+	//				Elements:       elements,
+	//			}),
+	//		).To(BeAssignableToTypeOf(&DictionarySetFieldsSuccess{}))
+	//		fetchResp, err := sharedContext.Client.DictionaryFetch(sharedContext.Ctx, &DictionaryFetchRequest{
+	//			CacheName:      sharedContext.CacheName,
+	//			DictionaryName: sharedContext.CollectionName,
+	//		})
+	//		Expect(err).To(BeNil())
+	//		switch result := fetchResp.(type) {
+	//		case *DictionaryFetchMiss:
+	//			Fail("got a miss for a dictionary fetch that should have been a hit")
+	//		case *DictionaryFetchHit:
+	//			Expect(reflect.DeepEqual(result.ValueMap(), expectedItemsStringValue)).To(BeTrue())
+	//			Expect(reflect.DeepEqual(result.ValueMapStringString(), expectedItemsStringValue)).To(BeTrue())
+	//			Expect(reflect.DeepEqual(result.ValueMapStringByte(), expectedItemsByteValue)).To(BeTrue())
+	//		}
+	//	},
+	//	Entry(
+	//		"with string values",
+	//		map[Value]Value{Bytes("myField1"): String("myValue1"), Bytes("myField2"): String("myValue2")},
+	//		map[string]string{"myField1": "myValue1", "myField2": "myValue2"},
+	//		map[string][]byte{"myField1": []byte("myValue1"), "myField2": []byte("myValue2")},
+	//	),
+	//	Entry(
+	//		"with byte values",
+	//		map[Value]Value{String("myField1"): Bytes("myValue1"), String("myField2"): Bytes("myValue2")},
+	//		map[string]string{"myField1": "myValue1", "myField2": "myValue2"},
+	//		map[string][]byte{"myField1": []byte("myValue1"), "myField2": []byte("myValue2")},
+	//	),
+	//	Entry(
+	//		"with mixed values",
+	//		map[string]Value{"myField1": String("myValue1"), "myField2": Bytes("myValue2")},
+	//		map[string]string{"myField1": "myValue1", "myField2": "myValue2"},
+	//		map[string][]byte{"myField1": []byte("myValue1"), "myField2": []byte("myValue2")},
+	//	),
+	//)
+	//
+	//It("returns an error if an item field is empty", func() {
+	//	Expect(
+	//		sharedContext.Client.DictionarySetFields(sharedContext.Ctx, &DictionarySetFieldsRequest{
+	//			CacheName:      sharedContext.CacheName,
+	//			DictionaryName: sharedContext.CollectionName,
+	//			Elements:       map[Value]Value{String("myField"): String("myValue"), String(""): String("myOtherValue")},
+	//		}),
+	//	).Error().To(HaveMomentoErrorCode(InvalidArgumentError))
+	//})
+	//
+	//It("returns an error if an item value is nil", func() {
+	//	Expect(
+	//		sharedContext.Client.DictionarySetFields(sharedContext.Ctx, &DictionarySetFieldsRequest{
+	//			CacheName:      sharedContext.CacheName,
+	//			DictionaryName: sharedContext.CollectionName,
+	//			Elements:       map[Value]Value{String("myField"): String("myValue"), String("myOtherField"): nil},
+	//		}),
+	//	).Error().To(HaveMomentoErrorCode(InvalidArgumentError))
+	//})
+	//
+	//Describe("dictionary increment", func() {
+	//
+	//	It("populates nonexistent field", func() {
+	//		incrResp, err := sharedContext.Client.DictionaryIncrement(sharedContext.Ctx, &DictionaryIncrementRequest{
+	//			CacheName:      sharedContext.CacheName,
+	//			DictionaryName: sharedContext.CollectionName,
+	//			Field:          String("myField"),
+	//			Amount:         3,
+	//		})
+	//		Expect(err).To(BeNil())
+	//		Expect(incrResp).To(BeAssignableToTypeOf(&DictionaryIncrementSuccess{}))
+	//		switch result := incrResp.(type) {
+	//		case *DictionaryIncrementSuccess:
+	//			Expect(result.Value()).To(Equal(int64(3)))
+	//		}
+	//	})
+	//
+	//	It("returns an error when called on a non-integer field", func() {
+	//		Expect(
+	//			sharedContext.Client.DictionarySetField(sharedContext.Ctx, &DictionarySetFieldRequest{
+	//				CacheName:      sharedContext.CacheName,
+	//				DictionaryName: sharedContext.CollectionName,
+	//				Field:          String("notacounter"),
+	//				Value:          String("notanumber"),
+	//			}),
+	//		).To(BeAssignableToTypeOf(&DictionarySetFieldSuccess{}))
+	//
+	//		Expect(
+	//			sharedContext.Client.DictionaryIncrement(sharedContext.Ctx, &DictionaryIncrementRequest{
+	//				CacheName:      sharedContext.CacheName,
+	//				DictionaryName: sharedContext.CollectionName,
+	//				Field:          String("notacounter"),
+	//				Amount:         1,
+	//			}),
+	//		).Error().To(HaveMomentoErrorCode(FailedPreconditionError))
+	//	})
+	//
+	//	It("returns an error when amount is zero", func() {
+	//		_, err := sharedContext.Client.DictionaryIncrement(sharedContext.Ctx, &DictionaryIncrementRequest{
+	//			CacheName:      sharedContext.CacheName,
+	//			DictionaryName: sharedContext.CollectionName,
+	//			Field:          String("myField"),
+	//			Amount:         0,
+	//		})
+	//		Expect(err).To(HaveMomentoErrorCode(InvalidArgumentError))
+	//	})
+	//
+	//	It("increments on the happy path", func() {
+	//		field := String("counter")
+	//		for i := 0; i < 10; i++ {
+	//			Expect(
+	//				sharedContext.Client.DictionaryIncrement(sharedContext.Ctx, &DictionaryIncrementRequest{
+	//					CacheName:      sharedContext.CacheName,
+	//					DictionaryName: sharedContext.CollectionName,
+	//					Field:          field,
+	//					Amount:         1,
+	//				}),
+	//			).To(BeAssignableToTypeOf(&DictionaryIncrementSuccess{}))
+	//		}
+	//		fetchResp, err := sharedContext.Client.DictionaryGetField(sharedContext.Ctx, &DictionaryGetFieldRequest{
+	//			CacheName:      sharedContext.CacheName,
+	//			DictionaryName: sharedContext.CollectionName,
+	//			Field:          field,
+	//		})
+	//		Expect(err).To(BeNil())
+	//		Expect(fetchResp).To(BeAssignableToTypeOf(&DictionaryGetFieldHit{}))
+	//		switch result := fetchResp.(type) {
+	//		case *DictionaryGetFieldHit:
+	//			Expect(result.ValueString()).To(Equal("10"))
+	//		default:
+	//			Fail("expected a hit for get field but got a miss")
+	//		}
+	//	})
+	//
+	//	It("returns an error when field is nil", func() {
+	//		Expect(
+	//			sharedContext.Client.DictionaryIncrement(sharedContext.Ctx, &DictionaryIncrementRequest{
+	//				CacheName:      sharedContext.CacheName,
+	//				DictionaryName: sharedContext.CollectionName,
+	//				Field:          nil,
+	//				Amount:         1,
+	//			}),
+	//		).Error().To(HaveMomentoErrorCode(InvalidArgumentError))
+	//	})
+	//})
+	//
+	//Describe("dictionary get", func() {
+	//
+	//	BeforeEach(func() {
+	//		Expect(
+	//			sharedContext.Client.DictionarySetFields(sharedContext.Ctx, &DictionarySetFieldsRequest{
+	//				CacheName:      sharedContext.CacheName,
+	//				DictionaryName: sharedContext.CollectionName,
+	//				Elements:       map[Value]Value{String("myField1"): String("myValue1"), String("myField2"): Bytes("myValue2")},
+	//			}),
+	//		).To(BeAssignableToTypeOf(&DictionarySetFieldsSuccess{}))
+	//	})
+	//
+	//	When("getting single field", func() {
+	//
+	//		It("returns the correct string and byte values", func() {
+	//			expected := map[string]string{"myField1": "myValue1", "myField2": "myValue2"}
+	//
+	//			for fieldName, valueStr := range expected {
+	//				getResp, err := sharedContext.Client.DictionaryGetField(sharedContext.Ctx, &DictionaryGetFieldRequest{
+	//					CacheName:      sharedContext.CacheName,
+	//					DictionaryName: sharedContext.CollectionName,
+	//					Field:          String(fieldName),
+	//				})
+	//				Expect(err).To(BeNil())
+	//				Expect(getResp).To(BeAssignableToTypeOf(&DictionaryGetFieldHit{}))
+	//				switch result := getResp.(type) {
+	//				case *DictionaryGetFieldHit:
+	//					Expect(result.FieldString()).To(Equal(fieldName))
+	//					Expect(result.FieldByte()).To(Equal([]byte(fieldName)))
+	//					Expect(result.ValueString()).To(Equal(valueStr))
+	//					Expect(result.ValueByte()).To(Equal([]byte(valueStr)))
+	//				default:
+	//					Fail("something really weird happened")
+	//				}
+	//			}
+	//		})
+	//
+	//		It("returns a miss for a nonexistent field", func() {
+	//			getResp, err := sharedContext.Client.DictionaryGetField(sharedContext.Ctx, &DictionaryGetFieldRequest{
+	//				CacheName:      sharedContext.CacheName,
+	//				DictionaryName: sharedContext.CollectionName,
+	//				Field:          String("idontexist"),
+	//			})
+	//			Expect(err).To(BeNil())
+	//			Expect(getResp).To(BeAssignableToTypeOf(&DictionaryGetFieldMiss{}))
+	//		})
+	//
+	//		It("returns a miss for a nonexistent dictionary", func() {
+	//			getResp, err := sharedContext.Client.DictionaryGetField(sharedContext.Ctx, &DictionaryGetFieldRequest{
+	//				CacheName:      sharedContext.CacheName,
+	//				DictionaryName: uuid.NewString(),
+	//				Field:          String("idontexist"),
+	//			})
+	//			Expect(err).To(BeNil())
+	//			Expect(getResp).To(BeAssignableToTypeOf(&DictionaryGetFieldMiss{}))
+	//		})
+	//
+	//		It("returns an error for a nil field", func() {
+	//			Expect(
+	//				sharedContext.Client.DictionaryGetField(sharedContext.Ctx, &DictionaryGetFieldRequest{
+	//					CacheName:      sharedContext.CacheName,
+	//					DictionaryName: sharedContext.CollectionName,
+	//					Field:          nil,
+	//				}),
+	//			).Error().To(HaveMomentoErrorCode(InvalidArgumentError))
+	//		})
+	//
+	//	})
+	//
+	//	When("getting multiple fields", func() {
+	//
+	//		It("returns the correct string and byte values", func() {
+	//			getResp, err := sharedContext.Client.DictionaryGetFields(sharedContext.Ctx, &DictionaryGetFieldsRequest{
+	//				CacheName:      sharedContext.CacheName,
+	//				DictionaryName: sharedContext.CollectionName,
+	//				Fields:         []Value{String("myField1"), String("myField2")},
+	//			})
+	//			Expect(err).To(BeNil())
+	//			Expect(getResp).To(BeAssignableToTypeOf(&DictionaryGetFieldsHit{}))
+	//
+	//			expectedStrings := map[string]string{"myField1": "myValue1", "myField2": "myValue2"}
+	//			expectedBytes := map[string][]byte{"myField1": []byte("myValue1"), "myField2": []byte("myValue2")}
+	//			switch result := getResp.(type) {
+	//			case *DictionaryGetFieldsHit:
+	//				Expect(result.ValueMapStringString()).To(Equal(expectedStrings))
+	//				Expect(result.ValueMap()).To(Equal(expectedStrings))
+	//				Expect(result.ValueMapStringBytes()).To(Equal(expectedBytes))
+	//			}
+	//		})
+	//
+	//		It("returns a miss for nonexistent dictionary", func() {
+	//			Expect(
+	//				sharedContext.Client.DictionaryGetFields(sharedContext.Ctx, &DictionaryGetFieldsRequest{
+	//					CacheName:      sharedContext.CacheName,
+	//					DictionaryName: uuid.NewString(),
+	//					Fields:         []Value{String("myField1")},
+	//				}),
+	//			).To(BeAssignableToTypeOf(&DictionaryGetFieldsMiss{}))
+	//		})
+	//
+	//		It("returns misses for nonexistent fields", func() {
+	//			getResp, err := sharedContext.Client.DictionaryGetFields(sharedContext.Ctx, &DictionaryGetFieldsRequest{
+	//				CacheName:      sharedContext.CacheName,
+	//				DictionaryName: sharedContext.CollectionName,
+	//				Fields:         []Value{String("bogusField1"), String("bogusField2")},
+	//			})
+	//			Expect(err).To(BeNil())
+	//			Expect(getResp).To(BeAssignableToTypeOf(&DictionaryGetFieldsHit{}))
+	//			switch result := getResp.(type) {
+	//			case *DictionaryGetFieldsHit:
+	//				Expect(result.ValueMap()).To(BeEmpty())
+	//				for _, value := range result.Responses() {
+	//					switch value.(type) {
+	//					case *DictionaryGetFieldHit:
+	//						Fail("got a hit response for a field that should return a miss")
+	//					}
+	//				}
+	//			}
+	//		})
+	//
+	//		It("filters missing fields out of response value maps", func() {
+	//			getResp, err := sharedContext.Client.DictionaryGetFields(sharedContext.Ctx, &DictionaryGetFieldsRequest{
+	//				CacheName:      sharedContext.CacheName,
+	//				DictionaryName: sharedContext.CollectionName,
+	//				Fields:         []Value{String("bogusField1"), String("myField2")},
+	//			})
+	//			Expect(err).To(BeNil())
+	//			Expect(getResp).To(BeAssignableToTypeOf(&DictionaryGetFieldsHit{}))
+	//			switch result := getResp.(type) {
+	//			case *DictionaryGetFieldsHit:
+	//				Expect(result.ValueMap()).To(Equal(map[string]string{"myField2": "myValue2"}))
+	//				Expect(len(result.Responses())).To(Equal(2))
+	//			}
+	//		})
+	//
+	//		It("returns an error for a nil field", func() {
+	//			Expect(
+	//				sharedContext.Client.DictionaryGetFields(sharedContext.Ctx, &DictionaryGetFieldsRequest{
+	//					CacheName:      sharedContext.CacheName,
+	//					DictionaryName: sharedContext.CollectionName,
+	//					Fields:         []Value{String("myField"), nil},
+	//				}),
+	//			).Error().To(HaveMomentoErrorCode(InvalidArgumentError))
+	//		})
+	//
+	//	})
+	//})
+	//
+	//Describe("dictionary fetch", func() {
+	//
+	//	BeforeEach(func() {
+	//		Expect(
+	//			sharedContext.Client.DictionarySetFields(sharedContext.Ctx, &DictionarySetFieldsRequest{
+	//				CacheName:      sharedContext.CacheName,
+	//				DictionaryName: sharedContext.CollectionName,
+	//				Elements:       map[Value]Value{String("myField1"): String("myValue1"), String("myField2"): Bytes("myValue2")},
+	//			}),
+	//		).To(BeAssignableToTypeOf(&DictionarySetFieldsSuccess{}))
+	//	})
+	//
+	//	It("fetches on the happy path", func() {
+	//		expected := map[string]string{"myField1": "myValue1", "myField2": "myValue2"}
+	//		fetchResp, err := sharedContext.Client.DictionaryFetch(sharedContext.Ctx, &DictionaryFetchRequest{
+	//			CacheName:      sharedContext.CacheName,
+	//			DictionaryName: sharedContext.CollectionName,
+	//		})
+	//		Expect(err).To(BeNil())
+	//		Expect(fetchResp).To(BeAssignableToTypeOf(&DictionaryFetchHit{}))
+	//		switch result := fetchResp.(type) {
+	//		case *DictionaryFetchHit:
+	//			Expect(result.ValueMap()).To(Equal(expected))
+	//		}
+	//	})
+	//
+	//	It("returns a miss for nonexistent dictionary", func() {
+	//		Expect(
+	//			sharedContext.Client.DictionaryFetch(sharedContext.Ctx, &DictionaryFetchRequest{
+	//				CacheName:      sharedContext.CacheName,
+	//				DictionaryName: uuid.NewString(),
+	//			}),
+	//		).To(BeAssignableToTypeOf(&DictionaryFetchMiss{}))
+	//	})
+	//
+	//})
+	//
+	//Describe("dictionary remove", func() {
+	//
+	//	BeforeEach(func() {
+	//		Expect(
+	//			sharedContext.Client.DictionarySetFields(sharedContext.Ctx, &DictionarySetFieldsRequest{
+	//				CacheName:      sharedContext.CacheName,
+	//				DictionaryName: sharedContext.CollectionName,
+	//				Elements: map[Value]Value{
+	//					String("myField1"): String("myValue1"),
+	//					String("myField2"): Bytes("myValue2"),
+	//					String("myField3"): String("myValue3"),
+	//				},
+	//			}),
+	//		).To(BeAssignableToTypeOf(&DictionarySetFieldsSuccess{}))
+	//	})
+	//
+	//	When("removing a single field", func() {
+	//
+	//		It("properly removes a field", func() {
+	//			removeResp, err := sharedContext.Client.DictionaryRemoveField(sharedContext.Ctx, &DictionaryRemoveFieldRequest{
+	//				CacheName:      sharedContext.CacheName,
+	//				DictionaryName: sharedContext.CollectionName,
+	//				Field:          String("myField1"),
+	//			})
+	//			Expect(err).To(BeNil())
+	//			Expect(removeResp).To(BeAssignableToTypeOf(&DictionaryRemoveFieldSuccess{}))
+	//
+	//			fetchResp, err := sharedContext.Client.DictionaryFetch(sharedContext.Ctx, &DictionaryFetchRequest{
+	//				CacheName:      sharedContext.CacheName,
+	//				DictionaryName: sharedContext.CollectionName,
+	//			})
+	//			Expect(err).To(BeNil())
+	//			switch result := fetchResp.(type) {
+	//			case *DictionaryFetchHit:
+	//				Expect(result.ValueMap()).To(Equal(map[string]string{
+	//					"myField2": "myValue2",
+	//					"myField3": "myValue3",
+	//				}))
+	//			default:
+	//				Fail("expected a hit from dictionary fetch but got a miss")
+	//			}
+	//		})
+	//
+	//		It("no-ops when attempting to remove a nonexistent field", func() {
+	//			removeResp, err := sharedContext.Client.DictionaryRemoveField(sharedContext.Ctx, &DictionaryRemoveFieldRequest{
+	//				CacheName:      sharedContext.CacheName,
+	//				DictionaryName: sharedContext.CollectionName,
+	//				Field:          String("bogusField1"),
+	//			})
+	//			Expect(err).To(BeNil())
+	//			Expect(removeResp).To(BeAssignableToTypeOf(&DictionaryRemoveFieldSuccess{}))
+	//		})
+	//
+	//		It("no-ops when using a nonexistent dictionary", func() {
+	//			removeResp, err := sharedContext.Client.DictionaryRemoveField(sharedContext.Ctx, &DictionaryRemoveFieldRequest{
+	//				CacheName:      sharedContext.CacheName,
+	//				DictionaryName: uuid.NewString(),
+	//				Field:          String("bogusField1"),
+	//			})
+	//			Expect(err).To(BeNil())
+	//			Expect(removeResp).To(BeAssignableToTypeOf(&DictionaryRemoveFieldSuccess{}))
+	//		})
+	//
+	//		It("returns an error when trying to remove a nil field", func() {
+	//			Expect(
+	//				sharedContext.Client.DictionaryRemoveField(sharedContext.Ctx, &DictionaryRemoveFieldRequest{
+	//					CacheName:      sharedContext.CacheName,
+	//					DictionaryName: sharedContext.CollectionName,
+	//					Field:          nil,
+	//				}),
+	//			).Error().To(HaveMomentoErrorCode(InvalidArgumentError))
+	//		})
+	//
+	//	})
+	//
+	//	When("removing multiple fields", func() {
+	//
+	//		It("properly removes multiple fields", func() {
+	//			removeResp, err := sharedContext.Client.DictionaryRemoveFields(sharedContext.Ctx, &DictionaryRemoveFieldsRequest{
+	//				CacheName:      sharedContext.CacheName,
+	//				DictionaryName: sharedContext.CollectionName,
+	//				Fields:         []Value{String("myField1"), Bytes("myField2")},
+	//			})
+	//			Expect(err).To(BeNil())
+	//			Expect(removeResp).To(BeAssignableToTypeOf(&DictionaryRemoveFieldsSuccess{}))
+	//
+	//			fetchResp, err := sharedContext.Client.DictionaryFetch(sharedContext.Ctx, &DictionaryFetchRequest{
+	//				CacheName:      sharedContext.CacheName,
+	//				DictionaryName: sharedContext.CollectionName,
+	//			})
+	//			Expect(err).To(BeNil())
+	//			switch result := fetchResp.(type) {
+	//			case *DictionaryFetchHit:
+	//				Expect(result.ValueMap()).To(Equal(map[string]string{
+	//					"myField3": "myValue3",
+	//				}))
+	//			default:
+	//				Fail("expected a hit from dictionary fetch but got a miss")
+	//			}
+	//		})
+	//
+	//		It("no-ops when attempting to remove a nonexistent field", func() {
+	//			removeResp, err := sharedContext.Client.DictionaryRemoveFields(sharedContext.Ctx, &DictionaryRemoveFieldsRequest{
+	//				CacheName:      sharedContext.CacheName,
+	//				DictionaryName: sharedContext.CollectionName,
+	//				Fields:         []Value{String("bogusField1"), Bytes("bogusField2")},
+	//			})
+	//			Expect(err).To(BeNil())
+	//			Expect(removeResp).To(BeAssignableToTypeOf(&DictionaryRemoveFieldsSuccess{}))
+	//		})
+	//
+	//		It("no-ops when using a nonexistent dictionary", func() {
+	//			removeResp, err := sharedContext.Client.DictionaryRemoveFields(sharedContext.Ctx, &DictionaryRemoveFieldsRequest{
+	//				CacheName:      sharedContext.CacheName,
+	//				DictionaryName: uuid.NewString(),
+	//				Fields:         []Value{String("bogusField1"), Bytes("bogusField2")},
+	//			})
+	//			Expect(err).To(BeNil())
+	//			Expect(removeResp).To(BeAssignableToTypeOf(&DictionaryRemoveFieldsSuccess{}))
+	//		})
+	//
+	//		It("returns an error when Fields is nil", func() {
+	//			Expect(
+	//				sharedContext.Client.DictionaryRemoveFields(sharedContext.Ctx, &DictionaryRemoveFieldsRequest{
+	//					CacheName:      sharedContext.CacheName,
+	//					DictionaryName: sharedContext.CollectionName,
+	//					Fields:         nil,
+	//				}),
+	//			).Error().To(HaveMomentoErrorCode(InvalidArgumentError))
+	//		})
+	//
+	//		It("returns an error when one field is nil", func() {
+	//			Expect(
+	//				sharedContext.Client.DictionaryRemoveFields(sharedContext.Ctx, &DictionaryRemoveFieldsRequest{
+	//					CacheName:      sharedContext.CacheName,
+	//					DictionaryName: sharedContext.CollectionName,
+	//					Fields:         []Value{String("myField"), nil, String("myField2")},
+	//				}),
+	//			).Error().To(HaveMomentoErrorCode(InvalidArgumentError))
+	//		})
+	//
+	//	})
+	//})
+	//
+	//Describe("client TTL", func() {
+	//
+	//	When("client TTL is exceeded", func() {
+	//
+	//		It("returns a miss for the collection", func() {
+	//			Expect(
+	//				sharedContext.Client.DictionarySetFields(sharedContext.Ctx, &DictionarySetFieldsRequest{
+	//					CacheName:      sharedContext.CacheName,
+	//					DictionaryName: sharedContext.CollectionName,
+	//					Elements:       map[Value]Value{String("myField1"): String("myValue1"), String("myField2"): String("myValue2")},
+	//				}),
+	//			).Error().To(BeNil())
+	//
+	//			Expect(
+	//				sharedContext.Client.DictionaryFetch(sharedContext.Ctx, &DictionaryFetchRequest{
+	//					CacheName:      sharedContext.CacheName,
+	//					DictionaryName: sharedContext.CollectionName,
+	//				}),
+	//			).To(BeAssignableToTypeOf(&DictionaryFetchHit{}))
+	//
+	//			time.Sleep(sharedContext.DefaultTtl)
+	//
+	//			Expect(
+	//				sharedContext.Client.DictionaryFetch(sharedContext.Ctx, &DictionaryFetchRequest{
+	//					CacheName:      sharedContext.CacheName,
+	//					DictionaryName: sharedContext.CollectionName,
+	//				}),
+	//			).To(BeAssignableToTypeOf(&DictionaryFetchMiss{}))
+	//		})
+	//
+	//	})
+	//
+	//})
+	//
+	//Describe("collection TTL", func() {
+	//
+	//	BeforeEach(func() {
+	//		Expect(
+	//			sharedContext.Client.DictionarySetFields(sharedContext.Ctx, &DictionarySetFieldsRequest{
+	//				CacheName:      sharedContext.CacheName,
+	//				DictionaryName: sharedContext.CollectionName,
+	//				Elements:       map[Value]Value{String("myField1"): String("myValue1"), String("myField2"): String("myValue2")},
+	//			}),
+	//		).Error().To(BeNil())
+	//	})
+	//
+	//	When("collection TTL is empty", func() {
+	//
+	//		It("will have a false refreshTTL and fetch will miss after client default ttl", func() {
+	//			time.Sleep(sharedContext.DefaultTtl / 2)
+	//			Expect(
+	//				sharedContext.Client.DictionarySetField(sharedContext.Ctx, &DictionarySetFieldRequest{
+	//					CacheName:      sharedContext.CacheName,
+	//					DictionaryName: sharedContext.CollectionName,
+	//					Field:          String("foo"),
+	//					Value:          String("bar"),
+	//					Ttl:            utils.CollectionTtl{},
+	//				}),
+	//			).To(BeAssignableToTypeOf(&DictionarySetFieldSuccess{}))
+	//
+	//			time.Sleep(sharedContext.DefaultTtl / 2)
+	//
+	//			Expect(
+	//				sharedContext.Client.DictionaryFetch(sharedContext.Ctx, &DictionaryFetchRequest{
+	//					CacheName:      sharedContext.CacheName,
+	//					DictionaryName: sharedContext.CollectionName,
+	//				}),
+	//			).To(BeAssignableToTypeOf(&DictionaryFetchMiss{}))
+	//		})
+	//
+	//	})
+	//
+	//	When("collection TTL is configured", func() {
+	//
+	//		It("is ignored if refresh ttl is false", func() {
+	//			Expect(
+	//				sharedContext.Client.DictionarySetField(sharedContext.Ctx, &DictionarySetFieldRequest{
+	//					CacheName:      sharedContext.CacheName,
+	//					DictionaryName: sharedContext.CollectionName,
+	//					Field:          String("myField3"),
+	//					Value:          String("myValue3"),
+	//					Ttl: utils.CollectionTtl{
+	//						Ttl:        sharedContext.DefaultTtl + time.Second*60,
+	//						RefreshTtl: false,
+	//					},
+	//				}),
+	//			).To(BeAssignableToTypeOf(&DictionarySetFieldSuccess{}))
+	//
+	//			time.Sleep(sharedContext.DefaultTtl)
+	//
+	//			Expect(
+	//				sharedContext.Client.DictionaryFetch(sharedContext.Ctx, &DictionaryFetchRequest{
+	//					CacheName:      sharedContext.CacheName,
+	//					DictionaryName: sharedContext.CollectionName,
+	//				}),
+	//			).To(BeAssignableToTypeOf(&DictionaryFetchMiss{}))
+	//		})
+	//
+	//		It("is respected if refresh TTL is true", func() {
+	//			Expect(
+	//				sharedContext.Client.DictionarySetField(sharedContext.Ctx, &DictionarySetFieldRequest{
+	//					CacheName:      sharedContext.CacheName,
+	//					DictionaryName: sharedContext.CollectionName,
+	//					Field:          String("myField3"),
+	//					Value:          String("myValue3"),
+	//					Ttl: utils.CollectionTtl{
+	//						Ttl:        sharedContext.DefaultTtl + time.Second*60,
+	//						RefreshTtl: true,
+	//					},
+	//				}),
+	//			).To(BeAssignableToTypeOf(&DictionarySetFieldSuccess{}))
+	//
+	//			time.Sleep(sharedContext.DefaultTtl)
+	//
+	//			Expect(
+	//				sharedContext.Client.DictionaryFetch(sharedContext.Ctx, &DictionaryFetchRequest{
+	//					CacheName:      sharedContext.CacheName,
+	//					DictionaryName: sharedContext.CollectionName,
+	//				}),
+	//			).To(BeAssignableToTypeOf(&DictionaryFetchHit{}))
+	//		})
+	//
+	//	})
+	//
+	//})
 
 })

--- a/momento/requester.go
+++ b/momento/requester.go
@@ -63,7 +63,7 @@ type hasFields interface {
 }
 
 type hasElements interface {
-	elements() map[Value]Value
+	elements() map[*Field]Value
 }
 
 type hasTtl interface {
@@ -173,10 +173,11 @@ func prepareElements(r hasElements) (map[string][]byte, error) {
 				momentoerrors.InvalidArgumentError, "item values may not be nil", nil,
 			)
 		}
-		if err := validateNotEmpty(k.asBytes(), "item keys"); err != nil {
+		key := *k
+		if err := validateNotEmpty(key.asBytes(), "item keys"); err != nil {
 			return nil, err
 		}
-		retMap[k.asString()] = v.asBytes()
+		retMap[key.asString()] = v.asBytes()
 	}
 	return retMap, nil
 }

--- a/momento/requester.go
+++ b/momento/requester.go
@@ -63,7 +63,7 @@ type hasFields interface {
 }
 
 type hasElements interface {
-	elements() map[string]Value
+	elements() map[Value]Value
 }
 
 type hasTtl interface {
@@ -173,10 +173,10 @@ func prepareElements(r hasElements) (map[string][]byte, error) {
 				momentoerrors.InvalidArgumentError, "item values may not be nil", nil,
 			)
 		}
-		if err := validateNotEmpty([]byte(k), "item keys"); err != nil {
+		if err := validateNotEmpty(k.asBytes(), "item keys"); err != nil {
 			return nil, err
 		}
-		retMap[k] = v.asBytes()
+		retMap[k.asString()] = v.asBytes()
 	}
 	return retMap, nil
 }

--- a/momento/simple_cache_client.go
+++ b/momento/simple_cache_client.go
@@ -348,8 +348,8 @@ func (c defaultScsClient) DictionarySetField(ctx context.Context, r *DictionaryS
 			),
 		)
 	}
-	elements := make(map[string]Value)
-	elements[r.Field.asString()] = r.Value
+	elements := make(map[*Field]Value)
+	elements[r.Field] = r.Value
 	newRequest := &DictionarySetFieldsRequest{
 		CacheName:      r.CacheName,
 		DictionaryName: r.DictionaryName,

--- a/momento/simple_cache_client.go
+++ b/momento/simple_cache_client.go
@@ -349,7 +349,7 @@ func (c defaultScsClient) DictionarySetField(ctx context.Context, r *DictionaryS
 		)
 	}
 	elements := make(map[string]Value)
-	elements[string(r.Field.asBytes())] = r.Value
+	elements[r.Field.asString()] = r.Value
 	newRequest := &DictionarySetFieldsRequest{
 		CacheName:      r.CacheName,
 		DictionaryName: r.DictionaryName,

--- a/momento/test_helpers/shared_context.go
+++ b/momento/test_helpers/shared_context.go
@@ -45,7 +45,6 @@ func NewSharedContext() SharedContext {
 
 	shared.Client = client
 	shared.TopicClient = topicClient
-
 	shared.CacheName = uuid.NewString()
 	shared.CollectionName = uuid.NewString()
 

--- a/momento/value.go
+++ b/momento/value.go
@@ -9,7 +9,12 @@ type Value interface {
 }
 
 // Type alias to future proof passing in keys.
+// [momento.Value]
 type Key = Value
+
+// Type alias to future proof passing in fields.
+// [momento.Value]
+type Field = Value
 
 // Bytes plain old []byte
 type Bytes []byte


### PR DESCRIPTION
Started with what @pgautier404 had in his experiment branch, `value-map-key` ([commit](https://github.com/momentohq/client-sdk-go/commit/7915ad7ade96638272b460a504feee5dbbc7bc0c)), I extended the spike on the map field param type.
I created a type alias called `Field` which is an alias for our existing `Value` interface type.
For this spike, I attempted to keep the map field to accept `Field` type so that it's clearer for users that they can use both `string` and `byte[]` types.
But it turns out that Go cannot hash interface, which made the following caused panic: 
```
elements := make(map[Field]Value)
elements[r.Field] = r.Value
```

To solve this, I made `Field` property to be a pointer. I'm not sure how I feel about this since one of the few reasons for this to be a pointer is so that it can be used as a map field. 
Another reason is so that users can see what types of fields are availabe.

I'm curious to see what feedback/advice @pgautier404 @schwern @eaddingtonwhite have!

https://github.com/momentohq/client-sdk-go/issues/180