### PR TITLE
feat: use "rank" terminology consistently for sorted sets

### DIFF
--- a/momento/sorted_set_fetch.go
+++ b/momento/sorted_set_fetch.go
@@ -15,9 +15,9 @@ const (
 	DESCENDING SortedSetOrder = 1
 )
 
-type SortedSetFetchByIndex struct {
-	StartIndex *int32
-	EndIndex   *int32
+type SortedSetFetchByRank struct {
+	StartRank *int32
+	EndRank   *int32
 }
 
 type SortedSetFetchByScore struct {
@@ -31,7 +31,7 @@ type SortedSetFetchRequest struct {
 	CacheName string
 	SetName   string
 	Order     SortedSetOrder
-	ByIndex   *SortedSetFetchByIndex
+	ByRank    *SortedSetFetchByRank
 	ByScore   *SortedSetFetchByScore
 
 	grpcRequest  *pb.XSortedSetFetchRequest
@@ -50,10 +50,10 @@ func (r *SortedSetFetchRequest) initGrpcRequest(scsDataClient) error {
 		return err
 	}
 
-	if r.ByIndex != nil && r.ByScore != nil {
+	if r.ByRank != nil && r.ByScore != nil {
 		return NewMomentoError(
 			InvalidArgumentError,
-			"Only one of ByIndex or ByScore may be specified",
+			"Only one of ByRank or ByScore may be specified",
 			nil,
 		)
 	}
@@ -110,16 +110,16 @@ func (r *SortedSetFetchRequest) initGrpcRequest(scsDataClient) error {
 			},
 		}
 
-		if r.ByIndex != nil {
-			if r.ByIndex.StartIndex != nil {
+		if r.ByRank != nil {
+			if r.ByRank.StartRank != nil {
 				by_index.ByIndex.Start = &pb.XSortedSetFetchRequest_XByIndex_InclusiveStartIndex{
-					InclusiveStartIndex: *r.ByIndex.StartIndex,
+					InclusiveStartIndex: *r.ByRank.StartRank,
 				}
 			}
 
-			if r.ByIndex.EndIndex != nil {
+			if r.ByRank.EndRank != nil {
 				by_index.ByIndex.End = &pb.XSortedSetFetchRequest_XByIndex_ExclusiveEndIndex{
-					ExclusiveEndIndex: *r.ByIndex.EndIndex,
+					ExclusiveEndIndex: *r.ByRank.EndRank,
 				}
 			}
 		}

--- a/momento/sorted_set_test.go
+++ b/momento/sorted_set_test.go
@@ -257,14 +257,14 @@ var _ = Describe("SortedSet", func() {
 				))
 			})
 
-			It(`It errors when ByIndex and ByScore are defined`, func() {
+			It(`It errors when ByRank and ByScore are defined`, func() {
 				Expect(
 					sharedContext.Client.SortedSetFetch(
 						sharedContext.Ctx,
 						&SortedSetFetchRequest{
 							CacheName: sharedContext.CacheName,
 							SetName:   sharedContext.CollectionName,
-							ByIndex:   &SortedSetFetchByIndex{},
+							ByRank:    &SortedSetFetchByRank{},
 							ByScore:   &SortedSetFetchByScore{},
 						},
 					),
@@ -293,7 +293,7 @@ var _ = Describe("SortedSet", func() {
 				))
 			})
 
-			It(`Constrains by start/end index`, func() {
+			It(`Constrains by start/end rank`, func() {
 				start := int32(1)
 				end := int32(4)
 				Expect(
@@ -303,9 +303,9 @@ var _ = Describe("SortedSet", func() {
 							CacheName: sharedContext.CacheName,
 							SetName:   sharedContext.CollectionName,
 							Order:     DESCENDING,
-							ByIndex: &SortedSetFetchByIndex{
-								StartIndex: &start,
-								EndIndex:   &end,
+							ByRank: &SortedSetFetchByRank{
+								StartRank: &start,
+								EndRank:   &end,
 							},
 						},
 					),
@@ -318,7 +318,7 @@ var _ = Describe("SortedSet", func() {
 				))
 			})
 
-			It(`Counts negative start index inclusive from the end`, func() {
+			It(`Counts negative start rank inclusive from the end`, func() {
 				start := int32(-3)
 				Expect(
 					sharedContext.Client.SortedSetFetch(
@@ -327,8 +327,8 @@ var _ = Describe("SortedSet", func() {
 							CacheName: sharedContext.CacheName,
 							SetName:   sharedContext.CollectionName,
 							Order:     DESCENDING,
-							ByIndex: &SortedSetFetchByIndex{
-								StartIndex: &start,
+							ByRank: &SortedSetFetchByRank{
+								StartRank: &start,
 							},
 						},
 					),
@@ -341,7 +341,7 @@ var _ = Describe("SortedSet", func() {
 				))
 			})
 
-			It(`Counts negative end index exclusively from the end`, func() {
+			It(`Counts negative end rank exclusively from the end`, func() {
 				end := int32(-3)
 				Expect(
 					sharedContext.Client.SortedSetFetch(
@@ -350,8 +350,8 @@ var _ = Describe("SortedSet", func() {
 							CacheName: sharedContext.CacheName,
 							SetName:   sharedContext.CollectionName,
 							Order:     DESCENDING,
-							ByIndex: &SortedSetFetchByIndex{
-								EndIndex: &end,
+							ByRank: &SortedSetFetchByRank{
+								EndRank: &end,
 							},
 						},
 					),


### PR DESCRIPTION
Allen pointed out that in some places for sorted sets we were
using the term Rank, while in other places we were using the
term Index.  This commit changes occurrences of Index to Rank.
This mirrors what we did in the node.js SDK.
