### PR TITLE
feat!: Normalize dictionaries.

### DIFF
--- a/momento/cache_client.go
+++ b/momento/cache_client.go
@@ -348,8 +348,8 @@ func (c defaultScsClient) DictionarySetField(ctx context.Context, r *DictionaryS
 		)
 	}
 
-	var elements []Element
-	elements = append(elements, Element{
+	var elements []DictionaryElement
+	elements = append(elements, DictionaryElement{
 		Field: r.Field,
 		Value: r.Value,
 	})

--- a/momento/cache_client.go
+++ b/momento/cache_client.go
@@ -350,8 +350,8 @@ func (c defaultScsClient) DictionarySetField(ctx context.Context, r *DictionaryS
 
 	var elements []Element
 	elements = append(elements, Element{
-		ElemField: r.Field,
-		ElemValue: r.Value,
+		Field: r.Field,
+		Value: r.Value,
 	})
 	newRequest := &DictionarySetFieldsRequest{
 		CacheName:      r.CacheName,

--- a/momento/dictionary_set_fields.go
+++ b/momento/dictionary_set_fields.go
@@ -13,7 +13,7 @@ import (
 type DictionarySetFieldsRequest struct {
 	CacheName      string
 	DictionaryName string
-	Elements       []Element
+	Elements       []DictionaryElement
 	Ttl            *utils.CollectionTtl
 
 	grpcRequest  *pb.XDictionarySetRequest
@@ -23,7 +23,7 @@ type DictionarySetFieldsRequest struct {
 
 func (r *DictionarySetFieldsRequest) cacheName() string { return r.CacheName }
 
-func (r *DictionarySetFieldsRequest) elements() []Element { return r.Elements }
+func (r *DictionarySetFieldsRequest) dictionaryElements() []DictionaryElement { return r.Elements }
 
 func (r *DictionarySetFieldsRequest) ttl() time.Duration { return r.Ttl.Ttl }
 
@@ -38,8 +38,8 @@ func (r *DictionarySetFieldsRequest) initGrpcRequest(client scsDataClient) error
 		return err
 	}
 
-	var elements []Element
-	if elements, err = prepareElements(r); err != nil {
+	var elements []DictionaryElement
+	if elements, err = prepareDictinoaryElements(r); err != nil {
 		return err
 	}
 

--- a/momento/dictionary_set_fields.go
+++ b/momento/dictionary_set_fields.go
@@ -39,7 +39,7 @@ func (r *DictionarySetFieldsRequest) initGrpcRequest(client scsDataClient) error
 	}
 
 	var elements []DictionaryElement
-	if elements, err = prepareDictinoaryElements(r); err != nil {
+	if elements, err = prepareDictionaryElements(r); err != nil {
 		return err
 	}
 

--- a/momento/dictionary_set_fields.go
+++ b/momento/dictionary_set_fields.go
@@ -46,8 +46,8 @@ func (r *DictionarySetFieldsRequest) initGrpcRequest(client scsDataClient) error
 	var pbElements []*pb.XDictionaryFieldValuePair
 	for _, v := range elements {
 		pbElements = append(pbElements, &pb.XDictionaryFieldValuePair{
-			Field: v.ElemField.asBytes(),
-			Value: v.ElemValue.asBytes(),
+			Field: v.Field.asBytes(),
+			Value: v.Value.asBytes(),
 		})
 	}
 

--- a/momento/dictionary_test.go
+++ b/momento/dictionary_test.go
@@ -159,7 +159,7 @@ var _ = Describe("Dictionary methods", func() {
 	})
 
 	DescribeTable("add string fields and string and bytes values for set fields happy path",
-		func(elements []Element, expectedItemsStringValue map[string]string, expectedItemsByteValue map[string][]byte) {
+		func(elements []DictionaryElement, expectedItemsStringValue map[string]string, expectedItemsByteValue map[string][]byte) {
 			Expect(
 				sharedContext.Client.DictionarySetFields(sharedContext.Ctx, &DictionarySetFieldsRequest{
 					CacheName:      sharedContext.CacheName,
@@ -198,7 +198,7 @@ var _ = Describe("Dictionary methods", func() {
 		},
 		Entry(
 			"with string values",
-			[]Element{
+			[]DictionaryElement{
 				{Field: String("myField1"), Value: String("myValue1")},
 				{Field: String("myField2"), Value: String("myValue2")},
 			},
@@ -207,7 +207,7 @@ var _ = Describe("Dictionary methods", func() {
 		),
 		Entry(
 			"with byte values",
-			[]Element{
+			[]DictionaryElement{
 				{Field: Bytes("myField1"), Value: Bytes("myValue1")},
 				{Field: Bytes("myField2"), Value: Bytes("myValue2")},
 			},
@@ -216,7 +216,7 @@ var _ = Describe("Dictionary methods", func() {
 		),
 		Entry(
 			"with mixed values",
-			[]Element{
+			[]DictionaryElement{
 				{Field: Bytes("myField1"), Value: String("myValue1")},
 				{Field: String("myField2"), Value: Bytes("myValue2")},
 			},
@@ -230,7 +230,7 @@ var _ = Describe("Dictionary methods", func() {
 			sharedContext.Client.DictionarySetFields(sharedContext.Ctx, &DictionarySetFieldsRequest{
 				CacheName:      sharedContext.CacheName,
 				DictionaryName: sharedContext.CollectionName,
-				Elements: []Element{
+				Elements: []DictionaryElement{
 					{Field: String("myField"), Value: String("myValue")},
 					{Field: String(""), Value: String("myOtherValue")},
 				},
@@ -243,7 +243,7 @@ var _ = Describe("Dictionary methods", func() {
 			sharedContext.Client.DictionarySetFields(sharedContext.Ctx, &DictionarySetFieldsRequest{
 				CacheName:      sharedContext.CacheName,
 				DictionaryName: sharedContext.CollectionName,
-				Elements: []Element{
+				Elements: []DictionaryElement{
 					{Field: String("myField"), Value: String("myValue")},
 					{Field: String("myOtherField"), Value: nil},
 				},
@@ -255,7 +255,7 @@ var _ = Describe("Dictionary methods", func() {
 
 		It("converts from a map with string values to element slice", func() {
 			theMap := map[string]string{"myField1": "myValue1", "myField2": "myValue2"}
-			expected := []Element{
+			expected := []DictionaryElement{
 				{Field: String("myField1"), Value: String("myValue1")},
 				{Field: String("myField2"), Value: String("myValue2")},
 			}
@@ -265,7 +265,7 @@ var _ = Describe("Dictionary methods", func() {
 
 		It("converts from a map with bytes values to element slice", func() {
 			theMap := map[string][]byte{"myField1": []byte("myValue1"), "myField2": []byte("myValue2")}
-			expected := []Element{
+			expected := []DictionaryElement{
 				{Field: String("myField1"), Value: Bytes("myValue1")},
 				{Field: String("myField2"), Value: Bytes("myValue2")},
 			}
@@ -275,7 +275,7 @@ var _ = Describe("Dictionary methods", func() {
 
 		It("converts from a map with Value values to element slice", func() {
 			theMap := map[string]Value{"myField1": String("myValue1"), "myField2": Bytes("myValue2")}
-			expected := []Element{
+			expected := []DictionaryElement{
 				{Field: String("myField1"), Value: String("myValue1")},
 				{Field: String("myField2"), Value: Bytes("myValue2")},
 			}

--- a/momento/dictionary_test.go
+++ b/momento/dictionary_test.go
@@ -199,8 +199,8 @@ var _ = Describe("Dictionary methods", func() {
 		Entry(
 			"with string values",
 			[]Element{
-				{ElemField: String("myField1"), ElemValue: String("myValue1")},
-				{ElemField: String("myField2"), ElemValue: String("myValue2")},
+				{Field: String("myField1"), Value: String("myValue1")},
+				{Field: String("myField2"), Value: String("myValue2")},
 			},
 			map[string]string{"myField1": "myValue1", "myField2": "myValue2"},
 			map[string][]byte{"myField1": []byte("myValue1"), "myField2": []byte("myValue2")},
@@ -208,8 +208,8 @@ var _ = Describe("Dictionary methods", func() {
 		Entry(
 			"with byte values",
 			[]Element{
-				{ElemField: Bytes("myField1"), ElemValue: Bytes("myValue1")},
-				{ElemField: Bytes("myField2"), ElemValue: Bytes("myValue2")},
+				{Field: Bytes("myField1"), Value: Bytes("myValue1")},
+				{Field: Bytes("myField2"), Value: Bytes("myValue2")},
 			},
 			map[string]string{"myField1": "myValue1", "myField2": "myValue2"},
 			map[string][]byte{"myField1": []byte("myValue1"), "myField2": []byte("myValue2")},
@@ -217,8 +217,8 @@ var _ = Describe("Dictionary methods", func() {
 		Entry(
 			"with mixed values",
 			[]Element{
-				{ElemField: Bytes("myField1"), ElemValue: String("myValue1")},
-				{ElemField: String("myField2"), ElemValue: Bytes("myValue2")},
+				{Field: Bytes("myField1"), Value: String("myValue1")},
+				{Field: String("myField2"), Value: Bytes("myValue2")},
 			},
 			map[string]string{"myField1": "myValue1", "myField2": "myValue2"},
 			map[string][]byte{"myField1": []byte("myValue1"), "myField2": []byte("myValue2")},
@@ -231,8 +231,8 @@ var _ = Describe("Dictionary methods", func() {
 				CacheName:      sharedContext.CacheName,
 				DictionaryName: sharedContext.CollectionName,
 				Elements: []Element{
-					{ElemField: String("myField"), ElemValue: String("myValue")},
-					{ElemField: String(""), ElemValue: String("myOtherValue")},
+					{Field: String("myField"), Value: String("myValue")},
+					{Field: String(""), Value: String("myOtherValue")},
 				},
 			}),
 		)
@@ -244,8 +244,8 @@ var _ = Describe("Dictionary methods", func() {
 				CacheName:      sharedContext.CacheName,
 				DictionaryName: sharedContext.CollectionName,
 				Elements: []Element{
-					{ElemField: String("myField"), ElemValue: String("myValue")},
-					{ElemField: String("myOtherField"), ElemValue: nil},
+					{Field: String("myField"), Value: String("myValue")},
+					{Field: String("myOtherField"), Value: nil},
 				},
 			}),
 		).Error().To(HaveMomentoErrorCode(InvalidArgumentError))
@@ -256,8 +256,8 @@ var _ = Describe("Dictionary methods", func() {
 		It("converts from a map with string values to element slice", func() {
 			theMap := map[string]string{"myField1": "myValue1", "myField2": "myValue2"}
 			expected := []Element{
-				{ElemField: String("myField1"), ElemValue: String("myValue1")},
-				{ElemField: String("myField2"), ElemValue: String("myValue2")},
+				{Field: String("myField1"), Value: String("myValue1")},
+				{Field: String("myField2"), Value: String("myValue2")},
 			}
 			elems := ElementsFromMapStringString(theMap)
 			Expect(elems).To(ConsistOf(expected))
@@ -266,8 +266,8 @@ var _ = Describe("Dictionary methods", func() {
 		It("converts from a map with bytes values to element slice", func() {
 			theMap := map[string][]byte{"myField1": []byte("myValue1"), "myField2": []byte("myValue2")}
 			expected := []Element{
-				{ElemField: String("myField1"), ElemValue: Bytes("myValue1")},
-				{ElemField: String("myField2"), ElemValue: Bytes("myValue2")},
+				{Field: String("myField1"), Value: Bytes("myValue1")},
+				{Field: String("myField2"), Value: Bytes("myValue2")},
 			}
 			elems := ElementsFromMapStringBytes(theMap)
 			Expect(elems).To(ConsistOf(expected))
@@ -276,8 +276,8 @@ var _ = Describe("Dictionary methods", func() {
 		It("converts from a map with Value values to element slice", func() {
 			theMap := map[string]Value{"myField1": String("myValue1"), "myField2": Bytes("myValue2")}
 			expected := []Element{
-				{ElemField: String("myField1"), ElemValue: String("myValue1")},
-				{ElemField: String("myField2"), ElemValue: Bytes("myValue2")},
+				{Field: String("myField1"), Value: String("myValue1")},
+				{Field: String("myField2"), Value: Bytes("myValue2")},
 			}
 			elems := ElementsFromMapStringValue(theMap)
 			Expect(elems).To(ConsistOf(expected))

--- a/momento/requester.go
+++ b/momento/requester.go
@@ -170,7 +170,7 @@ func prepareValues(r hasValues) ([][]byte, momentoerrors.MomentoSvcErr) {
 	return values, nil
 }
 
-func prepareDictinoaryElements(r hasDictionaryElements) ([]DictionaryElement, error) {
+func prepareDictionaryElements(r hasDictionaryElements) ([]DictionaryElement, error) {
 	for _, v := range r.dictionaryElements() {
 		if v.Value == nil || v.Field == nil {
 			return nil, buildError(

--- a/momento/requester.go
+++ b/momento/requester.go
@@ -172,12 +172,12 @@ func prepareValues(r hasValues) ([][]byte, momentoerrors.MomentoSvcErr) {
 
 func prepareElements(r hasElements) ([]Element, error) {
 	for _, v := range r.elements() {
-		if v.ElemValue == nil || v.ElemField == nil {
+		if v.Value == nil || v.Field == nil {
 			return nil, buildError(
 				momentoerrors.InvalidArgumentError, "element fields and values may not be nil", nil,
 			)
 		}
-		if err := validateNotEmpty(v.ElemField.asBytes(), "element field"); err != nil {
+		if err := validateNotEmpty(v.Field.asBytes(), "element field"); err != nil {
 			return nil, err
 		}
 	}
@@ -237,8 +237,8 @@ func ElementsFromMapStringString(theMap map[string]string) []Element {
 	var elements []Element
 	for k, v := range theMap {
 		elements = append(elements, Element{
-			ElemField: String(k),
-			ElemValue: String(v),
+			Field: String(k),
+			Value: String(v),
 		})
 	}
 	return elements
@@ -248,8 +248,8 @@ func ElementsFromMapStringBytes(theMap map[string][]byte) []Element {
 	var elements []Element
 	for k, v := range theMap {
 		elements = append(elements, Element{
-			ElemField: String(k),
-			ElemValue: Bytes(v),
+			Field: String(k),
+			Value: Bytes(v),
 		})
 	}
 	return elements
@@ -259,8 +259,8 @@ func ElementsFromMapStringValue(theMap map[string]Value) []Element {
 	var elements []Element
 	for k, v := range theMap {
 		elements = append(elements, Element{
-			ElemField: String(k),
-			ElemValue: v,
+			Field: String(k),
+			Value: v,
 		})
 	}
 	return elements

--- a/momento/requester.go
+++ b/momento/requester.go
@@ -64,8 +64,8 @@ type hasFields interface {
 	fields() []Value
 }
 
-type hasElements interface {
-	elements() []Element
+type hasDictionaryElements interface {
+	dictionaryElements() []DictionaryElement
 }
 
 type hasTtl interface {
@@ -170,8 +170,8 @@ func prepareValues(r hasValues) ([][]byte, momentoerrors.MomentoSvcErr) {
 	return values, nil
 }
 
-func prepareElements(r hasElements) ([]Element, error) {
-	for _, v := range r.elements() {
+func prepareDictinoaryElements(r hasDictionaryElements) ([]DictionaryElement, error) {
+	for _, v := range r.dictionaryElements() {
 		if v.Value == nil || v.Field == nil {
 			return nil, buildError(
 				momentoerrors.InvalidArgumentError, "element fields and values may not be nil", nil,
@@ -181,7 +181,7 @@ func prepareElements(r hasElements) ([]Element, error) {
 			return nil, err
 		}
 	}
-	return r.elements(), nil
+	return r.dictionaryElements(), nil
 }
 
 func prepareCollectionTtl(r hasCollectionTtl, defaultTtl time.Duration) (uint64, bool, error) {
@@ -233,10 +233,10 @@ func validateNotEmpty(field []byte, label string) error {
 	return nil
 }
 
-func ElementsFromMapStringString(theMap map[string]string) []Element {
-	var elements []Element
+func ElementsFromMapStringString(theMap map[string]string) []DictionaryElement {
+	var elements []DictionaryElement
 	for k, v := range theMap {
-		elements = append(elements, Element{
+		elements = append(elements, DictionaryElement{
 			Field: String(k),
 			Value: String(v),
 		})
@@ -244,10 +244,10 @@ func ElementsFromMapStringString(theMap map[string]string) []Element {
 	return elements
 }
 
-func ElementsFromMapStringBytes(theMap map[string][]byte) []Element {
-	var elements []Element
+func ElementsFromMapStringBytes(theMap map[string][]byte) []DictionaryElement {
+	var elements []DictionaryElement
 	for k, v := range theMap {
-		elements = append(elements, Element{
+		elements = append(elements, DictionaryElement{
 			Field: String(k),
 			Value: Bytes(v),
 		})
@@ -255,10 +255,10 @@ func ElementsFromMapStringBytes(theMap map[string][]byte) []Element {
 	return elements
 }
 
-func ElementsFromMapStringValue(theMap map[string]Value) []Element {
-	var elements []Element
+func ElementsFromMapStringValue(theMap map[string]Value) []DictionaryElement {
+	var elements []DictionaryElement
 	for k, v := range theMap {
-		elements = append(elements, Element{
+		elements = append(elements, DictionaryElement{
 			Field: String(k),
 			Value: v,
 		})

--- a/momento/value.go
+++ b/momento/value.go
@@ -31,9 +31,8 @@ func (v String) asString() string {
 	return string(v)
 }
 
-// Element Type to hold field/value pairs for use with the DictionarySetFields operation.
-// The Value type is used for Field and Value and allows  both strings and bytes
-// to be used for fields and values.
+// Type to hold field/value elements in dictionaries for use with DictionarySetFields.
+// Field and Value are both Value type which allows both Strings and Bytes.
 type DictionaryElement struct {
 	Field, Value Value
 }

--- a/momento/value.go
+++ b/momento/value.go
@@ -34,6 +34,6 @@ func (v String) asString() string {
 // Element Type to hold field/value pairs for use with the DictionarySetFields operation.
 // The Value type is used for Field and Value and allows  both strings and bytes
 // to be used for fields and values.
-type Element struct {
+type DictionaryElement struct {
 	Field, Value Value
 }

--- a/momento/value.go
+++ b/momento/value.go
@@ -32,8 +32,8 @@ func (v String) asString() string {
 }
 
 // Element Type to hold field/value pairs for use with the DictionarySetFields operation.
-// The Value type is used for ElemField and ElemValue and allows  both strings and bytes
+// The Value type is used for Field and Value and allows  both strings and bytes
 // to be used for fields and values.
 type Element struct {
-	ElemField, ElemValue Value
+	Field, Value Value
 }


### PR DESCRIPTION
* Element -> DictionaryElement
  * Distinguish it from every other kind of "element".
* ElemField/ElemValue -> Field/Value
  * We no longer prefix struct members. A field is a field, a value is a value.

I think this is the last naming issue.