### PR TITLE
feat!: SortedSetGetScores polish.

### DIFF
--- a/momento/sorted_set_get_scores.go
+++ b/momento/sorted_set_get_scores.go
@@ -58,9 +58,9 @@ func (r *SortedSetGetScoresRequest) makeGrpcRequest(metadata context.Context, cl
 func (r *SortedSetGetScoresRequest) interpretGrpcResponse() error {
 	switch grpcResp := r.grpcResponse.SortedSet.(type) {
 	case *pb.XSortedSetGetScoreResponse_Found:
-		r.response = &responses.SortedSetGetScoresHit{
-			Elements: convertSortedSetScoreElement(grpcResp.Found.GetElements()),
-		}
+		r.response = responses.NewSortedSetGetScoresHit(
+			convertSortedSetScoreElement(grpcResp.Found.GetElements()),
+		)
 	case *pb.XSortedSetGetScoreResponse_Missing:
 		r.response = &responses.SortedSetGetScoresMiss{}
 	default:
@@ -70,8 +70,8 @@ func (r *SortedSetGetScoresRequest) interpretGrpcResponse() error {
 	return nil
 }
 
-func convertSortedSetScoreElement(grpcSetElements []*pb.XSortedSetGetScoreResponse_XSortedSetGetScoreResponsePart) []responses.SortedSetScoreElement {
-	var rList []responses.SortedSetScoreElement
+func convertSortedSetScoreElement(grpcSetElements []*pb.XSortedSetGetScoreResponse_XSortedSetGetScoreResponsePart) []responses.SortedSetGetScore {
+	var rList []responses.SortedSetGetScore
 	for _, element := range grpcSetElements {
 		switch element.Result {
 		case pb.ECacheResult_Hit:

--- a/momento/sorted_set_test.go
+++ b/momento/sorted_set_test.go
@@ -371,26 +371,27 @@ var _ = Describe("SortedSet", func() {
 				},
 			)
 
-			Expect(
-				sharedContext.Client.SortedSetGetScores(
-					sharedContext.Ctx,
-					&SortedSetGetScoresRequest{
-						CacheName: sharedContext.CacheName,
-						SetName:   sharedContext.CollectionName,
-						Values: []Value{
-							String("first"), String("last"), String("dne"),
-						},
+			getResp, err := sharedContext.Client.SortedSetGetScores(
+				sharedContext.Ctx,
+				&SortedSetGetScoresRequest{
+					CacheName: sharedContext.CacheName,
+					SetName:   sharedContext.CollectionName,
+					Values: []Value{
+						String("first"), String("last"), String("dne"),
 					},
-				),
-			).To(Equal(
-				&SortedSetGetScoresHit{
-					Elements: []SortedSetScoreElement{
+				},
+			)
+			Expect(err).To(BeNil())
+			switch resp := getResp.(type) {
+			case *SortedSetGetScoresHit:
+				Expect(resp.Scores()).To(Equal(
+					[]SortedSetGetScore{
 						SortedSetScore(9999),
 						SortedSetScore(-9999),
 						&SortedSetScoreMiss{},
 					},
-				},
-			))
+				))
+			}
 		})
 
 		It(`returns an error when element values are nil`, func() {

--- a/responses/sorted_set_get_scores.go
+++ b/responses/sorted_set_get_scores.go
@@ -1,8 +1,6 @@
 package responses
 
-type SortedSetScoreElement interface {
-	isSortedSetScoreElement()
-}
+// High level responses.
 
 type SortedSetGetScoresResponse interface {
 	isSortedSetGetScoresResponse()
@@ -15,10 +13,24 @@ func (SortedSetGetScoresMiss) isSortedSetGetScoresResponse() {}
 
 // SortedSetGetScoresHit Hit Response to a cache SortedSetScore api request.
 type SortedSetGetScoresHit struct {
-	Elements []SortedSetScoreElement
+	scores []SortedSetGetScore
 }
 
 func (SortedSetGetScoresHit) isSortedSetGetScoresResponse() {}
+
+func NewSortedSetGetScoresHit(scores []SortedSetGetScore) *SortedSetGetScoresHit {
+	return &SortedSetGetScoresHit{scores: scores}
+}
+
+func (r SortedSetGetScoresHit) Scores() []SortedSetGetScore {
+	return r.scores
+}
+
+// Responses for individual scores.
+
+type SortedSetGetScore interface {
+	isSortedSetScoreElement()
+}
 
 type SortedSetScore float64
 


### PR DESCRIPTION
* SortedSetGetScoresHit
  * Make members private
  * Add Scores() accessor
* SortedSetScoreElement 0> SortedSetGetScore
  * They're not elements, and they're not just scores.

This should be the last SortedSet breaking change.