### PR TITLE
chore: default cache client testing

### DIFF
--- a/batchutils/batch_operations_test.go
+++ b/batchutils/batch_operations_test.go
@@ -92,4 +92,15 @@ var _ = Describe("Batch operations", func() {
 			}
 		}
 	})
+
+	It("doesn't error trying to batch delete nonexistent keys", func() {
+		keys := []Key{String("i"), String("don't"), String("exist")}
+		errors := batchutils.BatchDelete(ctx, &batchutils.BatchDeleteRequest{
+			Client:    client,
+			CacheName: cacheName,
+			Keys:      keys,
+		})
+		Expect(errors).To(BeNil())
+	})
+
 })

--- a/momento/control_test.go
+++ b/momento/control_test.go
@@ -20,8 +20,8 @@ var _ = Describe("Control ops", func() {
 		DeferCleanup(func() { sharedContext.Close() })
 	})
 
-	Describe(`Happy Path`, func() {
-		It(`creates, lists, and deletes caches`, func() {
+	Describe("Happy Path", func() {
+		It("creates, lists, and deletes caches", func() {
 			cacheNames := []string{uuid.NewString(), uuid.NewString()}
 			defer func() {
 				for _, cacheName := range cacheNames {
@@ -80,11 +80,40 @@ var _ = Describe("Control ops", func() {
 				sharedContext.ClientWithDefaultCacheName.DeleteCache(sharedContext.Ctx, &DeleteCacheRequest{}),
 			).To(BeAssignableToTypeOf(&DeleteCacheSuccess{}))
 		})
+
 	})
 
-	Describe(`Validate cache name`, func() {
-		It(`CreateCache and DeleteCache errors on bad cache names`, func() {
-			badCacheNames := []string{``, `   `}
+	Describe("cache client with default cache name", func() {
+		It("overrides default cache name", func() {
+			Expect(
+				sharedContext.ClientWithDefaultCacheName.CreateCache(
+					sharedContext.Ctx, &CreateCacheRequest{CacheName: sharedContext.CacheName},
+				),
+			).To(BeAssignableToTypeOf(&CreateCacheSuccess{}))
+			Expect(
+				sharedContext.ClientWithDefaultCacheName.Get(
+					sharedContext.Ctx, &GetRequest{Key: String("hi")},
+				),
+			).Error().To(HaveMomentoErrorCode(NotFoundError))
+			Expect(
+				sharedContext.ClientWithDefaultCacheName.Get(
+					sharedContext.Ctx, &GetRequest{
+						CacheName: sharedContext.CacheName,
+						Key:       String("hi"),
+					},
+				),
+			).To(BeAssignableToTypeOf(&GetMiss{}))
+			Expect(
+				sharedContext.ClientWithDefaultCacheName.DeleteCache(
+					sharedContext.Ctx, &DeleteCacheRequest{CacheName: sharedContext.CacheName},
+				),
+			).To(BeAssignableToTypeOf(&DeleteCacheSuccess{}))
+		})
+	})
+
+	Describe("Validate cache name", func() {
+		It("CreateCache and DeleteCache errors on bad cache names", func() {
+			badCacheNames := []string{"", "   "}
 			for _, badCacheName := range badCacheNames {
 				createResp, err := sharedContext.Client.CreateCache(sharedContext.Ctx, &CreateCacheRequest{CacheName: badCacheName})
 				Expect(createResp).To(BeNil())
@@ -102,8 +131,8 @@ var _ = Describe("Control ops", func() {
 		})
 	})
 
-	Describe(`DeleteCache`, func() {
-		It(`succeeds even if the cache does not exist`, func() {
+	Describe("DeleteCache", func() {
+		It("succeeds even if the cache does not exist", func() {
 			Expect(
 				sharedContext.Client.DeleteCache(sharedContext.Ctx, &DeleteCacheRequest{CacheName: uuid.NewString()}),
 			).To(BeAssignableToTypeOf(&DeleteCacheSuccess{}))

--- a/momento/dictionary_test.go
+++ b/momento/dictionary_test.go
@@ -619,7 +619,6 @@ var _ = Describe("Dictionary methods", func() {
 			).To(BeAssignableToTypeOf(&DictionarySetFieldsSuccess{}))
 			Expect(
 				sharedContext.ClientWithDefaultCacheName.DictionarySetFields(sharedContext.Ctx, &DictionarySetFieldsRequest{
-					CacheName:      sharedContext.CacheName,
 					DictionaryName: sharedContext.CollectionName,
 					Elements: DictionaryElementsFromMapStringValue(
 						map[string]Value{"myField1": String("myValue1"), "myField2": Bytes("myValue2")},
@@ -676,7 +675,6 @@ var _ = Describe("Dictionary methods", func() {
 			).To(BeAssignableToTypeOf(&DictionarySetFieldsSuccess{}))
 			Expect(
 				sharedContext.ClientWithDefaultCacheName.DictionarySetFields(sharedContext.Ctx, &DictionarySetFieldsRequest{
-					CacheName:      sharedContext.CacheName,
 					DictionaryName: sharedContext.CollectionName,
 					Elements: DictionaryElementsFromMapStringValue(
 						map[string]Value{

--- a/momento/dictionary_test.go
+++ b/momento/dictionary_test.go
@@ -18,7 +18,7 @@ var _ = Describe("Dictionary methods", func() {
 
 	BeforeEach(func() {
 		sharedContext = NewSharedContext()
-		sharedContext.CreateDefaultCache()
+		sharedContext.CreateDefaultCaches()
 		DeferCleanup(func() {
 			sharedContext.Close()
 		})
@@ -99,17 +99,18 @@ var _ = Describe("Dictionary methods", func() {
 	)
 
 	DescribeTable("add string and bytes value for single field happy path",
-		func(field Value, value Value, expectedFieldString string, expectedFieldBytes []byte, expectedValueString string, expectedValueBytes []byte) {
+		func(clientType string, field Value, value Value, expectedFieldString string, expectedFieldBytes []byte, expectedValueString string, expectedValueBytes []byte) {
+			client, cacheName := sharedContext.GetClientPrereqsForType(clientType)
 			Expect(
-				sharedContext.Client.DictionarySetField(sharedContext.Ctx, &DictionarySetFieldRequest{
-					CacheName:      sharedContext.CacheName,
+				client.DictionarySetField(sharedContext.Ctx, &DictionarySetFieldRequest{
+					CacheName:      cacheName,
 					DictionaryName: sharedContext.CollectionName,
 					Field:          field,
 					Value:          value,
 				}),
 			).Error().To(BeNil())
-			getFieldResp, err := sharedContext.Client.DictionaryGetField(sharedContext.Ctx, &DictionaryGetFieldRequest{
-				CacheName:      sharedContext.CacheName,
+			getFieldResp, err := client.DictionaryGetField(sharedContext.Ctx, &DictionaryGetFieldRequest{
+				CacheName:      cacheName,
 				DictionaryName: sharedContext.CollectionName,
 				Field:          field,
 			})
@@ -123,10 +124,14 @@ var _ = Describe("Dictionary methods", func() {
 				Expect(result.ValueByte()).To(Equal(expectedValueBytes))
 			}
 		},
-		Entry("using string value and field", String("myField"), String("myValue"), "myField", []byte("myField"), "myValue", []byte("myValue")),
-		Entry("using string value and bytes field", String("myField"), Bytes("myValue"), "myField", []byte("myField"), "myValue", []byte("myValue")),
-		Entry("using bytes value and string field", Bytes("myField"), String("myValue"), "myField", []byte("myField"), "myValue", []byte("myValue")),
-		Entry("using bytes value and field", Bytes("myField"), Bytes("myValue"), "myField", []byte("myField"), "myValue", []byte("myValue")),
+		Entry("using string value and field", DefaultClient, String("myField"), String("myValue"), "myField", []byte("myField"), "myValue", []byte("myValue")),
+		Entry("using string value and bytes field", DefaultClient, String("myField"), Bytes("myValue"), "myField", []byte("myField"), "myValue", []byte("myValue")),
+		Entry("using bytes value and string field", DefaultClient, Bytes("myField"), String("myValue"), "myField", []byte("myField"), "myValue", []byte("myValue")),
+		Entry("using bytes value and field", DefaultClient, Bytes("myField"), Bytes("myValue"), "myField", []byte("myField"), "myValue", []byte("myValue")),
+		Entry("using string value and field with default cache", WithDefaultCache, String("myField"), String("myValue"), "myField", []byte("myField"), "myValue", []byte("myValue")),
+		Entry("using string value and bytes field with default cache", WithDefaultCache, String("myField"), Bytes("myValue"), "myField", []byte("myField"), "myValue", []byte("myValue")),
+		Entry("using bytes value and string field with default cache", WithDefaultCache, Bytes("myField"), String("myValue"), "myField", []byte("myField"), "myValue", []byte("myValue")),
+		Entry("using bytes value and field with default cache", WithDefaultCache, Bytes("myField"), Bytes("myValue"), "myField", []byte("myField"), "myValue", []byte("myValue")),
 	)
 
 	DescribeTable("try using empty and nil fields and values for set",
@@ -159,16 +164,17 @@ var _ = Describe("Dictionary methods", func() {
 	})
 
 	DescribeTable("add string fields and string and bytes values for set fields happy path",
-		func(elements []DictionaryElement, expectedItemsStringValue map[string]string, expectedItemsByteValue map[string][]byte) {
+		func(clientType string, elements []DictionaryElement, expectedItemsStringValue map[string]string, expectedItemsByteValue map[string][]byte) {
+			client, cacheName := sharedContext.GetClientPrereqsForType(clientType)
 			Expect(
-				sharedContext.Client.DictionarySetFields(sharedContext.Ctx, &DictionarySetFieldsRequest{
-					CacheName:      sharedContext.CacheName,
+				client.DictionarySetFields(sharedContext.Ctx, &DictionarySetFieldsRequest{
+					CacheName:      cacheName,
 					DictionaryName: sharedContext.CollectionName,
 					Elements:       elements,
 				}),
 			).To(BeAssignableToTypeOf(&DictionarySetFieldsSuccess{}))
-			fetchResp, err := sharedContext.Client.DictionaryFetch(sharedContext.Ctx, &DictionaryFetchRequest{
-				CacheName:      sharedContext.CacheName,
+			fetchResp, err := client.DictionaryFetch(sharedContext.Ctx, &DictionaryFetchRequest{
+				CacheName:      cacheName,
 				DictionaryName: sharedContext.CollectionName,
 			})
 			Expect(err).To(BeNil())
@@ -198,6 +204,7 @@ var _ = Describe("Dictionary methods", func() {
 		},
 		Entry(
 			"with string values",
+			DefaultClient,
 			[]DictionaryElement{
 				{Field: String("myField1"), Value: String("myValue1")},
 				{Field: String("myField2"), Value: String("myValue2")},
@@ -207,6 +214,7 @@ var _ = Describe("Dictionary methods", func() {
 		),
 		Entry(
 			"with byte values",
+			DefaultClient,
 			[]DictionaryElement{
 				{Field: Bytes("myField1"), Value: Bytes("myValue1")},
 				{Field: Bytes("myField2"), Value: Bytes("myValue2")},
@@ -216,6 +224,7 @@ var _ = Describe("Dictionary methods", func() {
 		),
 		Entry(
 			"with mixed values",
+			DefaultClient,
 			[]DictionaryElement{
 				{Field: Bytes("myField1"), Value: String("myValue1")},
 				{Field: String("myField2"), Value: Bytes("myValue2")},
@@ -225,6 +234,47 @@ var _ = Describe("Dictionary methods", func() {
 		),
 		Entry(
 			"with empty values",
+			DefaultClient,
+			[]DictionaryElement{
+				{Field: Bytes("myField1"), Value: String("")},
+				{Field: String("myField2"), Value: Bytes("")},
+			},
+			map[string]string{"myField1": "", "myField2": ""},
+			map[string][]byte{"myField1": []byte(""), "myField2": []byte("")},
+		),
+		Entry(
+			"with string values and default cache",
+			WithDefaultCache,
+			[]DictionaryElement{
+				{Field: String("myField1"), Value: String("myValue1")},
+				{Field: String("myField2"), Value: String("myValue2")},
+			},
+			map[string]string{"myField1": "myValue1", "myField2": "myValue2"},
+			map[string][]byte{"myField1": []byte("myValue1"), "myField2": []byte("myValue2")},
+		),
+		Entry(
+			"with byte values and default cache",
+			WithDefaultCache,
+			[]DictionaryElement{
+				{Field: Bytes("myField1"), Value: Bytes("myValue1")},
+				{Field: Bytes("myField2"), Value: Bytes("myValue2")},
+			},
+			map[string]string{"myField1": "myValue1", "myField2": "myValue2"},
+			map[string][]byte{"myField1": []byte("myValue1"), "myField2": []byte("myValue2")},
+		),
+		Entry(
+			"with mixed values and default cache",
+			WithDefaultCache,
+			[]DictionaryElement{
+				{Field: Bytes("myField1"), Value: String("myValue1")},
+				{Field: String("myField2"), Value: Bytes("myValue2")},
+			},
+			map[string]string{"myField1": "myValue1", "myField2": "myValue2"},
+			map[string][]byte{"myField1": []byte("myValue1"), "myField2": []byte("myValue2")},
+		),
+		Entry(
+			"with empty values and default cache",
+			WithDefaultCache,
 			[]DictionaryElement{
 				{Field: Bytes("myField1"), Value: String("")},
 				{Field: String("myField2"), Value: Bytes("")},
@@ -296,20 +346,25 @@ var _ = Describe("Dictionary methods", func() {
 
 	Describe("dictionary increment", func() {
 
-		It("populates nonexistent field", func() {
-			incrResp, err := sharedContext.Client.DictionaryIncrement(sharedContext.Ctx, &DictionaryIncrementRequest{
-				CacheName:      sharedContext.CacheName,
-				DictionaryName: sharedContext.CollectionName,
-				Field:          String("myField"),
-				Amount:         3,
-			})
-			Expect(err).To(BeNil())
-			Expect(incrResp).To(BeAssignableToTypeOf(&DictionaryIncrementSuccess{}))
-			switch result := incrResp.(type) {
-			case *DictionaryIncrementSuccess:
-				Expect(result.Value()).To(Equal(int64(3)))
-			}
-		})
+		DescribeTable("populates nonexistent field",
+			func(clientType string) {
+				client, cacheName := sharedContext.GetClientPrereqsForType(clientType)
+				incrResp, err := client.DictionaryIncrement(sharedContext.Ctx, &DictionaryIncrementRequest{
+					CacheName:      cacheName,
+					DictionaryName: sharedContext.CollectionName,
+					Field:          String("myField"),
+					Amount:         3,
+				})
+				Expect(err).To(BeNil())
+				Expect(incrResp).To(BeAssignableToTypeOf(&DictionaryIncrementSuccess{}))
+				switch result := incrResp.(type) {
+				case *DictionaryIncrementSuccess:
+					Expect(result.Value()).To(Equal(int64(3)))
+				}
+			},
+			Entry("with default client", DefaultClient),
+			Entry("with client with default cache", WithDefaultCache),
+		)
 
 		It("returns an error when called on a non-integer field", func() {
 			Expect(
@@ -341,32 +396,37 @@ var _ = Describe("Dictionary methods", func() {
 			Expect(err).To(HaveMomentoErrorCode(InvalidArgumentError))
 		})
 
-		It("increments on the happy path", func() {
-			field := String("counter")
-			for i := 0; i < 10; i++ {
-				Expect(
-					sharedContext.Client.DictionaryIncrement(sharedContext.Ctx, &DictionaryIncrementRequest{
-						CacheName:      sharedContext.CacheName,
-						DictionaryName: sharedContext.CollectionName,
-						Field:          field,
-						Amount:         1,
-					}),
-				).To(BeAssignableToTypeOf(&DictionaryIncrementSuccess{}))
-			}
-			fetchResp, err := sharedContext.Client.DictionaryGetField(sharedContext.Ctx, &DictionaryGetFieldRequest{
-				CacheName:      sharedContext.CacheName,
-				DictionaryName: sharedContext.CollectionName,
-				Field:          field,
-			})
-			Expect(err).To(BeNil())
-			Expect(fetchResp).To(BeAssignableToTypeOf(&DictionaryGetFieldHit{}))
-			switch result := fetchResp.(type) {
-			case *DictionaryGetFieldHit:
-				Expect(result.ValueString()).To(Equal("10"))
-			default:
-				Fail("expected a hit for get field but got a miss")
-			}
-		})
+		DescribeTable("increments on the happy path",
+			func(clientType string) {
+				client, cacheName := sharedContext.GetClientPrereqsForType(clientType)
+				field := String("counter")
+				for i := 0; i < 10; i++ {
+					Expect(
+						client.DictionaryIncrement(sharedContext.Ctx, &DictionaryIncrementRequest{
+							CacheName:      cacheName,
+							DictionaryName: sharedContext.CollectionName,
+							Field:          field,
+							Amount:         1,
+						}),
+					).To(BeAssignableToTypeOf(&DictionaryIncrementSuccess{}))
+				}
+				fetchResp, err := client.DictionaryGetField(sharedContext.Ctx, &DictionaryGetFieldRequest{
+					CacheName:      cacheName,
+					DictionaryName: sharedContext.CollectionName,
+					Field:          field,
+				})
+				Expect(err).To(BeNil())
+				Expect(fetchResp).To(BeAssignableToTypeOf(&DictionaryGetFieldHit{}))
+				switch result := fetchResp.(type) {
+				case *DictionaryGetFieldHit:
+					Expect(result.ValueString()).To(Equal("10"))
+				default:
+					Fail("expected a hit for get field but got a miss")
+				}
+			},
+			Entry("with default client", DefaultClient),
+			Entry("with client with default cache", WithDefaultCache),
+		)
 
 		It("returns an error when field is nil", func() {
 			Expect(
@@ -392,32 +452,45 @@ var _ = Describe("Dictionary methods", func() {
 					),
 				}),
 			).To(BeAssignableToTypeOf(&DictionarySetFieldsSuccess{}))
+			Expect(
+				sharedContext.ClientWithDefaultCacheName.DictionarySetFields(sharedContext.Ctx, &DictionarySetFieldsRequest{
+					DictionaryName: sharedContext.CollectionName,
+					Elements: DictionaryElementsFromMapStringValue(
+						map[string]Value{"myField1": String("myValue1"), "myField2": Bytes("myValue2")},
+					),
+				}),
+			).To(BeAssignableToTypeOf(&DictionarySetFieldsSuccess{}))
 		})
 
 		When("getting single field", func() {
 
-			It("returns the correct string and byte values", func() {
-				expected := map[string]string{"myField1": "myValue1", "myField2": "myValue2"}
+			DescribeTable("returns the correct string and byte values",
+				func(clientType string) {
+					client, cacheName := sharedContext.GetClientPrereqsForType(clientType)
+					expected := map[string]string{"myField1": "myValue1", "myField2": "myValue2"}
 
-				for fieldName, valueStr := range expected {
-					getResp, err := sharedContext.Client.DictionaryGetField(sharedContext.Ctx, &DictionaryGetFieldRequest{
-						CacheName:      sharedContext.CacheName,
-						DictionaryName: sharedContext.CollectionName,
-						Field:          String(fieldName),
-					})
-					Expect(err).To(BeNil())
-					Expect(getResp).To(BeAssignableToTypeOf(&DictionaryGetFieldHit{}))
-					switch result := getResp.(type) {
-					case *DictionaryGetFieldHit:
-						Expect(result.FieldString()).To(Equal(fieldName))
-						Expect(result.FieldByte()).To(Equal([]byte(fieldName)))
-						Expect(result.ValueString()).To(Equal(valueStr))
-						Expect(result.ValueByte()).To(Equal([]byte(valueStr)))
-					default:
-						Fail("something really weird happened")
+					for fieldName, valueStr := range expected {
+						getResp, err := client.DictionaryGetField(sharedContext.Ctx, &DictionaryGetFieldRequest{
+							CacheName:      cacheName,
+							DictionaryName: sharedContext.CollectionName,
+							Field:          String(fieldName),
+						})
+						Expect(err).To(BeNil())
+						Expect(getResp).To(BeAssignableToTypeOf(&DictionaryGetFieldHit{}))
+						switch result := getResp.(type) {
+						case *DictionaryGetFieldHit:
+							Expect(result.FieldString()).To(Equal(fieldName))
+							Expect(result.FieldByte()).To(Equal([]byte(fieldName)))
+							Expect(result.ValueString()).To(Equal(valueStr))
+							Expect(result.ValueByte()).To(Equal([]byte(valueStr)))
+						default:
+							Fail("something really weird happened")
+						}
 					}
-				}
-			})
+				},
+				Entry("with default client", DefaultClient),
+				Entry("with client with default cache", WithDefaultCache),
+			)
 
 			It("returns a miss for a nonexistent field", func() {
 				getResp, err := sharedContext.Client.DictionaryGetField(sharedContext.Ctx, &DictionaryGetFieldRequest{
@@ -453,24 +526,29 @@ var _ = Describe("Dictionary methods", func() {
 
 		When("getting multiple fields", func() {
 
-			It("returns the correct string and byte values", func() {
-				getResp, err := sharedContext.Client.DictionaryGetFields(sharedContext.Ctx, &DictionaryGetFieldsRequest{
-					CacheName:      sharedContext.CacheName,
-					DictionaryName: sharedContext.CollectionName,
-					Fields:         []Value{String("myField1"), String("myField2")},
-				})
-				Expect(err).To(BeNil())
-				Expect(getResp).To(BeAssignableToTypeOf(&DictionaryGetFieldsHit{}))
+			DescribeTable("returns the correct string and byte values",
+				func(clientType string) {
+					client, cacheName := sharedContext.GetClientPrereqsForType(clientType)
+					getResp, err := client.DictionaryGetFields(sharedContext.Ctx, &DictionaryGetFieldsRequest{
+						CacheName:      cacheName,
+						DictionaryName: sharedContext.CollectionName,
+						Fields:         []Value{String("myField1"), String("myField2")},
+					})
+					Expect(err).To(BeNil())
+					Expect(getResp).To(BeAssignableToTypeOf(&DictionaryGetFieldsHit{}))
 
-				expectedStrings := map[string]string{"myField1": "myValue1", "myField2": "myValue2"}
-				expectedBytes := map[string][]byte{"myField1": []byte("myValue1"), "myField2": []byte("myValue2")}
-				switch result := getResp.(type) {
-				case *DictionaryGetFieldsHit:
-					Expect(result.ValueMapStringString()).To(Equal(expectedStrings))
-					Expect(result.ValueMap()).To(Equal(expectedStrings))
-					Expect(result.ValueMapStringBytes()).To(Equal(expectedBytes))
-				}
-			})
+					expectedStrings := map[string]string{"myField1": "myValue1", "myField2": "myValue2"}
+					expectedBytes := map[string][]byte{"myField1": []byte("myValue1"), "myField2": []byte("myValue2")}
+					switch result := getResp.(type) {
+					case *DictionaryGetFieldsHit:
+						Expect(result.ValueMapStringString()).To(Equal(expectedStrings))
+						Expect(result.ValueMap()).To(Equal(expectedStrings))
+						Expect(result.ValueMapStringBytes()).To(Equal(expectedBytes))
+					}
+				},
+				Entry("with default client", DefaultClient),
+				Entry("with client with default cache", WithDefaultCache),
+			)
 
 			It("returns a miss for nonexistent dictionary", func() {
 				Expect(
@@ -539,21 +617,35 @@ var _ = Describe("Dictionary methods", func() {
 					),
 				}),
 			).To(BeAssignableToTypeOf(&DictionarySetFieldsSuccess{}))
+			Expect(
+				sharedContext.ClientWithDefaultCacheName.DictionarySetFields(sharedContext.Ctx, &DictionarySetFieldsRequest{
+					CacheName:      sharedContext.CacheName,
+					DictionaryName: sharedContext.CollectionName,
+					Elements: DictionaryElementsFromMapStringValue(
+						map[string]Value{"myField1": String("myValue1"), "myField2": Bytes("myValue2")},
+					),
+				}),
+			).To(BeAssignableToTypeOf(&DictionarySetFieldsSuccess{}))
 		})
 
-		It("fetches on the happy path", func() {
-			expected := map[string]string{"myField1": "myValue1", "myField2": "myValue2"}
-			fetchResp, err := sharedContext.Client.DictionaryFetch(sharedContext.Ctx, &DictionaryFetchRequest{
-				CacheName:      sharedContext.CacheName,
-				DictionaryName: sharedContext.CollectionName,
-			})
-			Expect(err).To(BeNil())
-			Expect(fetchResp).To(BeAssignableToTypeOf(&DictionaryFetchHit{}))
-			switch result := fetchResp.(type) {
-			case *DictionaryFetchHit:
-				Expect(result.ValueMap()).To(Equal(expected))
-			}
-		})
+		DescribeTable("fetches on the happy path",
+			func(clientType string) {
+				client, cacheName := sharedContext.GetClientPrereqsForType(clientType)
+				expected := map[string]string{"myField1": "myValue1", "myField2": "myValue2"}
+				fetchResp, err := client.DictionaryFetch(sharedContext.Ctx, &DictionaryFetchRequest{
+					CacheName:      cacheName,
+					DictionaryName: sharedContext.CollectionName,
+				})
+				Expect(err).To(BeNil())
+				Expect(fetchResp).To(BeAssignableToTypeOf(&DictionaryFetchHit{}))
+				switch result := fetchResp.(type) {
+				case *DictionaryFetchHit:
+					Expect(result.ValueMap()).To(Equal(expected))
+				}
+			},
+			Entry("with default client", DefaultClient),
+			Entry("with client with default cache", WithDefaultCache),
+		)
 
 		It("returns a miss for nonexistent dictionary", func() {
 			Expect(
@@ -582,34 +674,52 @@ var _ = Describe("Dictionary methods", func() {
 					),
 				}),
 			).To(BeAssignableToTypeOf(&DictionarySetFieldsSuccess{}))
+			Expect(
+				sharedContext.ClientWithDefaultCacheName.DictionarySetFields(sharedContext.Ctx, &DictionarySetFieldsRequest{
+					CacheName:      sharedContext.CacheName,
+					DictionaryName: sharedContext.CollectionName,
+					Elements: DictionaryElementsFromMapStringValue(
+						map[string]Value{
+							"myField1": String("myValue1"),
+							"myField2": Bytes("myValue2"),
+							"myField3": String("myValue3"),
+						},
+					),
+				}),
+			).To(BeAssignableToTypeOf(&DictionarySetFieldsSuccess{}))
 		})
 
 		When("removing a single field", func() {
 
-			It("properly removes a field", func() {
-				removeResp, err := sharedContext.Client.DictionaryRemoveField(sharedContext.Ctx, &DictionaryRemoveFieldRequest{
-					CacheName:      sharedContext.CacheName,
-					DictionaryName: sharedContext.CollectionName,
-					Field:          String("myField1"),
-				})
-				Expect(err).To(BeNil())
-				Expect(removeResp).To(BeAssignableToTypeOf(&DictionaryRemoveFieldSuccess{}))
+			DescribeTable("properly removes a field",
+				func(clientType string) {
+					client, cacheName := sharedContext.GetClientPrereqsForType(clientType)
+					removeResp, err := client.DictionaryRemoveField(sharedContext.Ctx, &DictionaryRemoveFieldRequest{
+						CacheName:      cacheName,
+						DictionaryName: sharedContext.CollectionName,
+						Field:          String("myField1"),
+					})
+					Expect(err).To(BeNil())
+					Expect(removeResp).To(BeAssignableToTypeOf(&DictionaryRemoveFieldSuccess{}))
 
-				fetchResp, err := sharedContext.Client.DictionaryFetch(sharedContext.Ctx, &DictionaryFetchRequest{
-					CacheName:      sharedContext.CacheName,
-					DictionaryName: sharedContext.CollectionName,
-				})
-				Expect(err).To(BeNil())
-				switch result := fetchResp.(type) {
-				case *DictionaryFetchHit:
-					Expect(result.ValueMap()).To(Equal(map[string]string{
-						"myField2": "myValue2",
-						"myField3": "myValue3",
-					}))
-				default:
-					Fail("expected a hit from dictionary fetch but got a miss")
-				}
-			})
+					fetchResp, err := client.DictionaryFetch(sharedContext.Ctx, &DictionaryFetchRequest{
+						CacheName:      cacheName,
+						DictionaryName: sharedContext.CollectionName,
+					})
+					Expect(err).To(BeNil())
+					switch result := fetchResp.(type) {
+					case *DictionaryFetchHit:
+						Expect(result.ValueMap()).To(Equal(map[string]string{
+							"myField2": "myValue2",
+							"myField3": "myValue3",
+						}))
+					default:
+						Fail("expected a hit from dictionary fetch but got a miss")
+					}
+				},
+				Entry("with default client", DefaultClient),
+				Entry("with client with default cache", WithDefaultCache),
+			)
 
 			It("no-ops when attempting to remove a nonexistent field", func() {
 				removeResp, err := sharedContext.Client.DictionaryRemoveField(sharedContext.Ctx, &DictionaryRemoveFieldRequest{
@@ -644,29 +754,34 @@ var _ = Describe("Dictionary methods", func() {
 		})
 
 		When("removing multiple fields", func() {
-			It("properly removes multiple fields", func() {
-				removeResp, err := sharedContext.Client.DictionaryRemoveFields(sharedContext.Ctx, &DictionaryRemoveFieldsRequest{
-					CacheName:      sharedContext.CacheName,
-					DictionaryName: sharedContext.CollectionName,
-					Fields:         []Value{String("myField1"), Bytes("myField2")},
-				})
-				Expect(err).To(BeNil())
-				Expect(removeResp).To(BeAssignableToTypeOf(&DictionaryRemoveFieldsSuccess{}))
+			DescribeTable("properly removes multiple fields",
+				func(clientType string) {
+					client, cacheName := sharedContext.GetClientPrereqsForType(clientType)
+					removeResp, err := client.DictionaryRemoveFields(sharedContext.Ctx, &DictionaryRemoveFieldsRequest{
+						CacheName:      cacheName,
+						DictionaryName: sharedContext.CollectionName,
+						Fields:         []Value{String("myField1"), Bytes("myField2")},
+					})
+					Expect(err).To(BeNil())
+					Expect(removeResp).To(BeAssignableToTypeOf(&DictionaryRemoveFieldsSuccess{}))
 
-				fetchResp, err := sharedContext.Client.DictionaryFetch(sharedContext.Ctx, &DictionaryFetchRequest{
-					CacheName:      sharedContext.CacheName,
-					DictionaryName: sharedContext.CollectionName,
-				})
-				Expect(err).To(BeNil())
-				switch result := fetchResp.(type) {
-				case *DictionaryFetchHit:
-					Expect(result.ValueMap()).To(Equal(map[string]string{
-						"myField3": "myValue3",
-					}))
-				default:
-					Fail("expected a hit from dictionary fetch but got a miss")
-				}
-			})
+					fetchResp, err := client.DictionaryFetch(sharedContext.Ctx, &DictionaryFetchRequest{
+						CacheName:      cacheName,
+						DictionaryName: sharedContext.CollectionName,
+					})
+					Expect(err).To(BeNil())
+					switch result := fetchResp.(type) {
+					case *DictionaryFetchHit:
+						Expect(result.ValueMap()).To(Equal(map[string]string{
+							"myField3": "myValue3",
+						}))
+					default:
+						Fail("expected a hit from dictionary fetch but got a miss")
+					}
+				},
+				Entry("with default client", DefaultClient),
+				Entry("with client with default cache", WithDefaultCache),
+			)
 
 			It("no-ops when attempting to remove a nonexistent field", func() {
 				removeResp, err := sharedContext.Client.DictionaryRemoveFields(sharedContext.Ctx, &DictionaryRemoveFieldsRequest{

--- a/momento/list_test.go
+++ b/momento/list_test.go
@@ -46,7 +46,7 @@ var _ = Describe("List methods", func() {
 
 	BeforeEach(func() {
 		sharedContext = NewSharedContext()
-		sharedContext.CreateDefaultCache()
+		sharedContext.CreateDefaultCaches()
 		DeferCleanup(func() {
 			sharedContext.Close()
 		})

--- a/momento/list_test.go
+++ b/momento/list_test.go
@@ -38,6 +38,12 @@ func populateList(sharedContext SharedContext, numItems int) []string {
 			Values:    values,
 		}),
 	).To(BeAssignableToTypeOf(&ListConcatenateFrontSuccess{}))
+	Expect(
+		sharedContext.ClientWithDefaultCacheName.ListConcatenateFront(sharedContext.Ctx, &ListConcatenateFrontRequest{
+			ListName: sharedContext.CollectionName,
+			Values:   values,
+		}),
+	).To(BeAssignableToTypeOf(&ListConcatenateFrontSuccess{}))
 	return expected
 }
 
@@ -53,31 +59,24 @@ var _ = Describe("List methods", func() {
 	})
 
 	DescribeTable("try using invalid cache and list names",
-		func(cacheName string, listName string, expectedErrorCode string) {
+		func(clientType string, cacheName string, listName string, expectedErrorCode string) {
+			client, _ := sharedContext.GetClientPrereqsForType(clientType)
 			Expect(
-				sharedContext.Client.ListFetch(sharedContext.Ctx, &ListFetchRequest{
+				client.ListFetch(sharedContext.Ctx, &ListFetchRequest{
 					CacheName: cacheName,
 					ListName:  listName,
 				}),
 			).Error().To(HaveMomentoErrorCode(expectedErrorCode))
 
 			Expect(
-				sharedContext.Client.ListLength(sharedContext.Ctx, &ListLengthRequest{
+				client.ListLength(sharedContext.Ctx, &ListLengthRequest{
 					CacheName: cacheName,
 					ListName:  listName,
 				}),
 			).Error().To(HaveMomentoErrorCode(expectedErrorCode))
 
 			Expect(
-				sharedContext.Client.ListConcatenateBack(sharedContext.Ctx, &ListConcatenateBackRequest{
-					CacheName: cacheName,
-					ListName:  listName,
-					Values:    []Value{String("hi")},
-				}),
-			).Error().To(HaveMomentoErrorCode(expectedErrorCode))
-
-			Expect(
-				sharedContext.Client.ListConcatenateFront(sharedContext.Ctx, &ListConcatenateFrontRequest{
+				client.ListConcatenateBack(sharedContext.Ctx, &ListConcatenateBackRequest{
 					CacheName: cacheName,
 					ListName:  listName,
 					Values:    []Value{String("hi")},
@@ -85,21 +84,29 @@ var _ = Describe("List methods", func() {
 			).Error().To(HaveMomentoErrorCode(expectedErrorCode))
 
 			Expect(
-				sharedContext.Client.ListPopBack(sharedContext.Ctx, &ListPopBackRequest{
+				client.ListConcatenateFront(sharedContext.Ctx, &ListConcatenateFrontRequest{
+					CacheName: cacheName,
+					ListName:  listName,
+					Values:    []Value{String("hi")},
+				}),
+			).Error().To(HaveMomentoErrorCode(expectedErrorCode))
+
+			Expect(
+				client.ListPopBack(sharedContext.Ctx, &ListPopBackRequest{
 					CacheName: cacheName,
 					ListName:  listName,
 				}),
 			).Error().To(HaveMomentoErrorCode(expectedErrorCode))
 
 			Expect(
-				sharedContext.Client.ListPopFront(sharedContext.Ctx, &ListPopFrontRequest{
+				client.ListPopFront(sharedContext.Ctx, &ListPopFrontRequest{
 					CacheName: cacheName,
 					ListName:  listName,
 				}),
 			).Error().To(HaveMomentoErrorCode(expectedErrorCode))
 
 			Expect(
-				sharedContext.Client.ListPushFront(sharedContext.Ctx, &ListPushFrontRequest{
+				client.ListPushFront(sharedContext.Ctx, &ListPushFrontRequest{
 					CacheName: cacheName,
 					ListName:  listName,
 					Value:     String("hi"),
@@ -107,7 +114,7 @@ var _ = Describe("List methods", func() {
 			).Error().To(HaveMomentoErrorCode(expectedErrorCode))
 
 			Expect(
-				sharedContext.Client.ListPushBack(sharedContext.Ctx, &ListPushBackRequest{
+				client.ListPushBack(sharedContext.Ctx, &ListPushBackRequest{
 					CacheName: cacheName,
 					ListName:  listName,
 					Value:     String("hi"),
@@ -115,16 +122,19 @@ var _ = Describe("List methods", func() {
 			).Error().To(HaveMomentoErrorCode(expectedErrorCode))
 
 			Expect(
-				sharedContext.Client.ListRemoveValue(sharedContext.Ctx, &ListRemoveValueRequest{
+				client.ListRemoveValue(sharedContext.Ctx, &ListRemoveValueRequest{
 					CacheName: cacheName,
 					ListName:  listName,
 					Value:     String("hi"),
 				}),
 			).Error().To(HaveMomentoErrorCode(expectedErrorCode))
 		},
-		Entry("nonexistent cache name", uuid.NewString(), uuid.NewString(), NotFoundError),
-		Entry("empty cache name", "", sharedContext.CollectionName, InvalidArgumentError),
-		Entry("empty list name", sharedContext.CacheName, "", InvalidArgumentError),
+		Entry("nonexistent cache name", DefaultClient, uuid.NewString(), uuid.NewString(), NotFoundError),
+		Entry("empty cache name", DefaultClient, "", sharedContext.CollectionName, InvalidArgumentError),
+		Entry("empty list name", DefaultClient, sharedContext.CacheName, "", InvalidArgumentError),
+		Entry("nonexistent cache name", WithDefaultCache, uuid.NewString(), uuid.NewString(), NotFoundError),
+		Entry("empty cache name", WithDefaultCache, "", sharedContext.CollectionName, InvalidArgumentError),
+		Entry("empty list name", WithDefaultCache, sharedContext.CacheName, "", InvalidArgumentError),
 	)
 
 	It("returns the correct list length", func() {
@@ -147,51 +157,61 @@ var _ = Describe("List methods", func() {
 
 		When("pushing to the front of the list", func() {
 
-			It("pushes strings and bytes on the happy path", func() {
-				numItems := 10
-				values, expected := getValueAndExpectedValueLists(numItems)
-				sort.Sort(sort.Reverse(sort.StringSlice(expected)))
-				for _, value := range values {
-					Expect(
-						sharedContext.Client.ListPushFront(sharedContext.Ctx, &ListPushFrontRequest{
-							CacheName: sharedContext.CacheName,
-							ListName:  sharedContext.CollectionName,
-							Value:     value,
-						}),
-					).To(BeAssignableToTypeOf(&ListPushFrontSuccess{}))
-				}
-				fetchResp, err := sharedContext.Client.ListFetch(sharedContext.Ctx, &ListFetchRequest{
-					CacheName: sharedContext.CacheName,
-					ListName:  sharedContext.CollectionName,
-				})
-				Expect(err).To(BeNil())
-				Expect(fetchResp).To(BeAssignableToTypeOf(&ListFetchHit{}))
-				Expect(fetchResp).To(HaveListLength(numItems))
-				switch result := fetchResp.(type) {
-				case *ListFetchHit:
-					Expect(result.ValueList()).To(Equal(expected))
-				}
-			})
+			DescribeTable("pushes strings and bytes on the happy path",
+				func(clientType string) {
+					client, cacheName := sharedContext.GetClientPrereqsForType(clientType)
+					numItems := 10
+					values, expected := getValueAndExpectedValueLists(numItems)
+					sort.Sort(sort.Reverse(sort.StringSlice(expected)))
+					for _, value := range values {
+						Expect(
+							client.ListPushFront(sharedContext.Ctx, &ListPushFrontRequest{
+								CacheName: cacheName,
+								ListName:  sharedContext.CollectionName,
+								Value:     value,
+							}),
+						).To(BeAssignableToTypeOf(&ListPushFrontSuccess{}))
+					}
+					fetchResp, err := client.ListFetch(sharedContext.Ctx, &ListFetchRequest{
+						CacheName: cacheName,
+						ListName:  sharedContext.CollectionName,
+					})
+					Expect(err).To(BeNil())
+					Expect(fetchResp).To(BeAssignableToTypeOf(&ListFetchHit{}))
+					Expect(fetchResp).To(HaveListLength(numItems))
+					switch result := fetchResp.(type) {
+					case *ListFetchHit:
+						Expect(result.ValueList()).To(Equal(expected))
+					}
+				},
+				Entry("with default client", DefaultClient),
+				Entry("with client with default cache", WithDefaultCache),
+			)
 
-			It("truncates the list properly", func() {
-				numItems := 10
-				truncateTo := 5
-				populateList(sharedContext, numItems)
-				Expect(
-					sharedContext.Client.ListPushFront(sharedContext.Ctx, &ListPushFrontRequest{
-						CacheName:          sharedContext.CacheName,
-						ListName:           sharedContext.CollectionName,
-						Value:              String("andherlittledogtoo"),
-						TruncateBackToSize: uint32(truncateTo),
-					}),
-				).Error().To(BeNil())
-				fetchResp, err := sharedContext.Client.ListFetch(sharedContext.Ctx, &ListFetchRequest{
-					CacheName: sharedContext.CacheName,
-					ListName:  sharedContext.CollectionName,
-				})
-				Expect(err).To(BeNil())
-				Expect(fetchResp).To(HaveListLength(truncateTo))
-			})
+			DescribeTable("truncates the list properly",
+				func(clientType string) {
+					client, cacheName := sharedContext.GetClientPrereqsForType(clientType)
+					numItems := 10
+					truncateTo := 5
+					populateList(sharedContext, numItems)
+					Expect(
+						client.ListPushFront(sharedContext.Ctx, &ListPushFrontRequest{
+							CacheName:          cacheName,
+							ListName:           sharedContext.CollectionName,
+							Value:              String("andherlittledogtoo"),
+							TruncateBackToSize: uint32(truncateTo),
+						}),
+					).Error().To(BeNil())
+					fetchResp, err := client.ListFetch(sharedContext.Ctx, &ListFetchRequest{
+						CacheName: cacheName,
+						ListName:  sharedContext.CollectionName,
+					})
+					Expect(err).To(BeNil())
+					Expect(fetchResp).To(HaveListLength(truncateTo))
+				},
+				Entry("with default client", DefaultClient),
+				Entry("with client with default cache", WithDefaultCache),
+			)
 
 			It("returns invalid argument for a nil value", func() {
 				Expect(
@@ -223,50 +243,60 @@ var _ = Describe("List methods", func() {
 
 		When("pushing to the back of the list", func() {
 
-			It("pushes strings and bytes on the happy path", func() {
-				numItems := 10
-				values, expected := getValueAndExpectedValueLists(numItems)
-				for _, value := range values {
+			DescribeTable("pushes strings and bytes on the happy path",
+				func(clientType string) {
+					client, cacheName := sharedContext.GetClientPrereqsForType(clientType)
+					numItems := 10
+					values, expected := getValueAndExpectedValueLists(numItems)
+					for _, value := range values {
+						Expect(
+							client.ListPushBack(sharedContext.Ctx, &ListPushBackRequest{
+								CacheName: cacheName,
+								ListName:  sharedContext.CollectionName,
+								Value:     value,
+							}),
+						).To(BeAssignableToTypeOf(&ListPushBackSuccess{}))
+					}
+
+					fetchResp, err := client.ListFetch(sharedContext.Ctx, &ListFetchRequest{
+						CacheName: cacheName,
+						ListName:  sharedContext.CollectionName,
+					})
+					Expect(err).To(BeNil())
+					Expect(fetchResp).To(HaveListLength(numItems))
+					switch result := fetchResp.(type) {
+					case *ListFetchHit:
+						Expect(result.ValueList()).To(Equal(expected))
+					}
+				},
+				Entry("with default client", DefaultClient),
+				Entry("with client with default cache", WithDefaultCache),
+			)
+
+			DescribeTable("truncates the list properly",
+				func(clientType string) {
+					client, cacheName := sharedContext.GetClientPrereqsForType(clientType)
+					numItems := 10
+					truncateTo := 5
+					populateList(sharedContext, numItems)
 					Expect(
-						sharedContext.Client.ListPushBack(sharedContext.Ctx, &ListPushBackRequest{
-							CacheName: sharedContext.CacheName,
-							ListName:  sharedContext.CollectionName,
-							Value:     value,
+						client.ListPushBack(sharedContext.Ctx, &ListPushBackRequest{
+							CacheName:           cacheName,
+							ListName:            sharedContext.CollectionName,
+							Value:               String("andherlittledogtoo"),
+							TruncateFrontToSize: uint32(truncateTo),
 						}),
-					).To(BeAssignableToTypeOf(&ListPushBackSuccess{}))
-				}
-
-				fetchResp, err := sharedContext.Client.ListFetch(sharedContext.Ctx, &ListFetchRequest{
-					CacheName: sharedContext.CacheName,
-					ListName:  sharedContext.CollectionName,
-				})
-				Expect(err).To(BeNil())
-				Expect(fetchResp).To(HaveListLength(numItems))
-				switch result := fetchResp.(type) {
-				case *ListFetchHit:
-					Expect(result.ValueList()).To(Equal(expected))
-				}
-			})
-
-			It("truncates the list properly", func() {
-				numItems := 10
-				truncateTo := 5
-				populateList(sharedContext, numItems)
-				Expect(
-					sharedContext.Client.ListPushBack(sharedContext.Ctx, &ListPushBackRequest{
-						CacheName:           sharedContext.CacheName,
-						ListName:            sharedContext.CollectionName,
-						Value:               String("andherlittledogtoo"),
-						TruncateFrontToSize: uint32(truncateTo),
-					}),
-				).Error().To(BeNil())
-				fetchResp, err := sharedContext.Client.ListFetch(sharedContext.Ctx, &ListFetchRequest{
-					CacheName: sharedContext.CacheName,
-					ListName:  sharedContext.CollectionName,
-				})
-				Expect(err).To(BeNil())
-				Expect(fetchResp).To(HaveListLength(truncateTo))
-			})
+					).Error().To(BeNil())
+					fetchResp, err := client.ListFetch(sharedContext.Ctx, &ListFetchRequest{
+						CacheName: cacheName,
+						ListName:  sharedContext.CollectionName,
+					})
+					Expect(err).To(BeNil())
+					Expect(fetchResp).To(HaveListLength(truncateTo))
+				},
+				Entry("with default client", DefaultClient),
+				Entry("with client with default cache", WithDefaultCache),
+			)
 
 			It("returns invalid argument for a nil value", func() {
 				Expect(
@@ -302,58 +332,68 @@ var _ = Describe("List methods", func() {
 
 		When("concatenating to the front of the list", func() {
 
-			It("pushes strings and bytes on the happy path", func() {
-				numItems := 10
-				expected := populateList(sharedContext, numItems)
+			DescribeTable("pushes strings and bytes on the happy path",
+				func(clientType string) {
+					client, cacheName := sharedContext.GetClientPrereqsForType(clientType)
+					numItems := 10
+					expected := populateList(sharedContext, numItems)
 
-				numConcatItems := 5
-				concatValues, concatExpected := getValueAndExpectedValueLists(numConcatItems)
-				concatResp, err := sharedContext.Client.ListConcatenateFront(sharedContext.Ctx, &ListConcatenateFrontRequest{
-					CacheName: sharedContext.CacheName,
-					ListName:  sharedContext.CollectionName,
-					Values:    concatValues,
-				})
-				Expect(err).To(BeNil())
-				Expect(concatResp).To(BeAssignableToTypeOf(&ListConcatenateFrontSuccess{}))
+					numConcatItems := 5
+					concatValues, concatExpected := getValueAndExpectedValueLists(numConcatItems)
+					concatResp, err := client.ListConcatenateFront(sharedContext.Ctx, &ListConcatenateFrontRequest{
+						CacheName: cacheName,
+						ListName:  sharedContext.CollectionName,
+						Values:    concatValues,
+					})
+					Expect(err).To(BeNil())
+					Expect(concatResp).To(BeAssignableToTypeOf(&ListConcatenateFrontSuccess{}))
 
-				fetchResp, err := sharedContext.Client.ListFetch(sharedContext.Ctx, &ListFetchRequest{
-					CacheName: sharedContext.CacheName,
-					ListName:  sharedContext.CollectionName,
-				})
-				Expect(err).To(BeNil())
-				Expect(fetchResp).To(BeAssignableToTypeOf(&ListFetchHit{}))
-				Expect(fetchResp).To(HaveListLength(numItems + numConcatItems))
-				expected = append(concatExpected, expected...)
-				switch result := fetchResp.(type) {
-				case *ListFetchHit:
-					Expect(result.ValueList()).To(Equal(expected))
-				}
-			})
+					fetchResp, err := client.ListFetch(sharedContext.Ctx, &ListFetchRequest{
+						CacheName: cacheName,
+						ListName:  sharedContext.CollectionName,
+					})
+					Expect(err).To(BeNil())
+					Expect(fetchResp).To(BeAssignableToTypeOf(&ListFetchHit{}))
+					Expect(fetchResp).To(HaveListLength(numItems + numConcatItems))
+					expected = append(concatExpected, expected...)
+					switch result := fetchResp.(type) {
+					case *ListFetchHit:
+						Expect(result.ValueList()).To(Equal(expected))
+					}
+				},
+				Entry("with default client", DefaultClient),
+				Entry("with client with default cache", WithDefaultCache),
+			)
 
-			It("truncates the list properly", func() {
-				populateList(sharedContext, 5)
-				concatValues := []Value{String("100"), String("101"), String("102")}
-				concatResp, err := sharedContext.Client.ListConcatenateFront(sharedContext.Ctx, &ListConcatenateFrontRequest{
-					CacheName:          sharedContext.CacheName,
-					ListName:           sharedContext.CollectionName,
-					Values:             concatValues,
-					TruncateBackToSize: 3,
-				})
-				Expect(err).To(BeNil())
-				Expect(concatResp).To(BeAssignableToTypeOf(&ListConcatenateFrontSuccess{}))
+			DescribeTable("truncates the list properly",
+				func(clientType string) {
+					client, cacheName := sharedContext.GetClientPrereqsForType(clientType)
+					populateList(sharedContext, 5)
+					concatValues := []Value{String("100"), String("101"), String("102")}
+					concatResp, err := client.ListConcatenateFront(sharedContext.Ctx, &ListConcatenateFrontRequest{
+						CacheName:          cacheName,
+						ListName:           sharedContext.CollectionName,
+						Values:             concatValues,
+						TruncateBackToSize: 3,
+					})
+					Expect(err).To(BeNil())
+					Expect(concatResp).To(BeAssignableToTypeOf(&ListConcatenateFrontSuccess{}))
 
-				fetchResp, err := sharedContext.Client.ListFetch(sharedContext.Ctx, &ListFetchRequest{
-					CacheName: sharedContext.CacheName,
-					ListName:  sharedContext.CollectionName,
-				})
-				Expect(err).To(BeNil())
-				Expect(fetchResp).To(BeAssignableToTypeOf(&ListFetchHit{}))
-				Expect(fetchResp).To(HaveListLength(3))
-				switch result := fetchResp.(type) {
-				case *ListFetchHit:
-					Expect(result.ValueList()).To(Equal([]string{"100", "101", "102"}))
-				}
-			})
+					fetchResp, err := client.ListFetch(sharedContext.Ctx, &ListFetchRequest{
+						CacheName: cacheName,
+						ListName:  sharedContext.CollectionName,
+					})
+					Expect(err).To(BeNil())
+					Expect(fetchResp).To(BeAssignableToTypeOf(&ListFetchHit{}))
+					Expect(fetchResp).To(HaveListLength(3))
+					switch result := fetchResp.(type) {
+					case *ListFetchHit:
+						Expect(result.ValueList()).To(Equal([]string{"100", "101", "102"}))
+					}
+				},
+				Entry("with default client", DefaultClient),
+				Entry("with client with default cache", WithDefaultCache),
+			)
 
 			It("returns an invalid argument for a nil value", func() {
 				populateList(sharedContext, 5)
@@ -388,58 +428,68 @@ var _ = Describe("List methods", func() {
 
 		When("concatenating to the back of the list", func() {
 
-			It("pushes strings and bytes on the happy path", func() {
-				numItems := 10
-				expected := populateList(sharedContext, numItems)
+			DescribeTable("pushes strings and bytes on the happy path",
+				func(clientType string) {
+					client, cacheName := sharedContext.GetClientPrereqsForType(clientType)
+					numItems := 10
+					expected := populateList(sharedContext, numItems)
 
-				numConcatItems := 5
-				concatValues, concatExpected := getValueAndExpectedValueLists(numConcatItems)
-				concatResp, err := sharedContext.Client.ListConcatenateBack(sharedContext.Ctx, &ListConcatenateBackRequest{
-					CacheName: sharedContext.CacheName,
-					ListName:  sharedContext.CollectionName,
-					Values:    concatValues,
-				})
-				Expect(err).To(BeNil())
-				Expect(concatResp).To(BeAssignableToTypeOf(&ListConcatenateBackSuccess{}))
+					numConcatItems := 5
+					concatValues, concatExpected := getValueAndExpectedValueLists(numConcatItems)
+					concatResp, err := client.ListConcatenateBack(sharedContext.Ctx, &ListConcatenateBackRequest{
+						CacheName: cacheName,
+						ListName:  sharedContext.CollectionName,
+						Values:    concatValues,
+					})
+					Expect(err).To(BeNil())
+					Expect(concatResp).To(BeAssignableToTypeOf(&ListConcatenateBackSuccess{}))
 
-				fetchResp, err := sharedContext.Client.ListFetch(sharedContext.Ctx, &ListFetchRequest{
-					CacheName: sharedContext.CacheName,
-					ListName:  sharedContext.CollectionName,
-				})
-				Expect(err).To(BeNil())
-				Expect(fetchResp).To(BeAssignableToTypeOf(&ListFetchHit{}))
-				Expect(fetchResp).To(HaveListLength(numItems + numConcatItems))
-				expected = append(expected, concatExpected...)
-				switch result := fetchResp.(type) {
-				case *ListFetchHit:
-					Expect(result.ValueList()).To(Equal(expected))
-				}
-			})
+					fetchResp, err := client.ListFetch(sharedContext.Ctx, &ListFetchRequest{
+						CacheName: cacheName,
+						ListName:  sharedContext.CollectionName,
+					})
+					Expect(err).To(BeNil())
+					Expect(fetchResp).To(BeAssignableToTypeOf(&ListFetchHit{}))
+					Expect(fetchResp).To(HaveListLength(numItems + numConcatItems))
+					expected = append(expected, concatExpected...)
+					switch result := fetchResp.(type) {
+					case *ListFetchHit:
+						Expect(result.ValueList()).To(Equal(expected))
+					}
+				},
+				Entry("with default client", DefaultClient),
+				Entry("with client with default cache", WithDefaultCache),
+			)
 
-			It("truncates the list properly", func() {
-				populateList(sharedContext, 5)
-				concatValues := []Value{String("100"), String("101"), String("102")}
-				concatResp, err := sharedContext.Client.ListConcatenateBack(sharedContext.Ctx, &ListConcatenateBackRequest{
-					CacheName:           sharedContext.CacheName,
-					ListName:            sharedContext.CollectionName,
-					Values:              concatValues,
-					TruncateFrontToSize: 3,
-				})
-				Expect(err).To(BeNil())
-				Expect(concatResp).To(BeAssignableToTypeOf(&ListConcatenateBackSuccess{}))
+			DescribeTable("truncates the list properly",
+				func(clientType string) {
+					client, cacheName := sharedContext.GetClientPrereqsForType(clientType)
+					populateList(sharedContext, 5)
+					concatValues := []Value{String("100"), String("101"), String("102")}
+					concatResp, err := client.ListConcatenateBack(sharedContext.Ctx, &ListConcatenateBackRequest{
+						CacheName:           cacheName,
+						ListName:            sharedContext.CollectionName,
+						Values:              concatValues,
+						TruncateFrontToSize: 3,
+					})
+					Expect(err).To(BeNil())
+					Expect(concatResp).To(BeAssignableToTypeOf(&ListConcatenateBackSuccess{}))
 
-				fetchResp, err := sharedContext.Client.ListFetch(sharedContext.Ctx, &ListFetchRequest{
-					CacheName: sharedContext.CacheName,
-					ListName:  sharedContext.CollectionName,
-				})
-				Expect(err).To(BeNil())
-				Expect(fetchResp).To(BeAssignableToTypeOf(&ListFetchHit{}))
-				Expect(fetchResp).To(HaveListLength(3))
-				switch result := fetchResp.(type) {
-				case *ListFetchHit:
-					Expect(result.ValueList()).To(Equal([]string{"100", "101", "102"}))
-				}
-			})
+					fetchResp, err := client.ListFetch(sharedContext.Ctx, &ListFetchRequest{
+						CacheName: cacheName,
+						ListName:  sharedContext.CollectionName,
+					})
+					Expect(err).To(BeNil())
+					Expect(fetchResp).To(BeAssignableToTypeOf(&ListFetchHit{}))
+					Expect(fetchResp).To(HaveListLength(3))
+					switch result := fetchResp.(type) {
+					case *ListFetchHit:
+						Expect(result.ValueList()).To(Equal([]string{"100", "101", "102"}))
+					}
+				},
+				Entry("with default client", DefaultClient),
+				Entry("with client with default cache", WithDefaultCache),
+			)
 
 			It("returns an invalid argument for a nil value", func() {
 				populateList(sharedContext, 5)
@@ -477,29 +527,34 @@ var _ = Describe("List methods", func() {
 
 		When("popping from the front of the list", func() {
 
-			It("pops strings and bytes on the happy path", func() {
-				numItems := 5
-				expected := populateList(sharedContext, numItems)
+			DescribeTable("pops strings and bytes on the happy path",
+				func(clientType string) {
+					client, cacheName := sharedContext.GetClientPrereqsForType(clientType)
+					numItems := 5
+					expected := populateList(sharedContext, numItems)
 
-				popResp, err := sharedContext.Client.ListPopFront(sharedContext.Ctx, &ListPopFrontRequest{
-					CacheName: sharedContext.CacheName,
-					ListName:  sharedContext.CollectionName,
-				})
-				Expect(err).To(BeNil())
-				switch result := popResp.(type) {
-				case *ListPopFrontHit:
-					Expect(result.ValueString()).To(Equal(string(expected[0])))
-				default:
-					Fail("expected a hit from list pop front but got a miss")
-				}
+					popResp, err := client.ListPopFront(sharedContext.Ctx, &ListPopFrontRequest{
+						CacheName: cacheName,
+						ListName:  sharedContext.CollectionName,
+					})
+					Expect(err).To(BeNil())
+					switch result := popResp.(type) {
+					case *ListPopFrontHit:
+						Expect(result.ValueString()).To(Equal(string(expected[0])))
+					default:
+						Fail("expected a hit from list pop front but got a miss")
+					}
 
-				fetchResp, err := sharedContext.Client.ListFetch(sharedContext.Ctx, &ListFetchRequest{
-					CacheName: sharedContext.CacheName,
-					ListName:  sharedContext.CollectionName,
-				})
-				Expect(err).To(BeNil())
-				Expect(fetchResp).To(HaveListLength(numItems - 1))
-			})
+					fetchResp, err := client.ListFetch(sharedContext.Ctx, &ListFetchRequest{
+						CacheName: cacheName,
+						ListName:  sharedContext.CollectionName,
+					})
+					Expect(err).To(BeNil())
+					Expect(fetchResp).To(HaveListLength(numItems - 1))
+				},
+				Entry("with default client", DefaultClient),
+				Entry("with client with default cache", WithDefaultCache),
+			)
 
 			It("returns a miss after popping the last item", func() {
 				numItems := 3
@@ -524,29 +579,34 @@ var _ = Describe("List methods", func() {
 
 		When("popping from the back of the list", func() {
 
-			It("pops strings and bytes on the happy path", func() {
-				numItems := 5
-				expected := populateList(sharedContext, numItems)
+			DescribeTable("pops strings and bytes on the happy path",
+				func(clientType string) {
+					client, cacheName := sharedContext.GetClientPrereqsForType(clientType)
+					numItems := 5
+					expected := populateList(sharedContext, numItems)
 
-				popResp, err := sharedContext.Client.ListPopBack(sharedContext.Ctx, &ListPopBackRequest{
-					CacheName: sharedContext.CacheName,
-					ListName:  sharedContext.CollectionName,
-				})
-				Expect(err).To(BeNil())
-				switch result := popResp.(type) {
-				case *ListPopBackHit:
-					Expect(result.ValueString()).To(Equal(string(expected[numItems-1])))
-				default:
-					Fail("expected a hit from list pop front but got a miss")
-				}
+					popResp, err := client.ListPopBack(sharedContext.Ctx, &ListPopBackRequest{
+						CacheName: cacheName,
+						ListName:  sharedContext.CollectionName,
+					})
+					Expect(err).To(BeNil())
+					switch result := popResp.(type) {
+					case *ListPopBackHit:
+						Expect(result.ValueString()).To(Equal(string(expected[numItems-1])))
+					default:
+						Fail("expected a hit from list pop front but got a miss")
+					}
 
-				fetchResp, err := sharedContext.Client.ListFetch(sharedContext.Ctx, &ListFetchRequest{
-					CacheName: sharedContext.CacheName,
-					ListName:  sharedContext.CollectionName,
-				})
-				Expect(err).To(BeNil())
-				Expect(fetchResp).To(HaveListLength(numItems - 1))
-			})
+					fetchResp, err := client.ListFetch(sharedContext.Ctx, &ListFetchRequest{
+						CacheName: cacheName,
+						ListName:  sharedContext.CollectionName,
+					})
+					Expect(err).To(BeNil())
+					Expect(fetchResp).To(HaveListLength(numItems - 1))
+				},
+				Entry("with default client", DefaultClient),
+				Entry("with client with default cache", WithDefaultCache),
+			)
 
 			It("returns a miss after popping the last item", func() {
 				numItems := 3
@@ -575,29 +635,34 @@ var _ = Describe("List methods", func() {
 
 		When("removing a value that appears once", func() {
 
-			It("removes the value", func() {
-				numItems := 5
-				expected := populateList(sharedContext, numItems)
-				Expect(
-					sharedContext.Client.ListRemoveValue(sharedContext.Ctx, &ListRemoveValueRequest{
-						CacheName: sharedContext.CacheName,
-						ListName:  sharedContext.CollectionName,
-						Value:     String(expected[0]),
-					}),
-				).Error().To(BeNil())
+			DescribeTable("removes the value",
+				func(clientType string) {
+					client, cacheName := sharedContext.GetClientPrereqsForType(clientType)
+					numItems := 5
+					expected := populateList(sharedContext, numItems)
+					Expect(
+						client.ListRemoveValue(sharedContext.Ctx, &ListRemoveValueRequest{
+							CacheName: cacheName,
+							ListName:  sharedContext.CollectionName,
+							Value:     String(expected[0]),
+						}),
+					).Error().To(BeNil())
 
-				fetchResp, err := sharedContext.Client.ListFetch(sharedContext.Ctx, &ListFetchRequest{
-					CacheName: sharedContext.CacheName,
-					ListName:  sharedContext.CollectionName,
-				})
-				Expect(err).To(BeNil())
-				switch result := fetchResp.(type) {
-				case *ListFetchHit:
-					Expect(result.ValueList()).To(Equal(expected[1:]))
-				default:
-					Fail("expected a hit for list fetch but got a miss")
-				}
-			})
+					fetchResp, err := client.ListFetch(sharedContext.Ctx, &ListFetchRequest{
+						CacheName: cacheName,
+						ListName:  sharedContext.CollectionName,
+					})
+					Expect(err).To(BeNil())
+					switch result := fetchResp.(type) {
+					case *ListFetchHit:
+						Expect(result.ValueList()).To(Equal(expected[1:]))
+					default:
+						Fail("expected a hit for list fetch but got a miss")
+					}
+				},
+				Entry("with default client", DefaultClient),
+				Entry("with client with default cache", WithDefaultCache),
+			)
 
 			It("returns an error for a nil value", func() {
 				Expect(
@@ -645,38 +710,43 @@ var _ = Describe("List methods", func() {
 
 		When("removing a value that appears multiple times", func() {
 
-			It("removes all occurrences of the value", func() {
-				numItems := 5
-				populateList(sharedContext, numItems)
-				toAdd := []Value{String("#4"), String("#4"), String("#4"), String("#0")}
-				Expect(
-					sharedContext.Client.ListConcatenateBack(sharedContext.Ctx, &ListConcatenateBackRequest{
-						CacheName: sharedContext.CacheName,
-						ListName:  sharedContext.CollectionName,
-						Values:    toAdd,
-					}),
-				).To(BeAssignableToTypeOf(&ListConcatenateBackSuccess{}))
+			DescribeTable("removes all occurrences of the value",
+				func(clientType string) {
+					client, cacheName := sharedContext.GetClientPrereqsForType(clientType)
+					numItems := 5
+					populateList(sharedContext, numItems)
+					toAdd := []Value{String("#4"), String("#4"), String("#4"), String("#0")}
+					Expect(
+						client.ListConcatenateBack(sharedContext.Ctx, &ListConcatenateBackRequest{
+							CacheName: cacheName,
+							ListName:  sharedContext.CollectionName,
+							Values:    toAdd,
+						}),
+					).To(BeAssignableToTypeOf(&ListConcatenateBackSuccess{}))
 
-				Expect(
-					sharedContext.Client.ListRemoveValue(sharedContext.Ctx, &ListRemoveValueRequest{
-						CacheName: sharedContext.CacheName,
-						ListName:  sharedContext.CollectionName,
-						Value:     String("#4"),
-					}),
-				).To(BeAssignableToTypeOf(&ListRemoveValueSuccess{}))
+					Expect(
+						client.ListRemoveValue(sharedContext.Ctx, &ListRemoveValueRequest{
+							CacheName: cacheName,
+							ListName:  sharedContext.CollectionName,
+							Value:     String("#4"),
+						}),
+					).To(BeAssignableToTypeOf(&ListRemoveValueSuccess{}))
 
-				fetchResp, err := sharedContext.Client.ListFetch(sharedContext.Ctx, &ListFetchRequest{
-					CacheName: sharedContext.CacheName,
-					ListName:  sharedContext.CollectionName,
-				})
-				Expect(err).To(BeNil())
-				switch result := fetchResp.(type) {
-				case *ListFetchHit:
-					Expect(result.ValueList()).To(Equal([]string{"#0", "#1", "#2", "#3", "#0"}))
-				default:
-					Fail("expected a hit from list fetch but got a miss")
-				}
-			})
+					fetchResp, err := client.ListFetch(sharedContext.Ctx, &ListFetchRequest{
+						CacheName: cacheName,
+						ListName:  sharedContext.CollectionName,
+					})
+					Expect(err).To(BeNil())
+					switch result := fetchResp.(type) {
+					case *ListFetchHit:
+						Expect(result.ValueList()).To(Equal([]string{"#0", "#1", "#2", "#3", "#0"}))
+					default:
+						Fail("expected a hit from list fetch but got a miss")
+					}
+				},
+				Entry("with default client", DefaultClient),
+				Entry("with client with default cache", WithDefaultCache),
+			)
 
 			It("returns an error for a nil value", func() {
 				Expect(
@@ -692,25 +762,29 @@ var _ = Describe("List methods", func() {
 
 		When("removing a value that isn't in the list", func() {
 
-			It("returns success", func() {
-				numItems := 5
-				populateList(sharedContext, numItems)
-				Expect(
-					sharedContext.Client.ListRemoveValue(sharedContext.Ctx, &ListRemoveValueRequest{
-						CacheName: sharedContext.CacheName,
+			DescribeTable("returns success",
+				func(clientType string) {
+					client, cacheName := sharedContext.GetClientPrereqsForType(clientType)
+					numItems := 5
+					populateList(sharedContext, numItems)
+					Expect(
+						client.ListRemoveValue(sharedContext.Ctx, &ListRemoveValueRequest{
+							CacheName: cacheName,
+							ListName:  sharedContext.CollectionName,
+							Value:     String("iamnotinthelist"),
+						}),
+					).To(BeAssignableToTypeOf(&ListRemoveValueSuccess{}))
+
+					fetchResp, err := client.ListFetch(sharedContext.Ctx, &ListFetchRequest{
+						CacheName: cacheName,
 						ListName:  sharedContext.CollectionName,
-						Value:     String("iamnotinthelist"),
-					}),
-				).To(BeAssignableToTypeOf(&ListRemoveValueSuccess{}))
-
-				fetchResp, err := sharedContext.Client.ListFetch(sharedContext.Ctx, &ListFetchRequest{
-					CacheName: sharedContext.CacheName,
-					ListName:  sharedContext.CollectionName,
-				})
-				Expect(err).To(BeNil())
-				Expect(fetchResp).To(HaveListLength(numItems))
-			})
-
+					})
+					Expect(err).To(BeNil())
+					Expect(fetchResp).To(HaveListLength(numItems))
+				},
+				Entry("with default client", DefaultClient),
+				Entry("with client with default cache", WithDefaultCache),
+			)
 		})
 
 		When("removing from a nonexistent list", func() {

--- a/momento/ping_test.go
+++ b/momento/ping_test.go
@@ -12,7 +12,7 @@ var _ = Describe("ping", func() {
 
 	BeforeEach(func() {
 		sharedContext = NewSharedContext()
-		sharedContext.CreateDefaultCache()
+		sharedContext.CreateDefaultCaches()
 		DeferCleanup(func() {
 			sharedContext.Close()
 		})

--- a/momento/scalar_test.go
+++ b/momento/scalar_test.go
@@ -172,9 +172,8 @@ var _ = Describe("Scalar methods", func() {
 		Entry("With default client and an empty cache name", DefaultClient, "", String("key"), String("value")),
 		Entry("With default client and  an bank cache name", DefaultClient, "   ", String("key"), String("value")),
 		Entry("With default client and  an empty key", DefaultClient, uuid.NewString(), String(""), String("value")),
-		Entry("With client with default cache and an empty cache name", WithDefaultCache, "", String("key"), String("value")),
-		Entry("With client with default cache and  an bank cache name", WithDefaultCache, "   ", String("key"), String("value")),
-		Entry("With client with default cache and  an empty key", WithDefaultCache, uuid.NewString(), String(""), String("value")),
+		Entry("With client with default cache and an bank cache name", WithDefaultCache, "   ", String("key"), String("value")),
+		Entry("With client with default cache and an empty key", WithDefaultCache, uuid.NewString(), String(""), String("value")),
 	)
 
 	Describe("Set", func() {

--- a/momento/scalar_test.go
+++ b/momento/scalar_test.go
@@ -17,23 +17,24 @@ var _ = Describe("Scalar methods", func() {
 	var sharedContext SharedContext
 	BeforeEach(func() {
 		sharedContext = NewSharedContext()
-		sharedContext.CreateDefaultCache()
+		sharedContext.CreateDefaultCaches()
 
 		DeferCleanup(func() { sharedContext.Close() })
 	})
 
-	DescribeTable(`Gets, Sets, and Deletes`,
-		func(key Key, value Value, expectedString string, expectedBytes []byte) {
+	DescribeTable("Gets, Sets, and Deletes",
+		func(clientType string, key Key, value Value, expectedString string, expectedBytes []byte) {
+			client, cacheName := sharedContext.GetClientPrereqsForType(clientType)
 			Expect(
-				sharedContext.Client.Set(sharedContext.Ctx, &SetRequest{
-					CacheName: sharedContext.CacheName,
+				client.Set(sharedContext.Ctx, &SetRequest{
+					CacheName: cacheName,
 					Key:       key,
 					Value:     value,
 				}),
 			).To(BeAssignableToTypeOf(&SetSuccess{}))
 
-			getResp, err := sharedContext.Client.Get(sharedContext.Ctx, &GetRequest{
-				CacheName: sharedContext.CacheName,
+			getResp, err := client.Get(sharedContext.Ctx, &GetRequest{
+				CacheName: cacheName,
 				Key:       key,
 			})
 			Expect(err).To(BeNil())
@@ -47,93 +48,113 @@ var _ = Describe("Scalar methods", func() {
 			}
 
 			Expect(
-				sharedContext.Client.Delete(sharedContext.Ctx, &DeleteRequest{
-					CacheName: sharedContext.CacheName,
+				client.Delete(sharedContext.Ctx, &DeleteRequest{
+					CacheName: cacheName,
 					Key:       key,
 				}),
 			).To(BeAssignableToTypeOf(&DeleteSuccess{}))
 
 			Expect(
-				sharedContext.Client.Get(sharedContext.Ctx, &GetRequest{
-					CacheName: sharedContext.CacheName,
+				client.Get(sharedContext.Ctx, &GetRequest{
+					CacheName: cacheName,
 					Key:       key,
 				}),
 			).To(BeAssignableToTypeOf(&GetMiss{}))
 		},
-		Entry("when the key and value are strings", String("key"), String("value"), "value", []byte("value")),
-		Entry("when the key and value are bytes", Bytes([]byte{1, 2, 3}), Bytes([]byte("string")), "string", []byte("string")),
-		Entry("when the value is empty", String("key"), String(""), "", []byte("")),
-		Entry("when the value is blank", String("key"), String("  "), "  ", []byte("  ")),
+		Entry("when the key and value are strings", DefaultClient, String("key"), String("value"), "value", []byte("value")),
+		Entry("when the key and value are bytes", DefaultClient, Bytes([]byte{1, 2, 3}), Bytes("string"), "string", []byte("string")),
+		Entry("when the value is empty", DefaultClient, String("key"), String(""), "", []byte("")),
+		Entry("when the value is blank", DefaultClient, String("key"), String("  "), "  ", []byte("  ")),
+		Entry("with default cache name when the key and value are strings", WithDefaultCache, String("key"), String("value"), "value", []byte("value")),
+		Entry("with default cache name when the key and value are bytes", WithDefaultCache, Bytes([]byte{1, 2, 3}), Bytes("string"), "string", []byte("string")),
+		Entry("with default cache name when the value is empty", WithDefaultCache, String("key"), String(""), "", []byte("")),
+		Entry("with default cache name when the value is blank", WithDefaultCache, String("key"), String("  "), "  ", []byte("  ")),
 	)
 
-	It(`errors when the cache is missing`, func() {
-		cacheName := uuid.NewString()
-		key := String("key")
-		value := String("value")
+	DescribeTable("errors when the cache is missing",
+		func(clientType string) {
+			client, _ := sharedContext.GetClientPrereqsForType(clientType)
+			cacheName := uuid.NewString()
+			key := String("key")
+			value := String("value")
 
-		getResp, err := sharedContext.Client.Get(sharedContext.Ctx, &GetRequest{
-			CacheName: cacheName,
-			Key:       key,
-		})
-		Expect(getResp).To(BeNil())
-		Expect(err).To(HaveMomentoErrorCode(NotFoundError))
+			getResp, err := client.Get(sharedContext.Ctx, &GetRequest{
+				CacheName: cacheName,
+				Key:       key,
+			})
+			Expect(getResp).To(BeNil())
+			Expect(err).To(HaveMomentoErrorCode(NotFoundError))
 
-		setResp, err := sharedContext.Client.Set(sharedContext.Ctx, &SetRequest{
-			CacheName: cacheName,
-			Key:       key,
-			Value:     value,
-		})
-		Expect(setResp).To(BeNil())
-		Expect(err).To(HaveMomentoErrorCode(NotFoundError))
+			setResp, err := client.Set(sharedContext.Ctx, &SetRequest{
+				CacheName: cacheName,
+				Key:       key,
+				Value:     value,
+			})
+			Expect(setResp).To(BeNil())
+			Expect(err).To(HaveMomentoErrorCode(NotFoundError))
 
-		deleteResp, err := sharedContext.Client.Delete(sharedContext.Ctx, &DeleteRequest{
-			CacheName: cacheName,
-			Key:       key,
-		})
-		Expect(deleteResp).To(BeNil())
-		Expect(err).To(HaveMomentoErrorCode(NotFoundError))
-	})
+			deleteResp, err := client.Delete(sharedContext.Ctx, &DeleteRequest{
+				CacheName: cacheName,
+				Key:       key,
+			})
+			Expect(deleteResp).To(BeNil())
+			Expect(err).To(HaveMomentoErrorCode(NotFoundError))
+		},
+		Entry("with default client", DefaultClient),
+		Entry("with client with default cache", WithDefaultCache),
+	)
 
-	It(`errors when the key is nil`, func() {
-		Expect(
-			sharedContext.Client.Get(sharedContext.Ctx, &GetRequest{
-				CacheName: sharedContext.CacheName,
-				Key:       nil,
-			}),
-		).Error().To(HaveMomentoErrorCode(InvalidArgumentError))
-		Expect(
-			sharedContext.Client.Set(sharedContext.Ctx, &SetRequest{
-				CacheName: sharedContext.CacheName,
-				Key:       nil,
-			}),
-		).Error().To(HaveMomentoErrorCode(InvalidArgumentError))
-		Expect(
-			sharedContext.Client.Delete(sharedContext.Ctx, &DeleteRequest{
-				CacheName: sharedContext.CacheName,
-				Key:       nil,
-			}),
-		).Error().To(HaveMomentoErrorCode(InvalidArgumentError))
-	})
+	DescribeTable("errors when the key is nil",
+		func(clientType string) {
+			client, cacheName := sharedContext.GetClientPrereqsForType(clientType)
+			Expect(
+				client.Get(sharedContext.Ctx, &GetRequest{
+					CacheName: cacheName,
+					Key:       nil,
+				}),
+			).Error().To(HaveMomentoErrorCode(InvalidArgumentError))
+			Expect(
+				client.Set(sharedContext.Ctx, &SetRequest{
+					CacheName: cacheName,
+					Key:       nil,
+				}),
+			).Error().To(HaveMomentoErrorCode(InvalidArgumentError))
+			Expect(
+				client.Delete(sharedContext.Ctx, &DeleteRequest{
+					CacheName: cacheName,
+					Key:       nil,
+				}),
+			).Error().To(HaveMomentoErrorCode(InvalidArgumentError))
+		},
+		Entry("with default client", DefaultClient),
+		Entry("with client with default cache", WithDefaultCache),
+	)
 
-	It("returns a miss when the key doesn't exist", func() {
-		Expect(
-			sharedContext.Client.Get(sharedContext.Ctx, &GetRequest{
-				CacheName: sharedContext.CacheName,
-				Key:       String(uuid.NewString()),
-			}),
-		).To(BeAssignableToTypeOf(&GetMiss{}))
-	})
+	DescribeTable("returns a miss when the key doesn't exist",
+		func(clientType string) {
+			client, cacheName := sharedContext.GetClientPrereqsForType(clientType)
+			Expect(
+				client.Get(sharedContext.Ctx, &GetRequest{
+					CacheName: cacheName,
+					Key:       String(uuid.NewString()),
+				}),
+			).To(BeAssignableToTypeOf(&GetMiss{}))
+		},
+		Entry("with default client", DefaultClient),
+		Entry("with client with default cache", WithDefaultCache),
+	)
 
-	DescribeTable(`invalid cache names and keys`,
-		func(cacheName string, key Key, value Key) {
-			getResp, err := sharedContext.Client.Get(sharedContext.Ctx, &GetRequest{
+	DescribeTable("invalid cache names and keys",
+		func(clientType string, cacheName string, key Key, value Key) {
+			client, _ := sharedContext.GetClientPrereqsForType(clientType)
+			getResp, err := client.Get(sharedContext.Ctx, &GetRequest{
 				CacheName: cacheName,
 				Key:       key,
 			})
 			Expect(getResp).To(BeNil())
 			Expect(err).To(HaveMomentoErrorCode(InvalidArgumentError))
 
-			setResp, err := sharedContext.Client.Set(sharedContext.Ctx, &SetRequest{
+			setResp, err := client.Set(sharedContext.Ctx, &SetRequest{
 				CacheName: cacheName,
 				Key:       key,
 				Value:     value,
@@ -141,20 +162,23 @@ var _ = Describe("Scalar methods", func() {
 			Expect(setResp).To(BeNil())
 			Expect(err).To(HaveMomentoErrorCode(InvalidArgumentError))
 
-			deleteResp, err := sharedContext.Client.Delete(sharedContext.Ctx, &DeleteRequest{
+			deleteResp, err := client.Delete(sharedContext.Ctx, &DeleteRequest{
 				CacheName: cacheName,
 				Key:       key,
 			})
 			Expect(deleteResp).To(BeNil())
 			Expect(err).To(HaveMomentoErrorCode(InvalidArgumentError))
 		},
-		Entry(`With an empty cache name`, "", String("key"), String("value")),
-		Entry(`With an bank cache name`, "   ", String("key"), String("value")),
-		Entry(`With an empty key`, uuid.NewString(), String(""), String("value")),
+		Entry("With default client and an empty cache name", DefaultClient, "", String("key"), String("value")),
+		Entry("With default client and  an bank cache name", DefaultClient, "   ", String("key"), String("value")),
+		Entry("With default client and  an empty key", DefaultClient, uuid.NewString(), String(""), String("value")),
+		Entry("With client with default cache and an empty cache name", WithDefaultCache, "", String("key"), String("value")),
+		Entry("With client with default cache and  an bank cache name", WithDefaultCache, "   ", String("key"), String("value")),
+		Entry("With client with default cache and  an empty key", WithDefaultCache, uuid.NewString(), String(""), String("value")),
 	)
 
-	Describe(`Set`, func() {
-		It(`Uses the default TTL`, func() {
+	Describe("Set", func() {
+		It("Uses the default TTL", func() {
 			key := String("key")
 			value := String("value")
 
@@ -185,7 +209,7 @@ var _ = Describe("Scalar methods", func() {
 			).To(BeAssignableToTypeOf(&GetMiss{}))
 		})
 
-		It(`Overrides the default TTL`, func() {
+		It("Overrides the default TTL", func() {
 			key := String("key")
 			value := String("value")
 
@@ -250,13 +274,20 @@ var _ = Describe("Scalar methods", func() {
 						Value:     String(strVal),
 					}),
 				).To(BeAssignableToTypeOf(&SetSuccess{}))
+				Expect(
+					sharedContext.ClientWithDefaultCacheName.Set(sharedContext.Ctx, &SetRequest{
+						Key:   String(strKey),
+						Value: String(strVal),
+					}),
+				).To(BeAssignableToTypeOf(&SetSuccess{}))
 			}
 		})
 
 		DescribeTable("check for valid keys exist results",
-			func(toCheck []Key, expected []bool) {
-				resp, err := sharedContext.Client.KeysExist(sharedContext.Ctx, &KeysExistRequest{
-					CacheName: sharedContext.CacheName,
+			func(clientType string, toCheck []Key, expected []bool) {
+				client, cacheName := sharedContext.GetClientPrereqsForType(clientType)
+				resp, err := client.KeysExist(sharedContext.Ctx, &KeysExistRequest{
+					CacheName: cacheName,
 					Keys:      toCheck,
 				})
 				Expect(err).To(BeNil())
@@ -267,105 +298,124 @@ var _ = Describe("Scalar methods", func() {
 					Fail(fmt.Sprintf("expected keys exist success but got %s", result))
 				}
 			},
-			Entry("all hits", []Key{String("#1"), String("#2")}, []bool{true, true}),
-			Entry("all misses", []Key{String("nope"), String("stillnope")}, []bool{false, false}),
-			Entry("mixed", []Key{String("nope"), String("#1")}, []bool{false, true}),
+			Entry("all hits", DefaultClient, []Key{String("#1"), String("#2")}, []bool{true, true}),
+			Entry("all misses", DefaultClient, []Key{String("nope"), String("stillnope")}, []bool{false, false}),
+			Entry("mixed", DefaultClient, []Key{String("nope"), String("#1")}, []bool{false, true}),
+			Entry("all hits with default cache", WithDefaultCache, []Key{String("#1"), String("#2")}, []bool{true, true}),
+			Entry("all misses with default cache", WithDefaultCache, []Key{String("nope"), String("stillnope")}, []bool{false, false}),
+			Entry("mixed with default cache", WithDefaultCache, []Key{String("nope"), String("#1")}, []bool{false, true}),
 		)
 	})
 
-	Describe(`UpdateTtl`, func() {
-		It(`Overwrites Ttl`, func() {
-			key := String("key")
-			value := String("value")
+	Describe("UpdateTtl", func() {
+		DescribeTable("Overwrites Ttl",
+			func(clientType string) {
+				client, cacheName := sharedContext.GetClientPrereqsForType(clientType)
+				key := String("key")
+				value := String("value")
 
-			Expect(
-				sharedContext.Client.Set(sharedContext.Ctx, &SetRequest{
-					CacheName: sharedContext.CacheName,
-					Key:       key,
-					Value:     value,
-				}),
-			).To(BeAssignableToTypeOf(&SetSuccess{}))
+				Expect(
+					client.Set(sharedContext.Ctx, &SetRequest{
+						CacheName: cacheName,
+						Key:       key,
+						Value:     value,
+					}),
+				).To(BeAssignableToTypeOf(&SetSuccess{}))
 
-			Expect(
-				sharedContext.Client.UpdateTtl(sharedContext.Ctx, &UpdateTtlRequest{
-					CacheName: sharedContext.CacheName,
-					Key:       key,
-					Ttl:       6 * time.Second,
-				}),
-			).To(BeAssignableToTypeOf(&UpdateTtlSet{}))
+				Expect(
+					client.UpdateTtl(sharedContext.Ctx, &UpdateTtlRequest{
+						CacheName: cacheName,
+						Key:       key,
+						Ttl:       6 * time.Second,
+					}),
+				).To(BeAssignableToTypeOf(&UpdateTtlSet{}))
 
-			time.Sleep(sharedContext.DefaultTtl)
+				time.Sleep(sharedContext.DefaultTtl)
 
-			Expect(
-				sharedContext.Client.Get(sharedContext.Ctx, &GetRequest{
-					CacheName: sharedContext.CacheName,
-					Key:       key,
-				}),
-			).To(BeAssignableToTypeOf(&GetHit{}))
-		})
+				Expect(
+					client.Get(sharedContext.Ctx, &GetRequest{
+						CacheName: cacheName,
+						Key:       key,
+					}),
+				).To(BeAssignableToTypeOf(&GetHit{}))
+			},
+			Entry("with default client", DefaultClient),
+			Entry("with client with default cache", WithDefaultCache),
+		)
 
-		It(`Increases Ttl`, func() {
-			key := String("key")
-			value := String("value")
+		DescribeTable("Increases Ttl",
+			func(clientType string) {
+				client, cacheName := sharedContext.GetClientPrereqsForType(clientType)
+				key := String("key")
+				value := String("value")
 
-			Expect(
-				sharedContext.Client.Set(sharedContext.Ctx, &SetRequest{
-					CacheName: sharedContext.CacheName,
-					Key:       key,
-					Value:     value,
-					Ttl:       2 * time.Second,
-				}),
-			).To(BeAssignableToTypeOf(&SetSuccess{}))
+				Expect(
+					client.Set(sharedContext.Ctx, &SetRequest{
+						CacheName: cacheName,
+						Key:       key,
+						Value:     value,
+						Ttl:       2 * time.Second,
+					}),
+				).To(BeAssignableToTypeOf(&SetSuccess{}))
 
-			Expect(
-				sharedContext.Client.IncreaseTtl(sharedContext.Ctx, &IncreaseTtlRequest{
-					CacheName: sharedContext.CacheName,
-					Key:       key,
-					Ttl:       3 * time.Second,
-				}),
-			).To(BeAssignableToTypeOf(&IncreaseTtlSet{}))
+				Expect(
+					client.IncreaseTtl(sharedContext.Ctx, &IncreaseTtlRequest{
+						CacheName: cacheName,
+						Key:       key,
+						Ttl:       3 * time.Second,
+					}),
+				).To(BeAssignableToTypeOf(&IncreaseTtlSet{}))
 
-			time.Sleep(2 * time.Second)
+				time.Sleep(2 * time.Second)
 
-			Expect(
-				sharedContext.Client.Get(sharedContext.Ctx, &GetRequest{
-					CacheName: sharedContext.CacheName,
-					Key:       key,
-				}),
-			).To(BeAssignableToTypeOf(&GetHit{}))
-		})
+				Expect(
+					client.Get(sharedContext.Ctx, &GetRequest{
+						CacheName: cacheName,
+						Key:       key,
+					}),
+				).To(BeAssignableToTypeOf(&GetHit{}))
+			},
+			Entry("with default client", DefaultClient),
+			Entry("with client with default cache", WithDefaultCache),
+		)
 
-		It(`Decreases Ttl`, func() {
-			key := String("key")
-			value := String("value")
+		DescribeTable("Decreases Ttl",
+			func(clientType string) {
+				client, cacheName := sharedContext.GetClientPrereqsForType(clientType)
 
-			Expect(
-				sharedContext.Client.Set(sharedContext.Ctx, &SetRequest{
-					CacheName: sharedContext.CacheName,
-					Key:       key,
-					Value:     value,
-				}),
-			).To(BeAssignableToTypeOf(&SetSuccess{}))
+				key := String("key")
+				value := String("value")
 
-			Expect(
-				sharedContext.Client.DecreaseTtl(sharedContext.Ctx, &DecreaseTtlRequest{
-					CacheName: sharedContext.CacheName,
-					Key:       key,
-					Ttl:       2 * time.Second,
-				}),
-			).To(BeAssignableToTypeOf(&DecreaseTtlSet{}))
+				Expect(
+					client.Set(sharedContext.Ctx, &SetRequest{
+						CacheName: cacheName,
+						Key:       key,
+						Value:     value,
+					}),
+				).To(BeAssignableToTypeOf(&SetSuccess{}))
 
-			time.Sleep(2 * time.Second)
+				Expect(
+					client.DecreaseTtl(sharedContext.Ctx, &DecreaseTtlRequest{
+						CacheName: cacheName,
+						Key:       key,
+						Ttl:       2 * time.Second,
+					}),
+				).To(BeAssignableToTypeOf(&DecreaseTtlSet{}))
 
-			Expect(
-				sharedContext.Client.Get(sharedContext.Ctx, &GetRequest{
-					CacheName: sharedContext.CacheName,
-					Key:       key,
-				}),
-			).To(BeAssignableToTypeOf(&GetMiss{}))
-		})
+				time.Sleep(2 * time.Second)
 
-		It(`Returns InvalidArgumentError with negative or zero Ttl value for UpdateTtl`, func() {
+				Expect(
+					client.Get(sharedContext.Ctx, &GetRequest{
+						CacheName: cacheName,
+						Key:       key,
+					}),
+				).To(BeAssignableToTypeOf(&GetMiss{}))
+			},
+			Entry("with default client", DefaultClient),
+			Entry("with client with default cache", WithDefaultCache),
+		)
+
+		It("Returns InvalidArgumentError with negative or zero Ttl value for UpdateTtl", func() {
 			key := String("key")
 			value := String("value")
 
@@ -394,7 +444,7 @@ var _ = Describe("Scalar methods", func() {
 			).Error().To(HaveMomentoErrorCode(InvalidArgumentError))
 		})
 
-		It(`Returns InvalidArgumentError with negative or zero Ttl value for IncreaseTtl`, func() {
+		It("Returns InvalidArgumentError with negative or zero Ttl value for IncreaseTtl", func() {
 			key := String("key")
 			value := String("value")
 
@@ -423,7 +473,7 @@ var _ = Describe("Scalar methods", func() {
 			).Error().To(HaveMomentoErrorCode(InvalidArgumentError))
 		})
 
-		It(`Returns InvalidArgumentError with negative or zero Ttl value for DecreaseTtl`, func() {
+		It("Returns InvalidArgumentError with negative or zero Ttl value for DecreaseTtl", func() {
 			key := String("key")
 			value := String("value")
 
@@ -452,7 +502,7 @@ var _ = Describe("Scalar methods", func() {
 			).Error().To(HaveMomentoErrorCode(InvalidArgumentError))
 		})
 
-		It(`Returns UpdateTtlMiss when a key doesn't exist`, func() {
+		It("Returns UpdateTtlMiss when a key doesn't exist", func() {
 			Expect(
 				sharedContext.Client.UpdateTtl(sharedContext.Ctx, &UpdateTtlRequest{
 					CacheName: sharedContext.CacheName,
@@ -462,7 +512,7 @@ var _ = Describe("Scalar methods", func() {
 			).To(BeAssignableToTypeOf(&UpdateTtlMiss{}))
 		})
 
-		It(`Returns IncreaseTtlMiss when a key doesn't exist`, func() {
+		It("Returns IncreaseTtlMiss when a key doesn't exist", func() {
 			Expect(
 				sharedContext.Client.IncreaseTtl(sharedContext.Ctx, &IncreaseTtlRequest{
 					CacheName: sharedContext.CacheName,
@@ -472,7 +522,7 @@ var _ = Describe("Scalar methods", func() {
 			).To(BeAssignableToTypeOf(&IncreaseTtlMiss{}))
 		})
 
-		It(`Returns DecreaseTtlMiss when a key doesn't exist`, func() {
+		It("Returns DecreaseTtlMiss when a key doesn't exist", func() {
 			Expect(
 				sharedContext.Client.DecreaseTtl(sharedContext.Ctx, &DecreaseTtlRequest{
 					CacheName: sharedContext.CacheName,

--- a/momento/set_test.go
+++ b/momento/set_test.go
@@ -27,7 +27,7 @@ var _ = Describe("Set methods", func() {
 
 	BeforeEach(func() {
 		sharedContext = NewSharedContext()
-		sharedContext.CreateDefaultCache()
+		sharedContext.CreateDefaultCaches()
 		DeferCleanup(func() {
 			sharedContext.Close()
 		})

--- a/momento/set_test.go
+++ b/momento/set_test.go
@@ -199,56 +199,56 @@ var _ = Describe("Set methods", func() {
 				}
 			},
 			Entry(
-				"when elements are strings",
+				"with default client when elements are strings",
 				DefaultClient,
 				[]Value{String("hello"), String("world"), String("!"), String("␆")},
 				[]string{"hello", "world", "!", "␆"},
 				[][]byte{[]byte("hello"), []byte("world"), []byte("!"), []byte("␆")},
 			),
 			Entry(
-				"when elements are bytes",
+				"with default client when elements are bytes",
 				DefaultClient,
 				[]Value{Bytes([]byte("hello")), Bytes([]byte("world")), Bytes([]byte("!")), Bytes([]byte("␆"))},
 				[]string{"hello", "world", "!", "␆"},
 				[][]byte{[]byte("hello"), []byte("world"), []byte("!"), []byte("␆")},
 			),
 			Entry(
-				"when elements are mixed",
+				"with default client when elements are mixed",
 				DefaultClient,
 				[]Value{Bytes([]byte("hello")), String([]byte("world")), Bytes([]byte("!")), String([]byte("␆"))},
 				[]string{"hello", "world", "!", "␆"},
 				[][]byte{[]byte("hello"), []byte("world"), []byte("!"), []byte("␆")},
 			),
 			Entry(
-				"when elements are empty",
+				"with default client when elements are empty",
 				DefaultClient,
 				[]Value{Bytes([]byte("")), Bytes([]byte(""))},
 				[]string{""},
 				[][]byte{[]byte("")},
 			),
 			Entry(
-				"when elements are strings",
+				"with client with default cache when elements are strings",
 				WithDefaultCache,
 				[]Value{String("hello"), String("world"), String("!"), String("␆")},
 				[]string{"hello", "world", "!", "␆"},
 				[][]byte{[]byte("hello"), []byte("world"), []byte("!"), []byte("␆")},
 			),
 			Entry(
-				"when elements are bytes",
+				"with client with default cache when elements are bytes",
 				WithDefaultCache,
 				[]Value{Bytes([]byte("hello")), Bytes([]byte("world")), Bytes([]byte("!")), Bytes([]byte("␆"))},
 				[]string{"hello", "world", "!", "␆"},
 				[][]byte{[]byte("hello"), []byte("world"), []byte("!"), []byte("␆")},
 			),
 			Entry(
-				"when elements are mixed",
+				"with client with default cache when elements are mixed",
 				WithDefaultCache,
 				[]Value{Bytes([]byte("hello")), String([]byte("world")), Bytes([]byte("!")), String([]byte("␆"))},
 				[]string{"hello", "world", "!", "␆"},
 				[][]byte{[]byte("hello"), []byte("world"), []byte("!"), []byte("␆")},
 			),
 			Entry(
-				"when elements are empty",
+				"with client with default cache when elements are empty",
 				WithDefaultCache,
 				[]Value{Bytes([]byte("")), Bytes([]byte(""))},
 				[]string{""},
@@ -327,12 +327,12 @@ var _ = Describe("Set methods", func() {
 					Fail("something really weird happened")
 				}
 			},
-			Entry("as string", DefaultClient, String("#5"), 9),
-			Entry("as bytes", DefaultClient, Bytes([]byte("#5")), 9),
-			Entry("unmatched", DefaultClient, String("notvalid"), 10),
-			Entry("as string", WithDefaultCache, String("#5"), 9),
-			Entry("as bytes", WithDefaultCache, Bytes([]byte("#5")), 9),
-			Entry("unmatched", WithDefaultCache, String("notvalid"), 10),
+			Entry("with default client as string", DefaultClient, String("#5"), 9),
+			Entry("with default client as bytes", DefaultClient, Bytes([]byte("#5")), 9),
+			Entry("with default client unmatched", DefaultClient, String("notvalid"), 10),
+			Entry("with client with default cache as string", WithDefaultCache, String("#5"), 9),
+			Entry("with client with default cache as bytes", WithDefaultCache, Bytes([]byte("#5")), 9),
+			Entry("with client with default cache unmatched", WithDefaultCache, String("notvalid"), 10),
 		)
 
 		DescribeTable("multiple elements as strings and bytes",
@@ -359,12 +359,12 @@ var _ = Describe("Set methods", func() {
 					Fail("something really weird happened")
 				}
 			},
-			Entry("as strings", DefaultClient, getElements(5), 5),
-			Entry("as bytes", DefaultClient, []Value{Bytes("#3"), Bytes("#4")}, 8),
-			Entry("unmatched", DefaultClient, []Value{String("notvalid")}, 10),
-			Entry("as strings", WithDefaultCache, getElements(5), 5),
-			Entry("as bytes", WithDefaultCache, []Value{Bytes("#3"), Bytes("#4")}, 8),
-			Entry("unmatched", WithDefaultCache, []Value{String("notvalid")}, 10),
+			Entry("with default client as strings", DefaultClient, getElements(5), 5),
+			Entry("with default client as bytes", DefaultClient, []Value{Bytes("#3"), Bytes("#4")}, 8),
+			Entry("with default client unmatched", DefaultClient, []Value{String("notvalid")}, 10),
+			Entry("with client with default cache as strings", WithDefaultCache, getElements(5), 5),
+			Entry("with client with default cache as bytes", WithDefaultCache, []Value{Bytes("#3"), Bytes("#4")}, 8),
+			Entry("with client with default cache unmatched", WithDefaultCache, []Value{String("notvalid")}, 10),
 		)
 
 		It("returns an error when trying to remove nil elements", func() {
@@ -429,12 +429,12 @@ var _ = Describe("Set methods", func() {
 					Expect(result.ContainsElements()).To(Equal(expected))
 				}
 			},
-			Entry("all hits", DefaultClient, []Value{String("#1"), String("#2"), String("#3")}, []bool{true, true, true}),
-			Entry("all misses", DefaultClient, []Value{String("not"), String("this"), String("time")}, []bool{false, false, false}),
-			Entry("a mixture", DefaultClient, []Value{String("not"), String("#2"), String("time")}, []bool{false, true, false}),
-			Entry("all hits", WithDefaultCache, []Value{String("#1"), String("#2"), String("#3")}, []bool{true, true, true}),
-			Entry("all misses", WithDefaultCache, []Value{String("not"), String("this"), String("time")}, []bool{false, false, false}),
-			Entry("a mixture", WithDefaultCache, []Value{String("not"), String("#2"), String("time")}, []bool{false, true, false}),
+			Entry("with default client all hits", DefaultClient, []Value{String("#1"), String("#2"), String("#3")}, []bool{true, true, true}),
+			Entry("with default client all misses", DefaultClient, []Value{String("not"), String("this"), String("time")}, []bool{false, false, false}),
+			Entry("with default client a mixture", DefaultClient, []Value{String("not"), String("#2"), String("time")}, []bool{false, true, false}),
+			Entry("with client with default cache all hits", WithDefaultCache, []Value{String("#1"), String("#2"), String("#3")}, []bool{true, true, true}),
+			Entry("with client with default cache all misses", WithDefaultCache, []Value{String("not"), String("this"), String("time")}, []bool{false, false, false}),
+			Entry("with client with default cache a mixture", WithDefaultCache, []Value{String("not"), String("#2"), String("time")}, []bool{false, true, false}),
 		)
 
 		It("gets a miss on a nonexistent set", func() {

--- a/momento/sorted_set_test.go
+++ b/momento/sorted_set_test.go
@@ -18,7 +18,7 @@ var _ = Describe("SortedSet", func() {
 	var sharedContext SharedContext
 	BeforeEach(func() {
 		sharedContext = NewSharedContext()
-		sharedContext.CreateDefaultCache()
+		sharedContext.CreateDefaultCaches()
 
 		DeferCleanup(func() { sharedContext.Close() })
 	})

--- a/momento/sorted_set_test.go
+++ b/momento/sorted_set_test.go
@@ -128,16 +128,16 @@ var _ = Describe("SortedSet", func() {
 				}),
 			).Error().To(HaveMomentoErrorCode(expectedError))
 		},
-		Entry("Empty cache name", DefaultClient, "", sharedContext.CollectionName, InvalidArgumentError),
-		Entry("Blank cache name", DefaultClient, "  ", sharedContext.CollectionName, InvalidArgumentError),
-		Entry("Empty collection name", DefaultClient, sharedContext.CacheName, "", InvalidArgumentError),
-		Entry("Blank collection name", DefaultClient, sharedContext.CacheName, "  ", InvalidArgumentError),
-		Entry("Non-existent cache", DefaultClient, uuid.NewString(), uuid.NewString(), NotFoundError),
-		Entry("Empty cache name", WithDefaultCache, "", sharedContext.CollectionName, InvalidArgumentError),
-		Entry("Blank cache name", WithDefaultCache, "  ", sharedContext.CollectionName, InvalidArgumentError),
-		Entry("Empty collection name", WithDefaultCache, sharedContext.CacheName, "", InvalidArgumentError),
-		Entry("Blank collection name", WithDefaultCache, sharedContext.CacheName, "  ", InvalidArgumentError),
-		Entry("Non-existent cache", WithDefaultCache, uuid.NewString(), uuid.NewString(), NotFoundError),
+		Entry("Empty cache name with default client", DefaultClient, "", sharedContext.CollectionName, InvalidArgumentError),
+		Entry("Blank cache name with default client", DefaultClient, "  ", sharedContext.CollectionName, InvalidArgumentError),
+		Entry("Empty collection name with default client", DefaultClient, sharedContext.CacheName, "", InvalidArgumentError),
+		Entry("Blank collection name with default client", DefaultClient, sharedContext.CacheName, "  ", InvalidArgumentError),
+		Entry("Non-existent cache with default client", DefaultClient, uuid.NewString(), uuid.NewString(), NotFoundError),
+		Entry("Empty cache name with client with default cache", WithDefaultCache, "", sharedContext.CollectionName, InvalidArgumentError),
+		Entry("Blank cache name with client with default cache", WithDefaultCache, "  ", sharedContext.CollectionName, InvalidArgumentError),
+		Entry("Empty collection name with client with default cache", WithDefaultCache, sharedContext.CacheName, "", InvalidArgumentError),
+		Entry("Blank collection name with client with default cache", WithDefaultCache, sharedContext.CacheName, "  ", InvalidArgumentError),
+		Entry("Non-existent cache with client with default cache", WithDefaultCache, uuid.NewString(), uuid.NewString(), NotFoundError),
 	)
 
 	DescribeTable("Honors CollectionTtl  ",
@@ -1011,10 +1011,10 @@ var _ = Describe("SortedSet", func() {
 					Expect(fetchResp.ValueBytesElements()).To(Equal(expected))
 				}
 			},
-			Entry("string value", DefaultClient, String("aString"), 42.0, []SortedSetBytesElement{{Value: []byte("aString"), Score: 42}}),
-			Entry("bytes value", DefaultClient, Bytes("aString"), 42.0, []SortedSetBytesElement{{Value: []byte("aString"), Score: 42}}),
-			Entry("string value", WithDefaultCache, String("aString"), 42.0, []SortedSetBytesElement{{Value: []byte("aString"), Score: 42}}),
-			Entry("bytes value", WithDefaultCache, Bytes("aString"), 42.0, []SortedSetBytesElement{{Value: []byte("aString"), Score: 42}}),
+			Entry("string value with default client", DefaultClient, String("aString"), 42.0, []SortedSetBytesElement{{Value: []byte("aString"), Score: 42}}),
+			Entry("bytes value with default client", DefaultClient, Bytes("aString"), 42.0, []SortedSetBytesElement{{Value: []byte("aString"), Score: 42}}),
+			Entry("string value with client with default cache", WithDefaultCache, String("aString"), 42.0, []SortedSetBytesElement{{Value: []byte("aString"), Score: 42}}),
+			Entry("bytes value with client with default cache", WithDefaultCache, Bytes("aString"), 42.0, []SortedSetBytesElement{{Value: []byte("aString"), Score: 42}}),
 		)
 
 		It("overwrites an existing element's score", func() {

--- a/momento/topic_client_test.go
+++ b/momento/topic_client_test.go
@@ -17,7 +17,7 @@ var _ = Describe("Pubsub", func() {
 
 	BeforeEach(func() {
 		sharedContext = NewSharedContext()
-		sharedContext.CreateDefaultCache()
+		sharedContext.CreateDefaultCaches()
 
 		DeferCleanup(func() {
 			sharedContext.Close()


### PR DESCRIPTION
This commit adds testing for `CacheClient` instances created using the `NewCacheClientWithDefaultCache` constructor. It focuses on happy path test cases to ensure that the default cache is used when `CacheName` is empty or omitted and that the default cache is overridden when `CacheName` is specified.