### PR TITLE
feat!: Sortedset inconsistencies

### DIFF
--- a/momento/cache_client.go
+++ b/momento/cache_client.go
@@ -202,7 +202,7 @@ func (c defaultScsClient) SortedSetGetScores(ctx context.Context, r *SortedSetGe
 }
 
 func (c defaultScsClient) SortedSetRemove(ctx context.Context, r *SortedSetRemoveRequest) (responses.SortedSetRemoveResponse, error) {
-	if r.ElementsToRemove == nil {
+	if r.Values == nil {
 		return nil, convertMomentoSvcErrorToCustomerError(
 			momentoerrors.NewMomentoSvcErr(
 				momentoerrors.InvalidArgumentError, "elements to remove cannot be nil", nil,

--- a/momento/cache_client.go
+++ b/momento/cache_client.go
@@ -202,13 +202,6 @@ func (c defaultScsClient) SortedSetGetScores(ctx context.Context, r *SortedSetGe
 }
 
 func (c defaultScsClient) SortedSetRemove(ctx context.Context, r *SortedSetRemoveRequest) (responses.SortedSetRemoveResponse, error) {
-	if r.Values == nil {
-		return nil, convertMomentoSvcErrorToCustomerError(
-			momentoerrors.NewMomentoSvcErr(
-				momentoerrors.InvalidArgumentError, "elements to remove cannot be nil", nil,
-			),
-		)
-	}
 	if err := c.dataClient.makeRequest(ctx, r); err != nil {
 		return nil, err
 	}

--- a/momento/requester.go
+++ b/momento/requester.go
@@ -93,7 +93,7 @@ func prepareName(name string, label string) (string, error) {
 func prepareElementValue(value Value) ([]byte, error) {
 	if value == nil {
 		return nil, buildError(
-			momentoerrors.InvalidArgumentError, "element value cannot be nil or empty", nil,
+			momentoerrors.InvalidArgumentError, "element value cannot be nil", nil,
 		)
 	}
 

--- a/momento/requester.go
+++ b/momento/requester.go
@@ -90,21 +90,20 @@ func prepareName(name string, label string) (string, error) {
 	return name, nil
 }
 
-func prepareElementValue(name Value) ([]byte, error) {
-	if name == nil {
+func prepareElementValue(value Value) ([]byte, error) {
+	if value == nil {
 		return nil, buildError(
 			momentoerrors.InvalidArgumentError, "element value cannot be nil or empty", nil,
 		)
 	}
 
 	// just validate not empty using prepareName
-	nameBytes := name.asBytes()
-	_, err := prepareName(string(nameBytes), "element value")
+	_, err := prepareName(value.asString(), "element value")
 	if err != nil {
 		return nil, err
 	}
 
-	return nameBytes, nil
+	return value.asBytes(), nil
 }
 
 func prepareCacheName(r hasCacheName) (string, error) {

--- a/momento/sorted_set_get_rank.go
+++ b/momento/sorted_set_get_rank.go
@@ -9,9 +9,9 @@ import (
 )
 
 type SortedSetGetRankRequest struct {
-	CacheName    string
-	SetName      string
-	ElementValue Value
+	CacheName string
+	SetName   string
+	Value     Value
 
 	grpcRequest  *pb.XSortedSetGetRankRequest
 	grpcResponse *pb.XSortedSetGetRankResponse
@@ -30,7 +30,7 @@ func (r *SortedSetGetRankRequest) initGrpcRequest(scsDataClient) error {
 	}
 
 	var value []byte
-	if value, err = prepareElementValue(r.ElementValue); err != nil {
+	if value, err = prepareElementValue(r.Value); err != nil {
 		return err
 	}
 

--- a/momento/sorted_set_get_rank.go
+++ b/momento/sorted_set_get_rank.go
@@ -61,9 +61,7 @@ func (r *SortedSetGetRankRequest) interpretGrpcResponse() error {
 	var resp responses.SortedSetGetRankResponse
 	switch rank := grpcResp.Rank.(type) {
 	case *pb.XSortedSetGetRankResponse_ElementRank:
-		resp = &responses.SortedSetGetRankHit{
-			Rank: rank.ElementRank.Rank,
-		}
+		resp = responses.SortedSetGetRankHit(rank.ElementRank.Rank)
 	case *pb.XSortedSetGetRankResponse_Missing:
 		resp = &responses.SortedSetGetRankMiss{}
 	default:

--- a/momento/sorted_set_get_scores.go
+++ b/momento/sorted_set_get_scores.go
@@ -9,9 +9,9 @@ import (
 )
 
 type SortedSetGetScoresRequest struct {
-	CacheName     string
-	SetName       string
-	ElementValues []Value
+	CacheName string
+	SetName   string
+	Values    []Value
 
 	grpcRequest  *pb.XSortedSetGetScoreRequest
 	grpcResponse *pb.XSortedSetGetScoreResponse
@@ -29,7 +29,7 @@ func (r *SortedSetGetScoresRequest) initGrpcRequest(scsDataClient) error {
 		return err
 	}
 
-	values, err := momentoValuesToPrimitiveByteList(r.ElementValues)
+	values, err := momentoValuesToPrimitiveByteList(r.Values)
 	if err != nil {
 		return err
 	}

--- a/momento/sorted_set_increment_score.go
+++ b/momento/sorted_set_increment_score.go
@@ -14,11 +14,11 @@ import (
 )
 
 type SortedSetIncrementScoreRequest struct {
-	CacheName    string
-	SetName      string
-	ElementValue Value
-	Amount       float64
-	Ttl          *utils.CollectionTtl
+	CacheName string
+	SetName   string
+	Value     Value
+	Amount    float64
+	Ttl       *utils.CollectionTtl
 
 	grpcRequest  *pb.XSortedSetIncrementRequest
 	grpcResponse *pb.XSortedSetIncrementResponse
@@ -47,7 +47,7 @@ func (r *SortedSetIncrementScoreRequest) initGrpcRequest(client scsDataClient) e
 	}
 
 	var value []byte
-	if value, err = prepareElementValue(r.ElementValue); err != nil {
+	if value, err = prepareElementValue(r.Value); err != nil {
 		return err
 	}
 

--- a/momento/sorted_set_increment_score.go
+++ b/momento/sorted_set_increment_score.go
@@ -79,8 +79,7 @@ func (r *SortedSetIncrementScoreRequest) makeGrpcRequest(metadata context.Contex
 }
 
 func (r *SortedSetIncrementScoreRequest) interpretGrpcResponse() error {
-	r.response = &responses.SortedSetIncrementScoreSuccess{
-		Value: r.grpcResponse.Score,
-	}
+	r.response = responses.SortedSetIncrementScoreSuccess(r.grpcResponse.Score)
+
 	return nil
 }

--- a/momento/sorted_set_remove.go
+++ b/momento/sorted_set_remove.go
@@ -2,7 +2,6 @@ package momento
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/momentohq/client-sdk-go/responses"
 
@@ -10,32 +9,14 @@ import (
 )
 
 type SortedSetRemoveRequest struct {
-	CacheName        string
-	SetName          string
-	ElementsToRemove SortedSetRemoveNumElements
+	CacheName string
+	SetName   string
+	Values    []Value
 
 	grpcRequest  *pb.XSortedSetRemoveRequest
 	grpcResponse *pb.XSortedSetRemoveResponse
 	response     responses.SortedSetRemoveResponse
 }
-
-type SortedSetRemoveRequestElement struct {
-	Name Value
-}
-
-type SortedSetRemoveNumElements interface {
-	isSortedSetRemoveNumElement()
-}
-
-type RemoveAllElements struct{}
-
-func (RemoveAllElements) isSortedSetRemoveNumElement() {}
-
-type RemoveSomeElements struct {
-	Elements []Value
-}
-
-func (RemoveSomeElements) isSortedSetRemoveNumElement() {}
 
 func (r *SortedSetRemoveRequest) cacheName() string { return r.CacheName }
 
@@ -52,33 +33,14 @@ func (r *SortedSetRemoveRequest) initGrpcRequest(scsDataClient) error {
 		SetName: []byte(r.SetName),
 	}
 
-	switch toRemove := r.ElementsToRemove.(type) {
-	case RemoveAllElements:
-		grpcReq.RemoveElements = &pb.XSortedSetRemoveRequest_All{}
-	case *RemoveAllElements:
-		grpcReq.RemoveElements = &pb.XSortedSetRemoveRequest_All{}
-	case RemoveSomeElements:
-		elemToRemove, err := momentoValuesToPrimitiveByteList(toRemove.Elements)
-		if err != nil {
-			return err
-		}
-		grpcReq.RemoveElements = &pb.XSortedSetRemoveRequest_Some{
-			Some: &pb.XSortedSetRemoveRequest_XSome{
-				Values: elemToRemove,
-			},
-		}
-	case *RemoveSomeElements:
-		elemToRemove, err := momentoValuesToPrimitiveByteList(toRemove.Elements)
-		if err != nil {
-			return err
-		}
-		grpcReq.RemoveElements = &pb.XSortedSetRemoveRequest_Some{
-			Some: &pb.XSortedSetRemoveRequest_XSome{
-				Values: elemToRemove,
-			},
-		}
-	default:
-		return fmt.Errorf("%T is an unrecognized type for ElementsToRemove", r.ElementsToRemove)
+	valuesToRemove, err := momentoValuesToPrimitiveByteList(r.Values)
+	if err != nil {
+		return err
+	}
+	grpcReq.RemoveElements = &pb.XSortedSetRemoveRequest_Some{
+		Some: &pb.XSortedSetRemoveRequest_XSome{
+			Values: valuesToRemove,
+		},
 	}
 
 	r.grpcRequest = grpcReq

--- a/momento/sorted_set_remove.go
+++ b/momento/sorted_set_remove.go
@@ -22,6 +22,8 @@ func (r *SortedSetRemoveRequest) cacheName() string { return r.CacheName }
 
 func (r *SortedSetRemoveRequest) requestName() string { return "Sorted set remove" }
 
+func (r *SortedSetRemoveRequest) values() []Value { return r.Values }
+
 func (r *SortedSetRemoveRequest) initGrpcRequest(scsDataClient) error {
 	var err error
 
@@ -29,18 +31,17 @@ func (r *SortedSetRemoveRequest) initGrpcRequest(scsDataClient) error {
 		return err
 	}
 
+	var valuesToRemove [][]byte
+	if valuesToRemove, err = prepareValues(r); err != nil {
+		return err
+	}
+
 	grpcReq := &pb.XSortedSetRemoveRequest{
 		SetName: []byte(r.SetName),
 	}
 
-	valuesToRemove, err := momentoValuesToPrimitiveByteList(r.Values)
-	if err != nil {
-		return err
-	}
 	grpcReq.RemoveElements = &pb.XSortedSetRemoveRequest_Some{
-		Some: &pb.XSortedSetRemoveRequest_XSome{
-			Values: valuesToRemove,
-		},
+		Some: &pb.XSortedSetRemoveRequest_XSome{Values: valuesToRemove},
 	}
 
 	r.grpcRequest = grpcReq

--- a/momento/sorted_set_test.go
+++ b/momento/sorted_set_test.go
@@ -52,7 +52,7 @@ var _ = Describe("SortedSet", func() {
 		func(cacheName string, collectionName string, expectedError string) {
 			client := sharedContext.Client
 			ctx := sharedContext.Ctx
-			element := String(uuid.NewString())
+			value := String(uuid.NewString())
 
 			Expect(
 				client.SortedSetFetch(ctx, &SortedSetFetchRequest{
@@ -62,25 +62,25 @@ var _ = Describe("SortedSet", func() {
 
 			Expect(
 				client.SortedSetGetRank(ctx, &SortedSetGetRankRequest{
-					CacheName: cacheName, SetName: collectionName, Value: element,
+					CacheName: cacheName, SetName: collectionName, Value: value,
 				}),
 			).Error().To(HaveMomentoErrorCode(expectedError))
 
-			elements := []Value{element}
+			values := []Value{value}
 			Expect(
 				client.SortedSetGetScores(ctx, &SortedSetGetScoresRequest{
-					CacheName: cacheName, SetName: collectionName, Values: elements,
+					CacheName: cacheName, SetName: collectionName, Values: values,
 				}),
 			).Error().To(HaveMomentoErrorCode(expectedError))
 
 			Expect(
 				client.SortedSetIncrementScore(ctx, &SortedSetIncrementScoreRequest{
-					CacheName: cacheName, SetName: collectionName, Value: element, Amount: 1,
+					CacheName: cacheName, SetName: collectionName, Value: value, Amount: 1,
 				}),
 			).Error().To(HaveMomentoErrorCode(expectedError))
 
 			putElements := []*SortedSetPutElement{{
-				Value: element,
+				Value: value,
 				Score: float64(1),
 			}}
 			Expect(
@@ -91,7 +91,7 @@ var _ = Describe("SortedSet", func() {
 
 			Expect(
 				client.SortedSetRemove(ctx, &SortedSetRemoveRequest{
-					CacheName: cacheName, SetName: collectionName, ElementsToRemove: &RemoveSomeElements{Elements: elements},
+					CacheName: cacheName, SetName: collectionName, Values: values,
 				}),
 			).Error().To(HaveMomentoErrorCode(expectedError))
 		},
@@ -524,9 +524,7 @@ var _ = Describe("SortedSet", func() {
 					&SortedSetRemoveRequest{
 						CacheName: sharedContext.CacheName,
 						SetName:   sharedContext.CollectionName,
-						ElementsToRemove: RemoveSomeElements{
-							Elements: []Value{String("dne")},
-						},
+						Values:    []Value{String("dne")},
 					},
 				),
 			).To(BeAssignableToTypeOf(&SortedSetRemoveSuccess{}))
@@ -547,10 +545,8 @@ var _ = Describe("SortedSet", func() {
 					&SortedSetRemoveRequest{
 						CacheName: sharedContext.CacheName,
 						SetName:   sharedContext.CollectionName,
-						ElementsToRemove: RemoveSomeElements{
-							Elements: []Value{
-								String("first"), String("dne"),
-							},
+						Values: []Value{
+							String("first"), String("dne"),
 						},
 					},
 				),
@@ -579,9 +575,9 @@ var _ = Describe("SortedSet", func() {
 				sharedContext.Client.SortedSetRemove(
 					sharedContext.Ctx,
 					&SortedSetRemoveRequest{
-						CacheName:        sharedContext.CacheName,
-						SetName:          sharedContext.CollectionName,
-						ElementsToRemove: nil,
+						CacheName: sharedContext.CacheName,
+						SetName:   sharedContext.CollectionName,
+						Values:    nil,
 					},
 				),
 			).Error().To(HaveMomentoErrorCode(InvalidArgumentError))
@@ -592,22 +588,7 @@ var _ = Describe("SortedSet", func() {
 					&SortedSetRemoveRequest{
 						CacheName: sharedContext.CacheName,
 						SetName:   sharedContext.CollectionName,
-						ElementsToRemove: RemoveSomeElements{
-							Elements: nil,
-						},
-					},
-				),
-			).Error().To(HaveMomentoErrorCode(InvalidArgumentError))
-
-			Expect(
-				sharedContext.Client.SortedSetRemove(
-					sharedContext.Ctx,
-					&SortedSetRemoveRequest{
-						CacheName: sharedContext.CacheName,
-						SetName:   sharedContext.CollectionName,
-						ElementsToRemove: RemoveSomeElements{
-							Elements: []Value{nil, String("aValue"), nil},
-						},
+						Values:    []Value{nil, String("aValue"), nil},
 					},
 				),
 			).Error().To(HaveMomentoErrorCode(InvalidArgumentError))

--- a/momento/sorted_set_test.go
+++ b/momento/sorted_set_test.go
@@ -1,6 +1,7 @@
 package momento_test
 
 import (
+	"fmt"
 	"time"
 
 	. "github.com/momentohq/client-sdk-go/momento"
@@ -304,16 +305,22 @@ var _ = Describe("SortedSet", func() {
 				},
 			)
 
-			Expect(
-				sharedContext.Client.SortedSetGetRank(
-					sharedContext.Ctx,
-					&SortedSetGetRankRequest{
-						CacheName:    sharedContext.CacheName,
-						SetName:      sharedContext.CollectionName,
-						ElementValue: String("first"),
-					},
-				),
-			).To(Equal(&SortedSetGetRankHit{Rank: 2}))
+			resp, err := sharedContext.Client.SortedSetGetRank(
+				sharedContext.Ctx,
+				&SortedSetGetRankRequest{
+					CacheName:    sharedContext.CacheName,
+					SetName:      sharedContext.CollectionName,
+					ElementValue: String("first"),
+				},
+			)
+			Expect(err).To(BeNil())
+			Expect(resp).To(Equal(SortedSetGetRankHit(2)))
+			switch r := resp.(type) {
+			case SortedSetGetRankHit:
+				Expect(r.Rank()).To(Equal(2))
+			default:
+				Fail(fmt.Sprintf("Wrong type: %T", r))
+			}
 
 			Expect(
 				sharedContext.Client.SortedSetGetRank(
@@ -324,7 +331,7 @@ var _ = Describe("SortedSet", func() {
 						ElementValue: String("last"),
 					},
 				),
-			).To(Equal(&SortedSetGetRankHit{Rank: 0}))
+			).To(Equal(SortedSetGetRankHit(0)))
 		})
 
 		It(`returns an error for a nil element value`, func() {

--- a/momento/sorted_set_test.go
+++ b/momento/sorted_set_test.go
@@ -179,7 +179,7 @@ var _ = Describe("SortedSet", func() {
 
 				Expect(
 					sharedContext.Client.SortedSetIncrementScore(sharedContext.Ctx, request),
-				).To(BeAssignableToTypeOf(&SortedSetIncrementScoreSuccess{}))
+				).To(BeAssignableToTypeOf(SortedSetIncrementScoreSuccess(0)))
 			},
 		),
 		Entry(`SortedSetPut`,
@@ -430,7 +430,7 @@ var _ = Describe("SortedSet", func() {
 						Amount:    99,
 					},
 				),
-			).To(BeAssignableToTypeOf(&SortedSetIncrementScoreSuccess{Value: 99}))
+			).To(BeAssignableToTypeOf(SortedSetIncrementScoreSuccess(99)))
 		})
 
 		It(`Is invalid to increment by 0`, func() {
@@ -469,17 +469,23 @@ var _ = Describe("SortedSet", func() {
 				},
 			)
 
-			Expect(
-				sharedContext.Client.SortedSetIncrementScore(
-					sharedContext.Ctx,
-					&SortedSetIncrementScoreRequest{
-						CacheName: sharedContext.CacheName,
-						SetName:   sharedContext.CollectionName,
-						Value:     String("middle"),
-						Amount:    42,
-					},
-				),
-			).To(BeAssignableToTypeOf(&SortedSetIncrementScoreSuccess{Value: 92}))
+			resp, err := sharedContext.Client.SortedSetIncrementScore(
+				sharedContext.Ctx,
+				&SortedSetIncrementScoreRequest{
+					CacheName: sharedContext.CacheName,
+					SetName:   sharedContext.CollectionName,
+					Value:     String("middle"),
+					Amount:    42,
+				},
+			)
+			Expect(err).To(BeNil())
+			Expect(resp).To(BeAssignableToTypeOf(SortedSetIncrementScoreSuccess(92)))
+			switch r := resp.(type) {
+			case SortedSetIncrementScoreSuccess:
+				Expect(r.Score()).To(Equal(float64(92)))
+			default:
+				Fail(fmt.Sprintf("Unexpected response type %T", r))
+			}
 
 			Expect(
 				sharedContext.Client.SortedSetIncrementScore(
@@ -491,7 +497,7 @@ var _ = Describe("SortedSet", func() {
 						Amount:    -42,
 					},
 				),
-			).To(BeAssignableToTypeOf(&SortedSetIncrementScoreSuccess{Value: 50}))
+			).To(BeAssignableToTypeOf(SortedSetIncrementScoreSuccess(50)))
 		})
 
 		It("returns an error when element value is nil", func() {

--- a/momento/sorted_set_test.go
+++ b/momento/sorted_set_test.go
@@ -62,20 +62,20 @@ var _ = Describe("SortedSet", func() {
 
 			Expect(
 				client.SortedSetGetRank(ctx, &SortedSetGetRankRequest{
-					CacheName: cacheName, SetName: collectionName, ElementValue: element,
+					CacheName: cacheName, SetName: collectionName, Value: element,
 				}),
 			).Error().To(HaveMomentoErrorCode(expectedError))
 
 			elements := []Value{element}
 			Expect(
 				client.SortedSetGetScores(ctx, &SortedSetGetScoresRequest{
-					CacheName: cacheName, SetName: collectionName, ElementValues: elements,
+					CacheName: cacheName, SetName: collectionName, Values: elements,
 				}),
 			).Error().To(HaveMomentoErrorCode(expectedError))
 
 			Expect(
 				client.SortedSetIncrementScore(ctx, &SortedSetIncrementScoreRequest{
-					CacheName: cacheName, SetName: collectionName, ElementValue: element, Amount: 1,
+					CacheName: cacheName, SetName: collectionName, Value: element, Amount: 1,
 				}),
 			).Error().To(HaveMomentoErrorCode(expectedError))
 
@@ -168,10 +168,10 @@ var _ = Describe("SortedSet", func() {
 			`SortedSetIncrementScore`,
 			func(element SortedSetPutElement, ttl *utils.CollectionTtl) {
 				request := &SortedSetIncrementScoreRequest{
-					CacheName:    sharedContext.CacheName,
-					SetName:      sharedContext.CollectionName,
-					ElementValue: element.Value,
-					Amount:       element.Score,
+					CacheName: sharedContext.CacheName,
+					SetName:   sharedContext.CollectionName,
+					Value:     element.Value,
+					Amount:    element.Score,
 				}
 				if ttl != nil {
 					request.Ttl = ttl
@@ -288,9 +288,9 @@ var _ = Describe("SortedSet", func() {
 				sharedContext.Client.SortedSetGetRank(
 					sharedContext.Ctx,
 					&SortedSetGetRankRequest{
-						CacheName:    sharedContext.CacheName,
-						SetName:      sharedContext.CollectionName,
-						ElementValue: String("foo"),
+						CacheName: sharedContext.CacheName,
+						SetName:   sharedContext.CollectionName,
+						Value:     String("foo"),
 					},
 				),
 			).To(BeAssignableToTypeOf(&SortedSetGetRankMiss{}))
@@ -308,16 +308,16 @@ var _ = Describe("SortedSet", func() {
 			resp, err := sharedContext.Client.SortedSetGetRank(
 				sharedContext.Ctx,
 				&SortedSetGetRankRequest{
-					CacheName:    sharedContext.CacheName,
-					SetName:      sharedContext.CollectionName,
-					ElementValue: String("first"),
+					CacheName: sharedContext.CacheName,
+					SetName:   sharedContext.CollectionName,
+					Value:     String("first"),
 				},
 			)
 			Expect(err).To(BeNil())
 			Expect(resp).To(Equal(SortedSetGetRankHit(2)))
 			switch r := resp.(type) {
 			case SortedSetGetRankHit:
-				Expect(r.Rank()).To(Equal(2))
+				Expect(r.Rank()).To(Equal(uint64(2)))
 			default:
 				Fail(fmt.Sprintf("Wrong type: %T", r))
 			}
@@ -326,9 +326,9 @@ var _ = Describe("SortedSet", func() {
 				sharedContext.Client.SortedSetGetRank(
 					sharedContext.Ctx,
 					&SortedSetGetRankRequest{
-						CacheName:    sharedContext.CacheName,
-						SetName:      sharedContext.CollectionName,
-						ElementValue: String("last"),
+						CacheName: sharedContext.CacheName,
+						SetName:   sharedContext.CollectionName,
+						Value:     String("last"),
 					},
 				),
 			).To(Equal(SortedSetGetRankHit(0)))
@@ -339,9 +339,9 @@ var _ = Describe("SortedSet", func() {
 				sharedContext.Client.SortedSetGetRank(
 					sharedContext.Ctx,
 					&SortedSetGetRankRequest{
-						CacheName:    sharedContext.CacheName,
-						SetName:      sharedContext.CollectionName,
-						ElementValue: nil,
+						CacheName: sharedContext.CacheName,
+						SetName:   sharedContext.CollectionName,
+						Value:     nil,
 					},
 				),
 			).Error().To(HaveMomentoErrorCode(InvalidArgumentError))
@@ -354,9 +354,9 @@ var _ = Describe("SortedSet", func() {
 				sharedContext.Client.SortedSetGetScores(
 					sharedContext.Ctx,
 					&SortedSetGetScoresRequest{
-						CacheName:     sharedContext.CacheName,
-						SetName:       sharedContext.CollectionName,
-						ElementValues: []Value{String("foo")},
+						CacheName: sharedContext.CacheName,
+						SetName:   sharedContext.CollectionName,
+						Values:    []Value{String("foo")},
 					},
 				),
 			).To(BeAssignableToTypeOf(&SortedSetGetScoresMiss{}))
@@ -377,7 +377,7 @@ var _ = Describe("SortedSet", func() {
 					&SortedSetGetScoresRequest{
 						CacheName: sharedContext.CacheName,
 						SetName:   sharedContext.CollectionName,
-						ElementValues: []Value{
+						Values: []Value{
 							String("first"), String("last"), String("dne"),
 						},
 					},
@@ -398,9 +398,9 @@ var _ = Describe("SortedSet", func() {
 				sharedContext.Client.SortedSetGetScores(
 					sharedContext.Ctx,
 					&SortedSetGetScoresRequest{
-						CacheName:     sharedContext.CacheName,
-						SetName:       sharedContext.CollectionName,
-						ElementValues: nil,
+						CacheName: sharedContext.CacheName,
+						SetName:   sharedContext.CollectionName,
+						Values:    nil,
 					},
 				),
 			).Error().To(HaveMomentoErrorCode(InvalidArgumentError))
@@ -409,9 +409,9 @@ var _ = Describe("SortedSet", func() {
 				sharedContext.Client.SortedSetGetScores(
 					sharedContext.Ctx,
 					&SortedSetGetScoresRequest{
-						CacheName:     sharedContext.CacheName,
-						SetName:       sharedContext.CollectionName,
-						ElementValues: []Value{nil, String("aValue"), nil},
+						CacheName: sharedContext.CacheName,
+						SetName:   sharedContext.CollectionName,
+						Values:    []Value{nil, String("aValue"), nil},
 					},
 				),
 			).Error().To(HaveMomentoErrorCode(InvalidArgumentError))
@@ -424,10 +424,10 @@ var _ = Describe("SortedSet", func() {
 				sharedContext.Client.SortedSetIncrementScore(
 					sharedContext.Ctx,
 					&SortedSetIncrementScoreRequest{
-						CacheName:    sharedContext.CacheName,
-						SetName:      sharedContext.CollectionName,
-						ElementValue: String("dne"),
-						Amount:       99,
+						CacheName: sharedContext.CacheName,
+						SetName:   sharedContext.CollectionName,
+						Value:     String("dne"),
+						Amount:    99,
 					},
 				),
 			).To(BeAssignableToTypeOf(&SortedSetIncrementScoreSuccess{Value: 99}))
@@ -438,10 +438,10 @@ var _ = Describe("SortedSet", func() {
 				sharedContext.Client.SortedSetIncrementScore(
 					sharedContext.Ctx,
 					&SortedSetIncrementScoreRequest{
-						CacheName:    sharedContext.CacheName,
-						SetName:      sharedContext.CollectionName,
-						ElementValue: String("dne"),
-						Amount:       0,
+						CacheName: sharedContext.CacheName,
+						SetName:   sharedContext.CollectionName,
+						Value:     String("dne"),
+						Amount:    0,
 					},
 				),
 			).Error().To(HaveMomentoErrorCode(InvalidArgumentError))
@@ -452,9 +452,9 @@ var _ = Describe("SortedSet", func() {
 				sharedContext.Client.SortedSetIncrementScore(
 					sharedContext.Ctx,
 					&SortedSetIncrementScoreRequest{
-						CacheName:    sharedContext.CacheName,
-						SetName:      sharedContext.CollectionName,
-						ElementValue: String("dne"),
+						CacheName: sharedContext.CacheName,
+						SetName:   sharedContext.CollectionName,
+						Value:     String("dne"),
 					},
 				),
 			).Error().To(HaveMomentoErrorCode(InvalidArgumentError))
@@ -473,10 +473,10 @@ var _ = Describe("SortedSet", func() {
 				sharedContext.Client.SortedSetIncrementScore(
 					sharedContext.Ctx,
 					&SortedSetIncrementScoreRequest{
-						CacheName:    sharedContext.CacheName,
-						SetName:      sharedContext.CollectionName,
-						ElementValue: String("middle"),
-						Amount:       42,
+						CacheName: sharedContext.CacheName,
+						SetName:   sharedContext.CollectionName,
+						Value:     String("middle"),
+						Amount:    42,
 					},
 				),
 			).To(BeAssignableToTypeOf(&SortedSetIncrementScoreSuccess{Value: 92}))
@@ -485,10 +485,10 @@ var _ = Describe("SortedSet", func() {
 				sharedContext.Client.SortedSetIncrementScore(
 					sharedContext.Ctx,
 					&SortedSetIncrementScoreRequest{
-						CacheName:    sharedContext.CacheName,
-						SetName:      sharedContext.CollectionName,
-						ElementValue: String("middle"),
-						Amount:       -42,
+						CacheName: sharedContext.CacheName,
+						SetName:   sharedContext.CollectionName,
+						Value:     String("middle"),
+						Amount:    -42,
 					},
 				),
 			).To(BeAssignableToTypeOf(&SortedSetIncrementScoreSuccess{Value: 50}))
@@ -499,10 +499,10 @@ var _ = Describe("SortedSet", func() {
 				sharedContext.Client.SortedSetIncrementScore(
 					sharedContext.Ctx,
 					&SortedSetIncrementScoreRequest{
-						CacheName:    sharedContext.CacheName,
-						SetName:      sharedContext.CollectionName,
-						ElementValue: nil,
-						Amount:       42,
+						CacheName: sharedContext.CacheName,
+						SetName:   sharedContext.CollectionName,
+						Value:     nil,
+						Amount:    42,
 					},
 				),
 			).Error().To(HaveMomentoErrorCode(InvalidArgumentError))

--- a/responses/sorted_set_get_rank.go
+++ b/responses/sorted_set_get_rank.go
@@ -10,8 +10,8 @@ type SortedSetGetRankMiss struct{}
 func (SortedSetGetRankMiss) isSortedSetGetRankResponse() {}
 
 // SortedSetGetRankHit Hit Response to a cache SortedSetGetRank api request.
-type SortedSetGetRankHit struct {
-	Rank uint64
-}
+type SortedSetGetRankHit uint64
 
 func (SortedSetGetRankHit) isSortedSetGetRankResponse() {}
+
+func (r SortedSetGetRankHit) Rank() uint64 { return uint64(r) }

--- a/responses/sorted_set_increment_score.go
+++ b/responses/sorted_set_increment_score.go
@@ -3,8 +3,8 @@ package responses
 type SortedSetIncrementScoreResponse interface {
 	isSortedSetIncrementResponse()
 }
-type SortedSetIncrementScoreSuccess struct {
-	Value float64
-}
+type SortedSetIncrementScoreSuccess float64
 
 func (SortedSetIncrementScoreSuccess) isSortedSetIncrementResponse() {}
+
+func (r SortedSetIncrementScoreSuccess) Score() float64 { return float64(r) }


### PR DESCRIPTION
* Everything takes Value or Values
  * Not ElementValue, there's nothing special about sorted set values.
* SortedSetRemove only takes values.
  * The some/all flag was complex, use `client.delete`.
  * Use the usual value validation.
* SortedSetIncrementScoreSuccess
  * Add Score()
  * Remove public member.
  * Make it a type conversion.
* SortedSetGetRankHit
  * Add Rank()
  * Remove public member.
  * Make it a type conversion.

Closes #167 
Closes #204 
Closes #168 