### PR TITLE
chore: rename ElementsFromMap* to DictionaryElementsFromMap*

### DIFF
--- a/examples/dictionary-example/main.go
+++ b/examples/dictionary-example/main.go
@@ -108,7 +108,7 @@ func setElements(elements map[string]momento.Value) {
 	resp, err := client.DictionarySetFields(ctx, &momento.DictionarySetFieldsRequest{
 		CacheName:      cacheName,
 		DictionaryName: dictionaryName,
-		Elements:       momento.ElementsFromMapStringValue(elements),
+		Elements:       momento.DictionaryElementsFromMapStringValue(elements),
 	})
 	if err != nil {
 		panic(err)

--- a/momento/cache_client.go
+++ b/momento/cache_client.go
@@ -90,6 +90,7 @@ type CacheClient interface {
 	// DictionarySetField adds an element to the given dictionary. Creates the dictionary if it does not already exist.
 	DictionarySetField(ctx context.Context, r *DictionarySetFieldRequest) (responses.DictionarySetFieldResponse, error)
 	// DictionarySetFields adds multiple elements to the given dictionary. Creates the dictionary if it does not already exist.
+	//  Use momento.DictionaryElementsFromMap to help construct the Request from a map object.
 	DictionarySetFields(ctx context.Context, r *DictionarySetFieldsRequest) (responses.DictionarySetFieldsResponse, error)
 	// DictionaryFetch fetches all elements of the given dictionary.
 	DictionaryFetch(ctx context.Context, r *DictionaryFetchRequest) (responses.DictionaryFetchResponse, error)

--- a/momento/dictionary_set_fields.go
+++ b/momento/dictionary_set_fields.go
@@ -10,6 +10,9 @@ import (
 	pb "github.com/momentohq/client-sdk-go/internal/protos"
 )
 
+// DictionarySetFieldsRequest represents a request to store multiple elements in a Dictionary.
+//
+//	Use momento.DictionaryElementsFromMap to help construct the Request from a map object.
 type DictionarySetFieldsRequest struct {
 	CacheName      string
 	DictionaryName string

--- a/momento/dictionary_test.go
+++ b/momento/dictionary_test.go
@@ -268,7 +268,7 @@ var _ = Describe("Dictionary methods", func() {
 				{Field: String("myField1"), Value: String("myValue1")},
 				{Field: String("myField2"), Value: String("myValue2")},
 			}
-			elems := ElementsFromMapStringString(theMap)
+			elems := DictionaryElementsFromMapStringString(theMap)
 			Expect(elems).To(ConsistOf(expected))
 		})
 
@@ -278,7 +278,7 @@ var _ = Describe("Dictionary methods", func() {
 				{Field: String("myField1"), Value: Bytes("myValue1")},
 				{Field: String("myField2"), Value: Bytes("myValue2")},
 			}
-			elems := ElementsFromMapStringBytes(theMap)
+			elems := DictionaryElementsFromMapStringBytes(theMap)
 			Expect(elems).To(ConsistOf(expected))
 		})
 
@@ -288,7 +288,7 @@ var _ = Describe("Dictionary methods", func() {
 				{Field: String("myField1"), Value: String("myValue1")},
 				{Field: String("myField2"), Value: Bytes("myValue2")},
 			}
-			elems := ElementsFromMapStringValue(theMap)
+			elems := DictionaryElementsFromMapStringValue(theMap)
 			Expect(elems).To(ConsistOf(expected))
 		})
 
@@ -387,7 +387,7 @@ var _ = Describe("Dictionary methods", func() {
 				sharedContext.Client.DictionarySetFields(sharedContext.Ctx, &DictionarySetFieldsRequest{
 					CacheName:      sharedContext.CacheName,
 					DictionaryName: sharedContext.CollectionName,
-					Elements: ElementsFromMapStringValue(
+					Elements: DictionaryElementsFromMapStringValue(
 						map[string]Value{"myField1": String("myValue1"), "myField2": Bytes("myValue2")},
 					),
 				}),
@@ -534,7 +534,7 @@ var _ = Describe("Dictionary methods", func() {
 				sharedContext.Client.DictionarySetFields(sharedContext.Ctx, &DictionarySetFieldsRequest{
 					CacheName:      sharedContext.CacheName,
 					DictionaryName: sharedContext.CollectionName,
-					Elements: ElementsFromMapStringValue(
+					Elements: DictionaryElementsFromMapStringValue(
 						map[string]Value{"myField1": String("myValue1"), "myField2": Bytes("myValue2")},
 					),
 				}),
@@ -573,7 +573,7 @@ var _ = Describe("Dictionary methods", func() {
 				sharedContext.Client.DictionarySetFields(sharedContext.Ctx, &DictionarySetFieldsRequest{
 					CacheName:      sharedContext.CacheName,
 					DictionaryName: sharedContext.CollectionName,
-					Elements: ElementsFromMapStringValue(
+					Elements: DictionaryElementsFromMapStringValue(
 						map[string]Value{
 							"myField1": String("myValue1"),
 							"myField2": Bytes("myValue2"),
@@ -720,7 +720,7 @@ var _ = Describe("Dictionary methods", func() {
 					sharedContext.Client.DictionarySetFields(sharedContext.Ctx, &DictionarySetFieldsRequest{
 						CacheName:      sharedContext.CacheName,
 						DictionaryName: sharedContext.CollectionName,
-						Elements: ElementsFromMapStringValue(
+						Elements: DictionaryElementsFromMapStringValue(
 							map[string]Value{"myField1": String("myValue1"), "myField2": String("myValue2")},
 						),
 					}),
@@ -754,7 +754,7 @@ var _ = Describe("Dictionary methods", func() {
 				sharedContext.Client.DictionarySetFields(sharedContext.Ctx, &DictionarySetFieldsRequest{
 					CacheName:      sharedContext.CacheName,
 					DictionaryName: sharedContext.CollectionName,
-					Elements: ElementsFromMapStringValue(
+					Elements: DictionaryElementsFromMapStringValue(
 						map[string]Value{"myField1": String("myValue1"), "myField2": String("myValue2")},
 					),
 				}),

--- a/momento/requester.go
+++ b/momento/requester.go
@@ -240,7 +240,17 @@ func validateNotNil(value Value, label string) error {
 	return nil
 }
 
-func ElementsFromMapStringString(theMap map[string]string) []DictionaryElement {
+// DictionaryElementsFromMap converts a map[string]string to an array of momento DictionaryElements.
+//
+//	DictionaryElements are used as input to DictionarySetFields.
+func DictionaryElementsFromMap(theMap map[string]string) []DictionaryElement {
+	return DictionaryElementsFromMapStringString(theMap)
+}
+
+// DictionaryElementsFromMapStringString converts a map[string]string to an array of momento DictionaryElements.
+//
+//	DictionaryElements are used as input to DictionarySetFields.
+func DictionaryElementsFromMapStringString(theMap map[string]string) []DictionaryElement {
 	var elements []DictionaryElement
 	for k, v := range theMap {
 		elements = append(elements, DictionaryElement{
@@ -251,7 +261,10 @@ func ElementsFromMapStringString(theMap map[string]string) []DictionaryElement {
 	return elements
 }
 
-func ElementsFromMapStringBytes(theMap map[string][]byte) []DictionaryElement {
+// DictionaryElementsFromMapStringBytes converts a map[string][]byte to an array of momento DictionaryElements.
+//
+//	DictionaryElements are used as input to DictionarySetFields.
+func DictionaryElementsFromMapStringBytes(theMap map[string][]byte) []DictionaryElement {
 	var elements []DictionaryElement
 	for k, v := range theMap {
 		elements = append(elements, DictionaryElement{
@@ -262,7 +275,10 @@ func ElementsFromMapStringBytes(theMap map[string][]byte) []DictionaryElement {
 	return elements
 }
 
-func ElementsFromMapStringValue(theMap map[string]Value) []DictionaryElement {
+// DictionaryElementsFromMapStringValue converts a map[string]momento.Value to an array of momento DictionaryElements.
+//
+//	DictionaryElements are used as input to DictionarySetFields.
+func DictionaryElementsFromMapStringValue(theMap map[string]Value) []DictionaryElement {
 	var elements []DictionaryElement
 	for k, v := range theMap {
 		elements = append(elements, DictionaryElement{


### PR DESCRIPTION
Also adds an alias DictionaryElementsFromMap that is a short-hand
for the MapStringString variant.
