### PR TITLE
feat: add support to resubscribe to topics on disconnect

### DIFF
--- a/config/logger/momento_default_logger/momento-default-logger.go
+++ b/config/logger/momento_default_logger/momento-default-logger.go
@@ -59,7 +59,7 @@ func momentoLog(level LogLevel, loggerName string, message string, args ...strin
 		anyArgs[i] = v
 	}
 	finalMessage := fmt.Sprintf(message, anyArgs...)
-	log.Printf("[%s] %d (%s): %s\n", time.RFC3339, level, loggerName, finalMessage)
+	log.Printf("[%s] %d (%s): %s\n", time.Now().UTC().Format(time.RFC3339), level, loggerName, finalMessage)
 }
 
 type DefaultMomentoLoggerFactory struct {

--- a/config/logger/momento_default_logger/momento-default-logger.go
+++ b/config/logger/momento_default_logger/momento-default-logger.go
@@ -24,42 +24,42 @@ type DefaultMomentoLogger struct {
 }
 
 func (l *DefaultMomentoLogger) Trace(message string, args ...string) {
-	if l.level >= TRACE {
-		momentoLog(l.level, l.loggerName, message, args...)
+	if l.level <= TRACE {
+		momentoLog("TRACE", l.loggerName, message, args...)
 	}
 }
 
 func (l *DefaultMomentoLogger) Debug(message string, args ...string) {
-	if l.level >= DEBUG {
-		momentoLog(l.level, l.loggerName, message, args...)
+	if l.level <= DEBUG {
+		momentoLog("DEBUG", l.loggerName, message, args...)
 	}
 }
 
 func (l *DefaultMomentoLogger) Info(message string, args ...string) {
-	if l.level >= INFO {
-		momentoLog(l.level, l.loggerName, message, args...)
+	if l.level <= INFO {
+		momentoLog("INFO", l.loggerName, message, args...)
 	}
 }
 
 func (l *DefaultMomentoLogger) Warn(message string, args ...string) {
-	if l.level >= WARN {
-		momentoLog(l.level, l.loggerName, message, args...)
+	if l.level <= WARN {
+		momentoLog("WARN", l.loggerName, message, args...)
 	}
 }
 
 func (l *DefaultMomentoLogger) Error(message string, args ...string) {
-	if l.level >= ERROR {
-		momentoLog(l.level, l.loggerName, message, args...)
+	if l.level <= ERROR {
+		momentoLog("ERROR", l.loggerName, message, args...)
 	}
 }
 
-func momentoLog(level LogLevel, loggerName string, message string, args ...string) {
+func momentoLog(level string, loggerName string, message string, args ...string) {
 	anyArgs := make([]any, len(args))
 	for i, v := range args {
 		anyArgs[i] = v
 	}
 	finalMessage := fmt.Sprintf(message, anyArgs...)
-	log.Printf("[%s] %d (%s): %s\n", time.Now().UTC().Format(time.RFC3339), level, loggerName, finalMessage)
+	log.Printf("[%s] %s (%s): %s\n", time.Now().UTC().Format(time.RFC3339), level, loggerName, finalMessage)
 }
 
 type DefaultMomentoLoggerFactory struct {

--- a/examples/pubsub-example/main.go
+++ b/examples/pubsub-example/main.go
@@ -102,6 +102,6 @@ func publishMessages(client momento.TopicClient, ctx context.Context) {
 		if err != nil {
 			panic(err)
 		}
-		time.Sleep(5 * time.Second)
+		time.Sleep(time.Second)
 	}
 }

--- a/examples/pubsub-example/main.go
+++ b/examples/pubsub-example/main.go
@@ -92,7 +92,7 @@ func setupCache(client momento.CacheClient, ctx context.Context) {
 }
 
 func publishMessages(client momento.TopicClient, ctx context.Context) {
-	for i := 0; i < 10; i++ {
+	for i := 0; i < 100; i++ {
 		fmt.Printf("publishing message %d\n", i)
 		_, err := client.Publish(ctx, &momento.TopicPublishRequest{
 			CacheName: cacheName,
@@ -102,6 +102,6 @@ func publishMessages(client momento.TopicClient, ctx context.Context) {
 		if err != nil {
 			panic(err)
 		}
-		time.Sleep(time.Second)
+		time.Sleep(5 * time.Second)
 	}
 }

--- a/internal/grpcmanagers/data_manager.go
+++ b/internal/grpcmanagers/data_manager.go
@@ -45,7 +45,7 @@ func NewStreamDataGrpcManager(request *models.DataStreamGrpcManagerRequest) (*Da
 	conn, err := grpc.Dial(
 		endpoint,
 		grpc.WithTransportCredentials(credentials.NewTLS(config)),
-		grpc.WithChainStreamInterceptor(interceptor.StreamInterceptor(request.RetryStrategy), interceptor.AddStreamHeaderInterceptor(authToken)),
+		grpc.WithChainStreamInterceptor(interceptor.StreamRetryInterceptor(request.RetryStrategy), interceptor.AddStreamHeaderInterceptor(authToken)),
 	)
 
 	if err != nil {

--- a/internal/grpcmanagers/data_manager.go
+++ b/internal/grpcmanagers/data_manager.go
@@ -28,8 +28,7 @@ func NewUnaryDataGrpcManager(request *models.DataGrpcManagerRequest) (*DataGrpcM
 	conn, err := grpc.Dial(
 		endpoint,
 		grpc.WithTransportCredentials(credentials.NewTLS(config)),
-		grpc.WithUnaryInterceptor(interceptor.AddUnaryRetryInterceptor(request.RetryStrategy)),
-		grpc.WithUnaryInterceptor(interceptor.AddHeadersInterceptor(authToken)),
+		grpc.WithChainUnaryInterceptor(interceptor.AddUnaryRetryInterceptor(request.RetryStrategy), interceptor.AddHeadersInterceptor(authToken)),
 	)
 	if err != nil {
 		return nil, momentoerrors.ConvertSvcErr(err)
@@ -46,9 +45,9 @@ func NewStreamDataGrpcManager(request *models.DataStreamGrpcManagerRequest) (*Da
 	conn, err := grpc.Dial(
 		endpoint,
 		grpc.WithTransportCredentials(credentials.NewTLS(config)),
-		grpc.WithDisableRetry(),
-		grpc.WithStreamInterceptor(interceptor.AddStreamHeaderInterceptor(authToken)),
+		grpc.WithChainStreamInterceptor(interceptor.StreamInterceptor(request.RetryStrategy), interceptor.AddStreamHeaderInterceptor(authToken)),
 	)
+
 	if err != nil {
 		return nil, momentoerrors.ConvertSvcErr(err)
 	}
@@ -61,6 +60,7 @@ func NewLocalDataGrpcManager(request *models.LocalDataGrpcManagerRequest) (*Data
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
 		grpc.WithDisableRetry(),
 	)
+	
 	if err != nil {
 		return nil, momentoerrors.ConvertSvcErr(err)
 	}

--- a/internal/grpcmanagers/data_manager.go
+++ b/internal/grpcmanagers/data_manager.go
@@ -60,7 +60,7 @@ func NewLocalDataGrpcManager(request *models.LocalDataGrpcManagerRequest) (*Data
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
 		grpc.WithDisableRetry(),
 	)
-	
+
 	if err != nil {
 		return nil, momentoerrors.ConvertSvcErr(err)
 	}

--- a/internal/grpcmanagers/data_manager.go
+++ b/internal/grpcmanagers/data_manager.go
@@ -45,7 +45,7 @@ func NewStreamDataGrpcManager(request *models.DataStreamGrpcManagerRequest) (*Da
 	conn, err := grpc.Dial(
 		endpoint,
 		grpc.WithTransportCredentials(credentials.NewTLS(config)),
-		grpc.WithChainStreamInterceptor(interceptor.StreamRetryInterceptor(request.RetryStrategy), interceptor.AddStreamHeaderInterceptor(authToken)),
+		grpc.WithChainStreamInterceptor(interceptor.AddStreamHeaderInterceptor(authToken)),
 	)
 
 	if err != nil {

--- a/internal/interceptor/stream_retry_interceptor.go
+++ b/internal/interceptor/stream_retry_interceptor.go
@@ -9,8 +9,8 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-// streamInterceptor is an example stream interceptor.
-func StreamInterceptor(retryStrat retry.Strategy) func(ctx context.Context, desc *grpc.StreamDesc, cc *grpc.ClientConn, method string, streamer grpc.Streamer, opts ...grpc.CallOption) (grpc.ClientStream, error) {
+// StreamInterceptor is an interceptor that handles retries for streaming apis
+func StreamRetryInterceptor(retryStrat retry.Strategy) func(ctx context.Context, desc *grpc.StreamDesc, cc *grpc.ClientConn, method string, streamer grpc.Streamer, opts ...grpc.CallOption) (grpc.ClientStream, error) {
 	return func(ctx context.Context, desc *grpc.StreamDesc, cc *grpc.ClientConn, method string, streamer grpc.Streamer, opts ...grpc.CallOption) (grpc.ClientStream, error) {
 		attempt := 1
 		for {

--- a/internal/interceptor/stream_retry_interceptor.go
+++ b/internal/interceptor/stream_retry_interceptor.go
@@ -16,11 +16,14 @@ func StreamRetryInterceptor(retryStrat retry.Strategy) func(ctx context.Context,
 		for {
 			s, lastErr := streamer(ctx, desc, cc, method, opts...)
 			if lastErr == nil {
-				// Success no error returned stop interceptor
+				// Successfully connected the stream. If we wanted to get fancy here, we could return 
+				// a struct that implements the Stream interface, and wraps the SendMsg and ReceiveMsg function
+				// calls. Since we only care about retrying on subscribe, we just return the stream here
+				// ex. https://github.com/grpc/grpc-go/blob/7a7caf363d9b33bfa5ddac83e7dab744f695fb5b/examples/features/interceptor/server/main.go#L106-L141
 				return s, nil
 			}
 
-			// Check retry eligibility based off last error received
+			// Unable to connect to the stream, checking retry eligibility based off last error received
 			retryBackoffTime := retryStrat.DetermineWhenToRetry(retry.StrategyProps{
 				GrpcStatusCode: status.Code(lastErr),
 				GrpcMethod:     method,

--- a/internal/interceptor/stream_retry_interceptor.go
+++ b/internal/interceptor/stream_retry_interceptor.go
@@ -16,7 +16,7 @@ func StreamRetryInterceptor(retryStrat retry.Strategy) func(ctx context.Context,
 		for {
 			s, lastErr := streamer(ctx, desc, cc, method, opts...)
 			if lastErr == nil {
-				// Successfully connected the stream. If we wanted to get fancy here, we could return 
+				// Successfully connected the stream. If we wanted to get fancy here, we could return
 				// a struct that implements the Stream interface, and wraps the SendMsg and ReceiveMsg function
 				// calls. Since we only care about retrying on subscribe, we just return the stream here
 				// ex. https://github.com/grpc/grpc-go/blob/7a7caf363d9b33bfa5ddac83e7dab744f695fb5b/examples/features/interceptor/server/main.go#L106-L141

--- a/internal/interceptor/stream_retry_interceptor.go
+++ b/internal/interceptor/stream_retry_interceptor.go
@@ -1,0 +1,42 @@
+package interceptor
+
+import (
+	"context"
+	"time"
+
+	"github.com/momentohq/client-sdk-go/internal/retry"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/status"
+)
+
+// streamInterceptor is an example stream interceptor.
+func StreamInterceptor(retryStrat retry.Strategy) func (ctx context.Context, desc *grpc.StreamDesc, cc *grpc.ClientConn, method string, streamer grpc.Streamer, opts ...grpc.CallOption) (grpc.ClientStream, error) {
+	return func (ctx context.Context, desc *grpc.StreamDesc, cc *grpc.ClientConn, method string, streamer grpc.Streamer, opts ...grpc.CallOption) (grpc.ClientStream, error) {
+		attempt := 1
+		for {
+			s, lastErr := streamer(ctx, desc, cc, method, opts...)
+			if lastErr == nil {
+				// Success no error returned stop interceptor
+				return s, nil
+			}
+
+			// Check retry eligibility based off last error received
+			retryBackoffTime := retryStrat.DetermineWhenToRetry(retry.StrategyProps{
+				GrpcStatusCode: status.Code(lastErr),
+				GrpcMethod:     method,
+				AttemptNumber:  attempt,
+			})
+
+			if retryBackoffTime == nil {
+				// If nil backoff time don't retry just return last error received
+				return nil, lastErr
+			}
+
+			// Sleep for recommended time interval and increment attempts before trying again
+			if *retryBackoffTime > 0 {
+				time.Sleep(time.Duration(*retryBackoffTime) * time.Second)
+			}
+			attempt++
+		}
+	}
+}

--- a/internal/interceptor/stream_retry_interceptor.go
+++ b/internal/interceptor/stream_retry_interceptor.go
@@ -10,8 +10,8 @@ import (
 )
 
 // streamInterceptor is an example stream interceptor.
-func StreamInterceptor(retryStrat retry.Strategy) func (ctx context.Context, desc *grpc.StreamDesc, cc *grpc.ClientConn, method string, streamer grpc.Streamer, opts ...grpc.CallOption) (grpc.ClientStream, error) {
-	return func (ctx context.Context, desc *grpc.StreamDesc, cc *grpc.ClientConn, method string, streamer grpc.Streamer, opts ...grpc.CallOption) (grpc.ClientStream, error) {
+func StreamInterceptor(retryStrat retry.Strategy) func(ctx context.Context, desc *grpc.StreamDesc, cc *grpc.ClientConn, method string, streamer grpc.Streamer, opts ...grpc.CallOption) (grpc.ClientStream, error) {
+	return func(ctx context.Context, desc *grpc.StreamDesc, cc *grpc.ClientConn, method string, streamer grpc.Streamer, opts ...grpc.CallOption) (grpc.ClientStream, error) {
 		attempt := 1
 		for {
 			s, lastErr := streamer(ctx, desc, cc, method, opts...)

--- a/internal/models/requests.go
+++ b/internal/models/requests.go
@@ -21,7 +21,6 @@ type DataGrpcManagerRequest struct {
 
 type DataStreamGrpcManagerRequest struct {
 	CredentialProvider auth.CredentialProvider
-	RetryStrategy      retry.Strategy
 }
 
 type PingGrpcManagerRequest struct {

--- a/internal/models/requests.go
+++ b/internal/models/requests.go
@@ -21,6 +21,7 @@ type DataGrpcManagerRequest struct {
 
 type DataStreamGrpcManagerRequest struct {
 	CredentialProvider auth.CredentialProvider
+	RetryStrategy      retry.Strategy
 }
 
 type PingGrpcManagerRequest struct {

--- a/internal/retry/eligibility_strategy.go
+++ b/internal/retry/eligibility_strategy.go
@@ -40,6 +40,7 @@ var retryableRequestMethods = map[string]bool{
 	"/cache_client.Scs/ListLength": true,
 	// not idempotent: "/cache_client.Scs/ListConcatenateFront",
 	// not idempotent: "/cache_client.Scs/ListConcatenateBack"
+	"/cache_client.pubsub.Pubsub/Subscribe": true,
 }
 
 type DefaultEligibilityStrategy struct{}

--- a/momento/pubsub_client.go
+++ b/momento/pubsub_client.go
@@ -22,6 +22,7 @@ type pubSubClient struct {
 func newPubSubClient(request *models.PubSubClientRequest) (*pubSubClient, momentoerrors.MomentoSvcErr) {
 	streamDataManager, err := grpcmanagers.NewStreamDataGrpcManager(&models.DataStreamGrpcManagerRequest{
 		CredentialProvider: request.CredentialProvider,
+		RetryStrategy:      request.Configuration.GetRetryStrategy(),
 	})
 	if err != nil {
 		return nil, err

--- a/momento/pubsub_client.go
+++ b/momento/pubsub_client.go
@@ -44,8 +44,8 @@ func newPubSubClient(request *models.PubSubClientRequest) (*pubSubClient, moment
 
 func (client *pubSubClient) TopicSubscribe(ctx context.Context, request *TopicSubscribeRequest) (grpc.ClientStream, error) {
 	streamClient, err := client.streamGrpcClient.Subscribe(ctx, &pb.XSubscriptionRequest{
-		CacheName: request.CacheName,
-		Topic:     request.TopicName,
+		CacheName:                   request.CacheName,
+		Topic:                       request.TopicName,
 		ResumeAtTopicSequenceNumber: request.ResumeAtTopicSequenceNumber,
 	})
 	return streamClient, err

--- a/momento/pubsub_client.go
+++ b/momento/pubsub_client.go
@@ -22,7 +22,6 @@ type pubSubClient struct {
 func newPubSubClient(request *models.PubSubClientRequest) (*pubSubClient, momentoerrors.MomentoSvcErr) {
 	streamDataManager, err := grpcmanagers.NewStreamDataGrpcManager(&models.DataStreamGrpcManagerRequest{
 		CredentialProvider: request.CredentialProvider,
-		RetryStrategy:      request.Configuration.GetRetryStrategy(),
 	})
 	if err != nil {
 		return nil, err

--- a/momento/pubsub_client.go
+++ b/momento/pubsub_client.go
@@ -46,7 +46,7 @@ func (client *pubSubClient) TopicSubscribe(ctx context.Context, request *TopicSu
 	streamClient, err := client.streamGrpcClient.Subscribe(ctx, &pb.XSubscriptionRequest{
 		CacheName: request.CacheName,
 		Topic:     request.TopicName,
-		//ResumeAtTopicSequenceNumber: 0, TODO think about re-establish topic case
+		ResumeAtTopicSequenceNumber: request.ResumeAtTopicSequenceNumber,
 	})
 	return streamClient, err
 }

--- a/momento/topic_client.go
+++ b/momento/topic_client.go
@@ -118,6 +118,7 @@ func (c defaultTopicClient) Publish(ctx context.Context, request *TopicPublishRe
 	})
 
 	if err != nil {
+		c.log.Debug("failed to topic publish...")
 		return nil, momentoerrors.ConvertSvcErr(err)
 	}
 

--- a/momento/topic_subscribe.go
+++ b/momento/topic_subscribe.go
@@ -1,8 +1,8 @@
 package momento
 
 type TopicSubscribeRequest struct {
-	CacheName string
-	TopicName string
+	CacheName                   string
+	TopicName                   string
 	ResumeAtTopicSequenceNumber uint64
 }
 

--- a/momento/topic_subscribe.go
+++ b/momento/topic_subscribe.go
@@ -3,6 +3,7 @@ package momento
 type TopicSubscribeRequest struct {
 	CacheName string
 	TopicName string
+	ResumeAtTopicSequenceNumber uint64
 }
 
 func (r TopicSubscribeRequest) cacheName() string { return r.CacheName }

--- a/momento/topic_subscription.go
+++ b/momento/topic_subscription.go
@@ -63,7 +63,7 @@ func (s *topicSubscription) attemptReconnect(ctx context.Context) {
 	ticker := time.NewTicker(seconds)
 	for{
 		s.log.Debug("Attempting reconnecting to client stream")
-		_ = <-ticker.C
+		<-ticker.C
 		newStream, err := s.momentoTopicClient.TopicSubscribe(ctx, &TopicSubscribeRequest{
 			CacheName: s.cacheName,
 			TopicName: s.topicName,

--- a/momento/topic_subscription.go
+++ b/momento/topic_subscription.go
@@ -63,21 +63,19 @@ func (s *topicSubscription) attemptReconnect(ctx context.Context) {
 	ticker := time.NewTicker(seconds)
 	for{
 		s.log.Debug("Attempting reconnecting to client stream")
-		select {
-		case <- ticker.C:
-			newStream, err := s.momentoTopicClient.TopicSubscribe(ctx, &TopicSubscribeRequest{
-				CacheName: s.cacheName,
-				TopicName: s.topicName,
-				ResumeAtTopicSequenceNumber: s.lastKnownSequenceNumber,
-			})
+		_ = <-ticker.C
+		newStream, err := s.momentoTopicClient.TopicSubscribe(ctx, &TopicSubscribeRequest{
+			CacheName: s.cacheName,
+			TopicName: s.topicName,
+			ResumeAtTopicSequenceNumber: s.lastKnownSequenceNumber,
+		})
 
-			if err != nil {
-				s.log.Debug("failed to reconnect to stream, will continue to try in %s seconds", fmt.Sprint(seconds))
-			} else {
-				s.log.Debug("successfully reconnected to subscription stream")
-				s.grpcClient = newStream
-				return
-			}
+		if err != nil {
+			s.log.Debug("failed to reconnect to stream, will continue to try in %s seconds", fmt.Sprint(seconds))
+		} else {
+			s.log.Debug("successfully reconnected to subscription stream")
+			s.grpcClient = newStream
+			return
 		}
 	}
 }

--- a/momento/topic_subscription.go
+++ b/momento/topic_subscription.go
@@ -3,15 +3,12 @@ package momento
 import (
 	"context"
 	"fmt"
-	"io"
+	"time"
 
 	"github.com/momentohq/client-sdk-go/config/logger"
-	"github.com/momentohq/client-sdk-go/internal/momentoerrors"
 	pb "github.com/momentohq/client-sdk-go/internal/protos"
 
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 )
 
 type TopicSubscription interface {
@@ -19,26 +16,30 @@ type TopicSubscription interface {
 }
 
 type topicSubscription struct {
-	grpcClient         grpc.ClientStream
-	momentoTopicClient *pubSubClient
-	cacheName          string
-	topicName          string
-	log                logger.MomentoLogger
+	grpcClient         		grpc.ClientStream
+	momentoTopicClient 		*pubSubClient
+	cacheName          		string
+	topicName          		string
+	log                		logger.MomentoLogger
+	lastKnownSequenceNumber uint64
 }
 
 func (s *topicSubscription) Item(ctx context.Context) (TopicValue, error) {
 	for {
 		rawMsg := new(pb.XSubscriptionItem)
 		if err := s.grpcClient.RecvMsg(rawMsg); err != nil {
-			err := s.handleStreamError(ctx, err)
-			if err != nil {
-				return nil, err
-			}
-		} else {
-			switch typedMsg := rawMsg.Kind.(type) {
+			s.log.Error("stream disconnected, attempting to reconnect err:", fmt.Sprint(err))
+			s.attemptReconnect(ctx)
+			// retry getting the latest item
+			continue
+		}
+
+		switch typedMsg := rawMsg.Kind.(type) {
 			case *pb.XSubscriptionItem_Discontinuity:
+				s.log.Debug("recieved discontinuity item")
 				continue
 			case *pb.XSubscriptionItem_Item:
+				s.lastKnownSequenceNumber = typedMsg.Item.GetTopicSequenceNumber()
 				switch subscriptionItem := typedMsg.Item.Value.Kind.(type) {
 				case *pb.XTopicValue_Text:
 					return String(subscriptionItem.Text), nil
@@ -46,48 +47,37 @@ func (s *topicSubscription) Item(ctx context.Context) (TopicValue, error) {
 					return Bytes(subscriptionItem.Binary), nil
 				}
 			case *pb.XSubscriptionItem_Heartbeat:
+				s.log.Debug("recieved heartbeat item")
 				continue
 			default:
 				s.log.Trace("Unrecognized response detected.",
 					"response", fmt.Sprint(typedMsg))
 				continue
+		}
+	}
+}
+
+func (s *topicSubscription) attemptReconnect(ctx context.Context) {
+	// try and reconnect every n seconds. This will attempt to reconnect indefinetly
+	seconds := 5 * time.Second
+	ticker := time.NewTicker(seconds)
+	for{
+		s.log.Debug("Attempting reconnecting to client stream")
+		select {
+		case <- ticker.C:
+			newStream, err := s.momentoTopicClient.TopicSubscribe(ctx, &TopicSubscribeRequest{
+				CacheName: s.cacheName,
+				TopicName: s.topicName,
+				ResumeAtTopicSequenceNumber: s.lastKnownSequenceNumber,
+			})
+
+			if err != nil {
+				s.log.Debug("failed to reconnect to stream, will continue to try in %s seconds", fmt.Sprint(seconds))
+			} else {
+				s.log.Debug("successfully reconnected to subscription stream")
+				s.grpcClient = newStream
+				return
 			}
 		}
 	}
-}
-
-func (s *topicSubscription) handleStreamError(ctx context.Context, err error) error {
-	var returnErr error
-	if err == io.EOF {
-		returnErr = s.reInitStream(ctx)
-	} else if grpcStatusErr, ok := status.FromError(err); ok {
-		// FIXME ideally we could retry on raw h2 error not grpc error
-		// See this ticket for follow up https://github.com/momentohq/client-sdk-go/issues/156
-		if grpcStatusErr.Code() == codes.Internal &&
-			grpcStatusErr.Message() == "stream terminated by RST_STREAM with error code: NO_ERROR" {
-
-			returnErr = s.reInitStream(ctx)
-
-		}
-	}
-	if returnErr != nil {
-		return momentoerrors.NewMomentoSvcErr(
-			momentoerrors.InternalServerError,
-			"Fatal error getting item from topic",
-			err,
-		)
-	}
-	return nil
-}
-
-func (s *topicSubscription) reInitStream(ctx context.Context) error {
-	newStream, err := s.momentoTopicClient.TopicSubscribe(ctx, &TopicSubscribeRequest{
-		CacheName: s.cacheName,
-		TopicName: s.topicName,
-	})
-	if err != nil {
-		return err
-	}
-	s.grpcClient = newStream
-	return nil
 }


### PR DESCRIPTION
- fixes logging format to correctly display timestamp closes #319 
- fixes logging to correctly log traces vs debug vs error ..., and log level string instead of number
- ~~adds stream retry interceptor to retry `subscribe` api call~~
- implements "indefinite retry" for subscriptions who are cancelled
- adds debug logging around stream reconnection