### PR TITLE
chore: verify pointer responses

### DIFF
--- a/momento/dictionary_test.go
+++ b/momento/dictionary_test.go
@@ -485,10 +485,7 @@ var _ = Describe("Dictionary methods", func() {
 				case *DictionaryGetFieldsHit:
 					Expect(result.ValueMap()).To(BeEmpty())
 					for _, value := range result.Responses() {
-						switch value.(type) {
-						case *DictionaryGetFieldHit:
-							Fail("got a hit response for a field that should return a miss")
-						}
+						Expect(value).To(BeAssignableToTypeOf(&DictionaryGetFieldMiss{}))
 					}
 				}
 			})

--- a/momento/scalar_test.go
+++ b/momento/scalar_test.go
@@ -114,6 +114,15 @@ var _ = Describe("Scalar methods", func() {
 		).Error().To(HaveMomentoErrorCode(InvalidArgumentError))
 	})
 
+	It("returns a miss when the key doesn't exist", func() {
+		Expect(
+			sharedContext.Client.Get(sharedContext.Ctx, &GetRequest{
+				CacheName: sharedContext.CacheName,
+				Key:       String(uuid.NewString()),
+			}),
+		).To(BeAssignableToTypeOf(&GetMiss{}))
+	})
+
 	DescribeTable(`invalid cache names and keys`,
 		func(cacheName string, key Key, value Key) {
 			getResp, err := sharedContext.Client.Get(sharedContext.Ctx, &GetRequest{

--- a/momento/set_test.go
+++ b/momento/set_test.go
@@ -111,6 +111,15 @@ var _ = Describe("Set methods", func() {
 		).Error().To(HaveMomentoErrorCode(InvalidArgumentError))
 	})
 
+	It("gets a miss trying to fetch a nonexistent set", func() {
+		Expect(
+			sharedContext.Client.SetFetch(sharedContext.Ctx, &SetFetchRequest{
+				CacheName: sharedContext.CacheName,
+				SetName:   uuid.NewString(),
+			}),
+		).To(BeAssignableToTypeOf(&SetFetchMiss{}))
+	})
+
 	Describe("add", func() {
 		DescribeTable("add string and byte single elements happy path",
 			func(element Value, expectedStrings []string, expectedBytes [][]byte) {

--- a/momento/topic_client.go
+++ b/momento/topic_client.go
@@ -119,6 +119,7 @@ func (c defaultTopicClient) Publish(ctx context.Context, request *TopicPublishRe
 
 	return &responses.TopicPublishSuccess{}, err
 }
+
 func (c defaultTopicClient) Close() {
 	defer c.pubSubClient.Close()
 }

--- a/momento/topic_value.go
+++ b/momento/topic_value.go
@@ -1,5 +1,6 @@
 package momento
 
+// TopicValue
 // For now, topics take the same types as normal methods.
 // In the future this might not be so, topics might take
 // different types than methods.


### PR DESCRIPTION
This commit contains a grab bag of small fixes encountered while auditing response types for #193, mostly explicit checks for `miss` types to ensure they come in as pointers.