### PR TITLE
chore: sorted set testing followup

### DIFF
--- a/momento/requester.go
+++ b/momento/requester.go
@@ -239,3 +239,17 @@ func validateNotNil(value Value, label string) error {
 
 	return nil
 }
+
+func validateSortedSetRanks(start int32, end int32) error {
+	if start >= 0 && end >= 0 && start >= end {
+		return buildError(
+			momentoerrors.InvalidArgumentError, "start rank must be less than end rank", nil,
+		)
+	}
+	if start < 0 && end < 0 && start >= end {
+		return buildError(
+			momentoerrors.InvalidArgumentError, "negative start rank must be less than negative end rank", nil,
+		)
+	}
+	return nil
+}

--- a/momento/sorted_set_fetch_by_rank.go
+++ b/momento/sorted_set_fetch_by_rank.go
@@ -38,27 +38,33 @@ func (r *SortedSetFetchByRankRequest) initGrpcRequest(scsDataClient) error {
 	}
 
 	// This is the default: fetch everything in ascending order.
-	by_index := pb.XSortedSetFetchRequest_ByIndex{
+	byIndex := pb.XSortedSetFetchRequest_ByIndex{
 		ByIndex: &pb.XSortedSetFetchRequest_XByIndex{
 			Start: &pb.XSortedSetFetchRequest_XByIndex_UnboundedStart{},
 			End:   &pb.XSortedSetFetchRequest_XByIndex_UnboundedEnd{},
 		},
 	}
 
+	startForValidation := int32(0)
 	if r.StartRank != nil {
 
-		by_index.ByIndex.Start = &pb.XSortedSetFetchRequest_XByIndex_InclusiveStartIndex{
+		byIndex.ByIndex.Start = &pb.XSortedSetFetchRequest_XByIndex_InclusiveStartIndex{
 			InclusiveStartIndex: *r.StartRank,
 		}
+		startForValidation = *r.StartRank
 	}
 
 	if r.EndRank != nil {
-		by_index.ByIndex.End = &pb.XSortedSetFetchRequest_XByIndex_ExclusiveEndIndex{
+		byIndex.ByIndex.End = &pb.XSortedSetFetchRequest_XByIndex_ExclusiveEndIndex{
 			ExclusiveEndIndex: *r.EndRank,
+		}
+		endForValidation := *r.EndRank
+		if err := validateSortedSetRanks(startForValidation, endForValidation); err != nil {
+			return err
 		}
 	}
 
-	grpcReq.Range = &by_index
+	grpcReq.Range = &byIndex
 
 	r.grpcRequest = grpcReq
 

--- a/momento/sorted_set_test.go
+++ b/momento/sorted_set_test.go
@@ -406,23 +406,29 @@ var _ = Describe("SortedSet", func() {
 				))
 			})
 
-			It("returns an error for detectable invalid ranges", func() {
-				start := int32(10)
-				end := int32(3)
-				Expect(
-					sharedContext.Client.SortedSetFetchByRank(
-						sharedContext.Ctx,
-						&SortedSetFetchByRankRequest{
-							CacheName: sharedContext.CacheName,
-							SetName:   sharedContext.CollectionName,
-							StartRank: &start,
-							EndRank:   &end,
-						},
-					),
-				).Error().To(HaveMomentoErrorCode(InvalidArgumentError))
+			DescribeTable("we get an error for detectable invalid ranges",
+				func(start int32, end int32) {
+					Expect(
+						sharedContext.Client.SortedSetFetchByRank(
+							sharedContext.Ctx,
+							&SortedSetFetchByRankRequest{
+								CacheName: sharedContext.CacheName,
+								SetName:   sharedContext.CollectionName,
+								StartRank: &start,
+								EndRank:   &end,
+							},
+						),
+					).Error().To(HaveMomentoErrorCode(InvalidArgumentError))
 
-			})
+					start = int32(-5)
+					end = int32(-3)
 
+				},
+				Entry("positive values", int32(5), int32(3)),
+				Entry("negative values", int32(-5), int32(-8)),
+				Entry("equal positives", int32(5), int32(5)),
+				Entry("equal negatives", int32(-5), int32(-5)),
+			)
 		})
 	})
 

