### PR TITLE
feat: tweaks to how we configure logging

### DIFF
--- a/config/configurations.go
+++ b/config/configurations.go
@@ -8,34 +8,34 @@ import (
 	"github.com/momentohq/client-sdk-go/config/logger"
 )
 
-func LaptopLatest(loggerFactory ...logger.MomentoLoggerFactory) Configuration {
-	defaultLoggerFactory := logger.NewNoopMomentoLoggerFactory()
-	if len(loggerFactory) != 0 {
-		defaultLoggerFactory = loggerFactory[0]
-	}
+func LaptopLatest() Configuration {
+	return LaptopLatestWithLogger(logger.NewNoopMomentoLoggerFactory())
+}
+
+func LaptopLatestWithLogger(loggerFactory logger.MomentoLoggerFactory) Configuration {
 	return NewCacheConfiguration(&ConfigurationProps{
-		LoggerFactory: defaultLoggerFactory,
+		LoggerFactory: loggerFactory,
 		TransportStrategy: NewStaticTransportStrategy(&TransportStrategyProps{
 			GrpcConfiguration: NewStaticGrpcConfiguration(&GrpcConfigurationProps{
 				deadline: 5 * time.Second,
 			}),
 		}),
-		RetryStrategy: retry.NewFixedCountRetryStrategy(defaultLoggerFactory),
+		RetryStrategy: retry.NewFixedCountRetryStrategy(loggerFactory),
 	})
 }
 
-func InRegionLatest(loggerFactory ...logger.MomentoLoggerFactory) Configuration {
-	defaultLoggerFactory := logger.NewNoopMomentoLoggerFactory()
-	if len(loggerFactory) != 0 {
-		defaultLoggerFactory = loggerFactory[0]
-	}
+func InRegionLatest() Configuration {
+	return InRegionLatestWithLogger(logger.NewNoopMomentoLoggerFactory())
+}
+
+func InRegionLatestWithLogger(loggerFactory logger.MomentoLoggerFactory) Configuration {
 	return NewCacheConfiguration(&ConfigurationProps{
-		LoggerFactory: defaultLoggerFactory,
+		LoggerFactory: loggerFactory,
 		TransportStrategy: NewStaticTransportStrategy(&TransportStrategyProps{
 			GrpcConfiguration: NewStaticGrpcConfiguration(&GrpcConfigurationProps{
 				deadline: 1100 * time.Millisecond,
 			}),
 		}),
-		RetryStrategy: retry.NewFixedCountRetryStrategy(defaultLoggerFactory),
+		RetryStrategy: retry.NewFixedCountRetryStrategy(loggerFactory),
 	})
 }

--- a/momento/cache_client_test.go
+++ b/momento/cache_client_test.go
@@ -2,6 +2,7 @@ package momento_test
 
 import (
 	"errors"
+	"github.com/momentohq/client-sdk-go/config/logger"
 	"time"
 
 	"github.com/momentohq/client-sdk-go/config"
@@ -37,5 +38,27 @@ var _ = Describe("CacheClient", func() {
 		Expect(
 			NewCacheClient(sharedContext.Configuration, sharedContext.CredentialProvider, sharedContext.DefaultTtl),
 		).Error().To(HaveMomentoErrorCode(InvalidArgumentError))
+	})
+
+	It(`Supports constructing a laptop config with a logger`, func() {
+		_, err := NewCacheClient(
+			config.LaptopLatestWithLogger(logger.NewBuiltinMomentoLoggerFactory()),
+			sharedContext.CredentialProvider,
+			sharedContext.DefaultTtl,
+		)
+		if err != nil {
+			panic(err)
+		}
+	})
+
+	It(`Supports constructing an InRegion config with a logger`, func() {
+		_, err := NewCacheClient(
+			config.InRegionLatestWithLogger(logger.NewBuiltinMomentoLoggerFactory()),
+			sharedContext.CredentialProvider,
+			sharedContext.DefaultTtl,
+		)
+		if err != nil {
+			panic(err)
+		}
 	})
 })

--- a/momento/cache_client_test.go
+++ b/momento/cache_client_test.go
@@ -2,8 +2,9 @@ package momento_test
 
 import (
 	"errors"
-	"github.com/momentohq/client-sdk-go/config/logger"
 	"time"
+
+	"github.com/momentohq/client-sdk-go/config/logger"
 
 	"github.com/momentohq/client-sdk-go/config"
 	. "github.com/momentohq/client-sdk-go/momento"


### PR DESCRIPTION
This changes the signatures that we use to configure logging for the client.  Prior to this commit the constructors were taking a vararg array of loggerFactories, which might lead users to think they could pass more than one.

This commit adds alternate constructors that accept a single logger factory instead.