### PR TITLE
fix: use alternative data structure for dict ops

### DIFF
--- a/momento/dictionary_set_fields.go
+++ b/momento/dictionary_set_fields.go
@@ -24,7 +24,7 @@ func (DictionarySetFieldsSuccess) isDictionarySetFieldsResponse() {}
 type DictionarySetFieldsRequest struct {
 	CacheName      string
 	DictionaryName string
-	Elements       map[string]Value
+	Elements       []Element
 	Ttl            *utils.CollectionTtl
 
 	grpcRequest  *pb.XDictionarySetRequest
@@ -34,7 +34,7 @@ type DictionarySetFieldsRequest struct {
 
 func (r *DictionarySetFieldsRequest) cacheName() string { return r.CacheName }
 
-func (r *DictionarySetFieldsRequest) elements() map[string]Value { return r.Elements }
+func (r *DictionarySetFieldsRequest) elements() []Element { return r.Elements }
 
 func (r *DictionarySetFieldsRequest) ttl() time.Duration { return r.Ttl.Ttl }
 
@@ -49,16 +49,16 @@ func (r *DictionarySetFieldsRequest) initGrpcRequest(client scsDataClient) error
 		return err
 	}
 
-	var elements map[string][]byte
+	var elements []Element
 	if elements, err = prepareElements(r); err != nil {
 		return err
 	}
 
 	var pbElements []*pb.XDictionaryFieldValuePair
-	for k, v := range elements {
+	for _, v := range elements {
 		pbElements = append(pbElements, &pb.XDictionaryFieldValuePair{
-			Field: []byte(k),
-			Value: v,
+			Field: v.ElemField.asBytes(),
+			Value: v.ElemValue.asBytes(),
 		})
 	}
 

--- a/momento/simple_cache_client.go
+++ b/momento/simple_cache_client.go
@@ -349,8 +349,11 @@ func (c defaultScsClient) DictionarySetField(ctx context.Context, r *DictionaryS
 		)
 	}
 
-	elements := make(map[string]Value)
-	elements[string(r.Field.asBytes())] = r.Value
+	var elements []Element
+	elements = append(elements, Element{
+		ElemField: r.Field,
+		ElemValue: r.Value,
+	})
 	newRequest := &DictionarySetFieldsRequest{
 		CacheName:      r.CacheName,
 		DictionaryName: r.DictionaryName,

--- a/momento/test_helpers/shared_context.go
+++ b/momento/test_helpers/shared_context.go
@@ -2,6 +2,7 @@ package helpers
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/google/uuid"
@@ -46,7 +47,7 @@ func NewSharedContext() SharedContext {
 	shared.Client = client
 	shared.TopicClient = topicClient
 
-	shared.CacheName = uuid.NewString()
+	shared.CacheName = fmt.Sprintf("golang-%s", uuid.NewString())
 	shared.CollectionName = uuid.NewString()
 
 	return shared

--- a/momento/value.go
+++ b/momento/value.go
@@ -1,6 +1,6 @@
 package momento
 
-// Interface to help users deal with passing us values as strings or bytes.
+// Value Interface to help users deal with passing us values as strings or bytes.
 // Value: momento.Bytes([]bytes("abc"))
 // Value: momento.String("abc")
 type Value interface {
@@ -8,7 +8,7 @@ type Value interface {
 	asString() string
 }
 
-// Type alias to future proof passing in keys.
+// Key Type alias to future proof passing in keys.
 type Key = Value
 
 // Bytes plain old []byte
@@ -29,4 +29,8 @@ func (v String) asBytes() []byte {
 
 func (v String) asString() string {
 	return string(v)
+}
+
+type Element struct {
+	ElemField, ElemValue Value
 }

--- a/momento/value.go
+++ b/momento/value.go
@@ -31,6 +31,9 @@ func (v String) asString() string {
 	return string(v)
 }
 
+// Element Type to hold field/value pairs for use with the DictionarySetFields operation.
+// The Value type is used for ElemField and ElemValue and allows  both strings and bytes
+// to be used for fields and values.
 type Element struct {
 	ElemField, ElemValue Value
 }


### PR DESCRIPTION
This commit introduces an `Element` type that contains an `ElemField` and `ElemValue`, both of which use our `Value` type. This type is for use with `DictionarySetFields` and allows users to provide byte and string fields and values, as opposed to go's built-in `map` which disallows byte slice keys. It also includes helper functions to convert from a few different types of maps to `[]Element`. Finally, the shared test context code has been modified to prepend test caches with `golang-` for easy identification of the source of stranded caches.