--- a/momento/sorted_set_test.go
+++ b/momento/sorted_set_test.go
@@ -364,7 +364,7 @@ var _ = Describe("SortedSet", func() {
 				))
 			})
 
-			It("returns nil when start is after end", func() {
+			It("returns an empty list when start is after end", func() {
 				start := int32(3)
 				end := int32(-5)
 				fetchResp, err := sharedContext.Client.SortedSetFetchByRank(
@@ -380,8 +380,8 @@ var _ = Describe("SortedSet", func() {
 				Expect(err).To(BeNil())
 				switch fetchResp := fetchResp.(type) {
 				case *SortedSetFetchHit:
-					Expect(fetchResp.ValueBytesElements()).To(BeNil())
-					Expect(fetchResp.ValueStringElements()).To(BeNil())
+					Expect(fetchResp.ValueBytesElements()).To(Equal([]SortedSetBytesElement{}))
+					Expect(fetchResp.ValueStringElements()).To(Equal([]SortedSetStringElement{}))
 				}
 			})
 

--- a/momento/sorted_set_test.go
+++ b/momento/sorted_set_test.go
@@ -61,8 +61,20 @@ var _ = Describe("SortedSet", func() {
 			).Error().To(HaveMomentoErrorCode(expectedError))
 
 			Expect(
+				client.SortedSetFetchByScore(ctx, &SortedSetFetchByScoreRequest{
+					CacheName: cacheName, SetName: collectionName,
+				}),
+			).Error().To(HaveMomentoErrorCode(expectedError))
+
+			Expect(
 				client.SortedSetGetRank(ctx, &SortedSetGetRankRequest{
 					CacheName: cacheName, SetName: collectionName, Value: value,
+				}),
+			).Error().To(HaveMomentoErrorCode(expectedError))
+
+			Expect(
+				client.SortedSetGetScore(ctx, &SortedSetGetScoreRequest{
+					CacheName: cacheName, SetName: collectionName, Value: String("hi"),
 				}),
 			).Error().To(HaveMomentoErrorCode(expectedError))
 
@@ -92,6 +104,12 @@ var _ = Describe("SortedSet", func() {
 			Expect(
 				client.SortedSetPutElements(ctx, &SortedSetPutElementsRequest{
 					CacheName: cacheName, SetName: collectionName, Elements: putElements,
+				}),
+			).Error().To(HaveMomentoErrorCode(expectedError))
+
+			Expect(
+				client.SortedSetRemoveElement(ctx, &SortedSetRemoveElementRequest{
+					CacheName: cacheName, SetName: collectionName, Value: String("hi"),
 				}),
 			).Error().To(HaveMomentoErrorCode(expectedError))
 
@@ -186,7 +204,7 @@ var _ = Describe("SortedSet", func() {
 				).To(BeAssignableToTypeOf(SortedSetIncrementScoreSuccess(0)))
 			},
 		),
-		Entry(`SortedSetElement`,
+		Entry(`SortedSetPutElement`,
 			func(element SortedSetElement, ttl *utils.CollectionTtl) {
 				request := &SortedSetPutElementRequest{
 					CacheName: sharedContext.CacheName,
@@ -346,6 +364,27 @@ var _ = Describe("SortedSet", func() {
 				))
 			})
 
+			It("returns nil when start is after end", func() {
+				start := int32(3)
+				end := int32(-5)
+				fetchResp, err := sharedContext.Client.SortedSetFetchByRank(
+					sharedContext.Ctx,
+					&SortedSetFetchByRankRequest{
+						CacheName: sharedContext.CacheName,
+						SetName:   sharedContext.CollectionName,
+						Order:     DESCENDING,
+						StartRank: &start,
+						EndRank:   &end,
+					},
+				)
+				Expect(err).To(BeNil())
+				switch fetchResp := fetchResp.(type) {
+				case *SortedSetFetchHit:
+					Expect(fetchResp.ValueBytesElements()).To(BeNil())
+					Expect(fetchResp.ValueStringElements()).To(BeNil())
+				}
+			})
+
 			It(`Counts negative end rank exclusively from the end`, func() {
 				end := int32(-3)
 				Expect(
@@ -366,6 +405,24 @@ var _ = Describe("SortedSet", func() {
 					},
 				))
 			})
+
+			It("returns an error for detectable invalid ranges", func() {
+				start := int32(10)
+				end := int32(3)
+				Expect(
+					sharedContext.Client.SortedSetFetchByRank(
+						sharedContext.Ctx,
+						&SortedSetFetchByRankRequest{
+							CacheName: sharedContext.CacheName,
+							SetName:   sharedContext.CollectionName,
+							StartRank: &start,
+							EndRank:   &end,
+						},
+					),
+				).Error().To(HaveMomentoErrorCode(InvalidArgumentError))
+
+			})
+
 		})
 	})
 
@@ -514,6 +571,18 @@ var _ = Describe("SortedSet", func() {
 			).To(BeAssignableToTypeOf(&SortedSetGetRankMiss{}))
 		})
 
+		It("Misses when the sorted set doesn't exist", func() {
+			getResp, err := sharedContext.Client.SortedSetGetRank(
+				sharedContext.Ctx, &SortedSetGetRankRequest{
+					CacheName: sharedContext.CacheName,
+					SetName:   uuid.NewString(),
+					Value:     String("idontexist"),
+				},
+			)
+			Expect(err).To(BeNil())
+			Expect(getResp).To(BeAssignableToTypeOf(&SortedSetGetRankMiss{}))
+		})
+
 		It(`Gets the rank`, func() {
 			putElements(
 				[]SortedSetElement{
@@ -609,7 +678,19 @@ var _ = Describe("SortedSet", func() {
 			).To(BeAssignableToTypeOf(&SortedSetGetScoresMiss{}))
 		})
 
-		It(`Gets the score`, func() {
+		It("misses when the sorted set doesn't exist", func() {
+			getResp, err := sharedContext.Client.SortedSetGetScores(
+				sharedContext.Ctx, &SortedSetGetScoresRequest{
+					CacheName: sharedContext.CacheName,
+					SetName:   uuid.NewString(),
+					Values:    []Value{String("idontexist")},
+				},
+			)
+			Expect(err).To(BeNil())
+			Expect(getResp).To(BeAssignableToTypeOf(&SortedSetGetScoresMiss{}))
+		})
+
+		It(`Gets the correct set of scores`, func() {
 			putElements(
 				[]SortedSetElement{
 					{Value: String("first"), Score: 9999},
@@ -694,6 +775,45 @@ var _ = Describe("SortedSet", func() {
 			default:
 				Fail("expected a sorted set get score hit but got a miss")
 			}
+		})
+
+		It("misses when the element doesn't exist", func() {
+			putElements([]SortedSetElement{
+				{Value: Bytes("value1"), Score: 0},
+				{Value: String("value2"), Score: 10},
+			})
+			getResp, err := sharedContext.Client.SortedSetGetScore(
+				sharedContext.Ctx, &SortedSetGetScoreRequest{
+					CacheName: sharedContext.CacheName,
+					SetName:   sharedContext.CollectionName,
+					Value:     String("idontexist"),
+				},
+			)
+			Expect(err).To(BeNil())
+			Expect(getResp).To(BeAssignableToTypeOf(&SortedSetGetScoreMiss{}))
+		})
+
+		It("misses when the sorted set doesn't exist", func() {
+			getResp, err := sharedContext.Client.SortedSetGetScore(
+				sharedContext.Ctx, &SortedSetGetScoreRequest{
+					CacheName: sharedContext.CacheName,
+					SetName:   uuid.NewString(),
+					Value:     String("idontexist"),
+				},
+			)
+			Expect(err).To(BeNil())
+			Expect(getResp).To(BeAssignableToTypeOf(&SortedSetGetScoreMiss{}))
+		})
+
+		It("returns an error for a nil value", func() {
+			Expect(
+				sharedContext.Client.SortedSetPutElement(sharedContext.Ctx, &SortedSetPutElementRequest{
+					CacheName: sharedContext.CacheName,
+					SetName:   sharedContext.CollectionName,
+					Value:     nil,
+					Score:     10,
+				}),
+			).Error().To(HaveMomentoErrorCode(InvalidArgumentError))
 		})
 	})
 
@@ -812,41 +932,96 @@ var _ = Describe("SortedSet", func() {
 		})
 	})
 
-	Describe(`SortedSetElement`, func() {
-		It(`Puts an element with a string value`, func() {
-			resp, err := sharedContext.Client.SortedSetPutElement(
-				sharedContext.Ctx,
-				&SortedSetPutElementRequest{
+	Describe("SortedSetPutElement", func() {
+
+		DescribeTable("put an element with each of string and byte values",
+			func(inputValue Value, inputScore float64, expected []SortedSetBytesElement) {
+				resp, err := sharedContext.Client.SortedSetPutElement(
+					sharedContext.Ctx,
+					&SortedSetPutElementRequest{
+						CacheName: sharedContext.CacheName,
+						SetName:   sharedContext.CollectionName,
+						Value:     inputValue,
+						Score:     inputScore,
+					})
+				Expect(err).To(BeNil())
+				Expect(resp).To(BeAssignableToTypeOf(&SortedSetPutElementSuccess{}))
+
+				fetchResp, fetchErr := sharedContext.Client.SortedSetFetchByRank(
+					sharedContext.Ctx,
+					&SortedSetFetchByRankRequest{
+						CacheName: sharedContext.CacheName,
+						SetName:   sharedContext.CollectionName,
+					},
+				)
+				Expect(fetchErr).To(BeNil())
+				switch fetchResp := fetchResp.(type) {
+				case *SortedSetFetchHit:
+					Expect(fetchResp.ValueBytesElements()).To(Equal(expected))
+				}
+			},
+			Entry("string value", String("aString"), 42.0, []SortedSetBytesElement{{Value: []byte("aString"), Score: 42}}),
+			Entry("bytes value", Bytes("aString"), 42.0, []SortedSetBytesElement{{Value: []byte("aString"), Score: 42}}),
+		)
+
+		It("overwrites an existing element's score", func() {
+			strValue := String("aValue")
+			putElements([]SortedSetElement{{Value: strValue, Score: 5}})
+			putElements([]SortedSetElement{{Value: strValue, Score: 500}})
+			fetchResp, err := sharedContext.Client.SortedSetGetScore(sharedContext.Ctx, &SortedSetGetScoreRequest{
+				CacheName: sharedContext.CacheName,
+				SetName:   sharedContext.CollectionName,
+				Value:     strValue,
+			})
+			Expect(err).To(BeNil())
+			switch fetchResp := fetchResp.(type) {
+			case *SortedSetGetScoreHit:
+				Expect(fetchResp.Score()).To(Equal(500.0))
+			default:
+				Fail("expected a hit from sorted set get score but got a miss")
+			}
+		})
+
+		It("creates the sorted set if it doesn't exist", func() {
+			newSetName := uuid.NewString()
+			Expect(
+				sharedContext.Client.SortedSetPutElement(sharedContext.Ctx, &SortedSetPutElementRequest{
 					CacheName: sharedContext.CacheName,
-					SetName:   sharedContext.CollectionName,
+					SetName:   newSetName,
 					Value:     String("aValue"),
 					Score:     42,
-				})
-			Expect(err).To(BeNil())
-			Expect(resp).To(BeAssignableToTypeOf(&SortedSetPutElementSuccess{}))
+				}),
+			).To(BeAssignableToTypeOf(&SortedSetPutElementSuccess{}))
 
-			fetchResp, fetchErr := sharedContext.Client.SortedSetFetchByRank(
-				sharedContext.Ctx,
-				&SortedSetFetchByRankRequest{
+			fetchResp, err := sharedContext.Client.SortedSetGetScore(sharedContext.Ctx, &SortedSetGetScoreRequest{
+				CacheName: sharedContext.CacheName,
+				SetName:   newSetName,
+				Value:     String("aValue"),
+			})
+			Expect(err).To(BeNil())
+			switch fetchResp := fetchResp.(type) {
+			case *SortedSetGetScoreHit:
+				Expect(fetchResp.Score()).To(Equal(42.0))
+			default:
+				Fail("expected a hit from sorted set get score but got a miss")
+			}
+		})
+
+		It("returns an error for a nil value", func() {
+			Expect(
+				sharedContext.Client.SortedSetPutElement(sharedContext.Ctx, &SortedSetPutElementRequest{
 					CacheName: sharedContext.CacheName,
 					SetName:   sharedContext.CollectionName,
-				},
-			)
-			Expect(fetchErr).To(BeNil())
-			switch fetchResp := fetchResp.(type) {
-			case *SortedSetFetchHit:
-				Expect(fetchResp.ValueBytesElements()).To(Equal(
-					[]SortedSetBytesElement{
-						{Value: Bytes("aValue"), Score: 42},
-					},
-				))
-			}
+					Value:     nil,
+					Score:     0,
+				}),
+			).Error().To(HaveMomentoErrorCode(InvalidArgumentError))
 		})
 	})
 
 	Describe(`SortedSetPutElements`, func() {
 		It("puts multiple elements", func() {
-			elems := []SortedSetElement{{Value: String("val1"), Score: 0}, {Value: String("val2"), Score: 10}}
+			elems := []SortedSetElement{{Value: String("val1"), Score: 0}, {Value: Bytes("val2"), Score: 10}}
 			Expect(
 				sharedContext.Client.SortedSetPutElements(
 					sharedContext.Ctx,
@@ -869,9 +1044,46 @@ var _ = Describe("SortedSet", func() {
 				Expect(
 					result.ValueStringElements(),
 				).To(Equal([]SortedSetStringElement{{Value: "val1", Score: 0}, {Value: "val2", Score: 10}}))
+				Expect(
+					result.ValueBytesElements(),
+				).To(Equal([]SortedSetBytesElement{{Value: []byte("val1"), Score: 0}, {Value: []byte("val2"), Score: 10}}))
 			default:
 				Fail("expected a hit for sorted set fetch but got a miss")
 			}
+		})
+
+		It("overwrites multiple elements", func() {
+			elems := []SortedSetElement{{Value: String("val1"), Score: 0}, {Value: Bytes("val2"), Score: 10}}
+			putElements(elems)
+			elems = []SortedSetElement{{Value: String("val1"), Score: -999}, {Value: Bytes("val2"), Score: -100}}
+			putElements(elems)
+			fetchResp, err := fetch()
+			Expect(err).To(BeNil())
+			switch fetchResp := fetchResp.(type) {
+			case *SortedSetFetchHit:
+				Expect(fetchResp.ValueBytesElements()).To(Equal(
+					[]SortedSetBytesElement{{Value: []byte("val1"), Score: -999}, {Value: []byte("val2"), Score: -100}},
+				))
+				Expect(fetchResp.ValueStringElements()).To(Equal(
+					[]SortedSetStringElement{{Value: "val1", Score: -999}, {Value: "val2", Score: -100}},
+				))
+			}
+		})
+
+		It("returns an error for nil elements", func() {
+			Expect(sharedContext.Client.SortedSetPutElements(sharedContext.Ctx, &SortedSetPutElementsRequest{
+				CacheName: sharedContext.CacheName,
+				SetName:   sharedContext.CollectionName,
+				Elements:  nil,
+			})).Error().To(HaveMomentoErrorCode(InvalidArgumentError))
+		})
+
+		It("returns an error for nil values", func() {
+			Expect(sharedContext.Client.SortedSetPutElements(sharedContext.Ctx, &SortedSetPutElementsRequest{
+				CacheName: sharedContext.CacheName,
+				SetName:   sharedContext.CollectionName,
+				Elements:  []SortedSetElement{{Value: String("hi"), Score: 10}, {Value: nil, Score: 500}},
+			})).Error().To(HaveMomentoErrorCode(InvalidArgumentError))
 		})
 	})
 
@@ -912,6 +1124,33 @@ var _ = Describe("SortedSet", func() {
 				Fail("expected a hit for sorted set fetch but got a miss")
 			}
 
+		})
+
+		It("succeeds when the element doesn't exist", func() {
+			Expect(
+				sharedContext.Client.SortedSetRemoveElement(sharedContext.Ctx, &SortedSetRemoveElementRequest{
+					CacheName: sharedContext.CacheName,
+					SetName:   sharedContext.CollectionName,
+					Value:     String("idontexist"),
+				}),
+			).To(BeAssignableToTypeOf(&SortedSetRemoveElementSuccess{}))
+		})
+
+		It("returns an error when value is nil", func() {
+			Expect(
+				sharedContext.Client.SortedSetRemoveElement(sharedContext.Ctx, &SortedSetRemoveElementRequest{
+					CacheName: sharedContext.CacheName,
+					SetName:   sharedContext.CollectionName,
+					Value:     nil,
+				}),
+			).Error().To(HaveMomentoErrorCode(InvalidArgumentError))
+
+			Expect(
+				sharedContext.Client.SortedSetRemoveElement(sharedContext.Ctx, &SortedSetRemoveElementRequest{
+					CacheName: sharedContext.CacheName,
+					SetName:   sharedContext.CollectionName,
+				}),
+			).Error().To(HaveMomentoErrorCode(InvalidArgumentError))
 		})
 	})
 

--- a/responses/sorted_set_fetch.go
+++ b/responses/sorted_set_fetch.go
@@ -33,6 +33,9 @@ func NewSortedSetFetchHit(elements []SortedSetBytesElement) *SortedSetFetchHit {
 // ValueStringElements returns the elements as an array of objects, each containing a `value` and `score` field.
 // The value is a utf-8 string, decoded from the underlying byte array, and the score is a number.
 func (r SortedSetFetchHit) ValueStringElements() []SortedSetStringElement {
+	if r.elements == nil {
+		return nil
+	}
 	elementsString := make([]SortedSetStringElement, 0, len(r.elements))
 
 	for _, element := range r.elements {

--- a/responses/sorted_set_fetch.go
+++ b/responses/sorted_set_fetch.go
@@ -27,15 +27,15 @@ func (SortedSetFetchHit) isSortedSetFetchResponse() {}
 
 // NewSortedSetFetchHit returns a new SortedSetFetchHit containing the supplied elements.
 func NewSortedSetFetchHit(elements []SortedSetBytesElement) *SortedSetFetchHit {
+	if elements == nil {
+		elements = []SortedSetBytesElement{}
+	}
 	return &SortedSetFetchHit{elements: elements}
 }
 
 // ValueStringElements returns the elements as an array of objects, each containing a `value` and `score` field.
 // The value is a utf-8 string, decoded from the underlying byte array, and the score is a number.
 func (r SortedSetFetchHit) ValueStringElements() []SortedSetStringElement {
-	if r.elements == nil {
-		return nil
-	}
 	elementsString := make([]SortedSetStringElement, 0, len(r.elements))
 
 	for _, element := range r.elements {


### PR DESCRIPTION
This commit adds testing for sorted set functionality as well as validation for sorted set "by rank" indexes. It also validates values in `SortedSetPutElements` and errors on nils.