### PR TITLE
fix: export LogLevel

### DIFF
--- a/config/logger/builtin-logger.go
+++ b/config/logger/builtin-logger.go
@@ -8,7 +8,7 @@ import (
 
 type BuiltinMomentoLogger struct {
 	loggerName string
-	level      loggerLevel
+	level      LogLevel
 }
 
 func (l *BuiltinMomentoLogger) Trace(message string, args ...string) {
@@ -41,7 +41,7 @@ func (l *BuiltinMomentoLogger) Error(message string, args ...string) {
 	}
 }
 
-func momentoLog(level loggerLevel, loggerName string, message string, args ...string) {
+func momentoLog(level LogLevel, loggerName string, message string, args ...string) {
 	if len(args) > 0 {
 		log.Printf("[%s] %d (%s): %s, %s\n", time.RFC3339, level, loggerName, message, strings.Join(args, ", "))
 	} else {
@@ -49,14 +49,13 @@ func momentoLog(level loggerLevel, loggerName string, message string, args ...st
 	}
 }
 
-type BuiltinMomentoLoggerFactory struct {
-}
+type BuiltinMomentoLoggerFactory struct{}
 
 func NewBuiltinMomentoLoggerFactory() MomentoLoggerFactory {
 	return &BuiltinMomentoLoggerFactory{}
 }
 
-func (*BuiltinMomentoLoggerFactory) GetLogger(loggerName string, level loggerLevel) MomentoLogger {
+func (BuiltinMomentoLoggerFactory) GetLogger(loggerName string, level LogLevel) MomentoLogger {
 	log.SetFlags(0)
 	return &BuiltinMomentoLogger{loggerName: loggerName, level: level}
 }

--- a/config/logger/momento-logger.go
+++ b/config/logger/momento-logger.go
@@ -1,13 +1,13 @@
 package logger
 
-type loggerLevel int
+type LogLevel int
 
 const (
-	TRACE loggerLevel = 5
-	DEBUG loggerLevel = 10
-	INFO  loggerLevel = 20
-	WARN  loggerLevel = 30
-	ERROR loggerLevel = 40
+	TRACE LogLevel = 5
+	DEBUG LogLevel = 10
+	INFO  LogLevel = 20
+	WARN  LogLevel = 30
+	ERROR LogLevel = 40
 )
 
 type MomentoLogger interface {
@@ -19,5 +19,5 @@ type MomentoLogger interface {
 }
 
 type MomentoLoggerFactory interface {
-	GetLogger(loggerName string, logLevel loggerLevel) MomentoLogger
+	GetLogger(loggerName string, logLevel LogLevel) MomentoLogger
 }

--- a/config/logger/noop-momento-logger.go
+++ b/config/logger/noop-momento-logger.go
@@ -30,6 +30,6 @@ func NewNoopMomentoLoggerFactory() MomentoLoggerFactory {
 	return &NoopMomentoLoggerFactory{}
 }
 
-func (*NoopMomentoLoggerFactory) GetLogger(loggerName string, logLevel loggerLevel) MomentoLogger {
+func (*NoopMomentoLoggerFactory) GetLogger(loggerName string, logLevel LogLevel) MomentoLogger {
 	return &NoopMomentoLogger{}
 }


### PR DESCRIPTION
This commit exports the `LogLevel` const from `momento-logger` so users can access it.