### PR TITLE
chore: run `examples` in `on-pull-request` workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,10 +54,7 @@ jobs:
         run: make build
 
       - name: Build examples
-        run: |
-          pushd examples
-             make build
-          popd
+        run: make build-examples
 
       - name: Run test
         run: make test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,6 @@ jobs:
       pull-requests: read
     env:
       TEST_AUTH_TOKEN: ${{ secrets.auth-token }}
-      MOMENTO_AUTH_TOKEN: ${{ secrets.auth-token }}
     steps:
       - name: Setup repo
         uses: actions/checkout@v3
@@ -51,8 +50,14 @@ jobs:
             exit 1
           fi
 
+      - name: Build
+        run: make build
+
+      - name: Build examples
+        run: |
+          pushd examples
+             make build
+          popd
+
       - name: Run test
         run: make test
-
-      - name: Run examples
-        run: make examples

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,7 @@ jobs:
       pull-requests: read
     env:
       TEST_AUTH_TOKEN: ${{ secrets.auth-token }}
+      MOMENTO_AUTH_TOKEN: ${{ secrets.auth-token }}
     steps:
       - name: Setup repo
         uses: actions/checkout@v3
@@ -52,3 +53,6 @@ jobs:
 
       - name: Run test
         run: make test
+
+      - name: Run examples
+        run: make examples

--- a/Makefile
+++ b/Makefile
@@ -54,4 +54,9 @@ test:
 .PHONY: vendor
 vendor:
 	go mod vendor
+
+.PHONY: build-examples
+build:
+	cd examples
+	go build ./...
 	

--- a/Makefile
+++ b/Makefile
@@ -54,3 +54,14 @@ test:
 .PHONY: vendor
 vendor:
 	go mod vendor
+
+.PHONY: examples
+examples:
+	go run scalar-example/main.go
+	go run dictionary-example/main.go
+	go run list-example/main.go
+	go run set-example/main.go
+	go run sortedset-example/main.go
+	go run logging-example/main.go
+	go run pubsub-example/main.go
+	

--- a/Makefile
+++ b/Makefile
@@ -54,14 +54,4 @@ test:
 .PHONY: vendor
 vendor:
 	go mod vendor
-
-.PHONY: examples
-examples:
-	go run scalar-example/main.go
-	go run dictionary-example/main.go
-	go run list-example/main.go
-	go run set-example/main.go
-	go run sortedset-example/main.go
-	go run logging-example/main.go
-	go run pubsub-example/main.go
 	

--- a/examples/set-example/main.go
+++ b/examples/set-example/main.go
@@ -113,6 +113,13 @@ func printSet() {
 	}
 }
 
+func cleanUp() {
+	_, err := client.DeleteCache(ctx, &momento.DeleteCacheRequest{CacheName: cacheName})
+	if err != nil {
+		panic(err)
+	}
+}
+
 func main() {
 	setup()
 
@@ -137,4 +144,6 @@ func main() {
 
 	removeElements(elements)
 	printSet()
+
+	cleanUp()
 }

--- a/examples/sortedset-example/main.go
+++ b/examples/sortedset-example/main.go
@@ -76,6 +76,12 @@ func main() {
 	}
 
 	displayElements(setName, descendingResp)
+
+	// Clean up the cache
+	_, err = client.DeleteCache(ctx, &momento.DeleteCacheRequest{CacheName: cacheName})
+	if err != nil {
+		panic(err)
+	}
 }
 
 func getClient() momento.CacheClient {
@@ -96,7 +102,7 @@ func getClient() momento.CacheClient {
 
 func setupCache(client momento.CacheClient, ctx context.Context) {
 	_, err := client.CreateCache(ctx, &momento.CreateCacheRequest{
-		CacheName: "test-cache",
+		CacheName: cacheName,
 	})
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
- Added a step to run the examples except the loadgen (I'm not sure if we want to run the script every time...) to make sure all the examples are up-to-date.
- Updated a few examples to add cache cleanup.
- Confirmed that dependabot is looking for new versions of the dependencies.

Closes #283 