### PR TITLE
fix: default logger wasn't spreading varargs properly

### DIFF
--- a/config/logger/momento_default_logger/momento-default-logger.go
+++ b/config/logger/momento_default_logger/momento-default-logger.go
@@ -54,7 +54,11 @@ func (l *DefaultMomentoLogger) Error(message string, args ...string) {
 }
 
 func momentoLog(level LogLevel, loggerName string, message string, args ...string) {
-	finalMessage := fmt.Sprintf(message, args)
+	anyArgs := make([]any, len(args))
+	for i, v := range args {
+		anyArgs[i] = v
+	}
+	finalMessage := fmt.Sprintf(message, anyArgs...)
 	log.Printf("[%s] %d (%s): %s\n", time.RFC3339, level, loggerName, finalMessage)
 }
 


### PR DESCRIPTION
The default logger was calling Printf with its varargs array without spreading it back out, meaning that the whole array would get formatted into the first %s.  This spreads the varargs back out properly.