### PR TITLE
feat: enable multiple subscription channels

### DIFF
--- a/config/topics_config.go
+++ b/config/topics_config.go
@@ -5,25 +5,46 @@ import (
 )
 
 type topicsConfiguration struct {
-	loggerFactory logger.MomentoLoggerFactory
+	loggerFactory    logger.MomentoLoggerFactory
+	maxSubscriptions uint32
 }
 
 type TopicsConfigurationProps struct {
 	// LoggerFactory represents a type used to configure the Momento logging system.
 	LoggerFactory logger.MomentoLoggerFactory
+
+	MaxSubscriptions uint32
 }
 
 type TopicsConfiguration interface {
 	// GetLoggerFactory Returns the current configuration options for logging verbosity and format
 	GetLoggerFactory() logger.MomentoLoggerFactory
+
+	// GetMaxSubscriptions Returns the configuration option for the maximum number of subscriptions
+	// a client is allowed
+	GetMaxSubscriptions() uint32
+
+	WithMaxSubscriptions(maxSubscriptions uint32) TopicsConfiguration
 }
 
 func NewTopicConfiguration(props *TopicsConfigurationProps) TopicsConfiguration {
 	return &topicsConfiguration{
-		loggerFactory: props.LoggerFactory,
+		loggerFactory:    props.LoggerFactory,
+		maxSubscriptions: props.MaxSubscriptions,
 	}
 }
 
 func (s *topicsConfiguration) GetLoggerFactory() logger.MomentoLoggerFactory {
 	return s.loggerFactory
+}
+
+func (s *topicsConfiguration) GetMaxSubscriptions() uint32 {
+	return s.maxSubscriptions
+}
+
+func (s *topicsConfiguration) WithMaxSubscriptions(maxSubscriptions uint32) TopicsConfiguration {
+	return &topicsConfiguration{
+		loggerFactory:    s.loggerFactory,
+		maxSubscriptions: maxSubscriptions,
+	}
 }

--- a/config/topics_configurations.go
+++ b/config/topics_configurations.go
@@ -7,7 +7,7 @@ import (
 	"github.com/momentohq/client-sdk-go/config/logger"
 )
 
-// TopicsDefailt provides defaults configuration for a Topic Client
+// TopicsDefault provides defaults configuration for a Topic Client
 func TopicsDefault() TopicsConfiguration {
 	return TopicsDefaultWithLogger(momento_default_logger.NewDefaultMomentoLoggerFactory(momento_default_logger.INFO))
 }

--- a/internal/grpcmanagers/data_manager.go
+++ b/internal/grpcmanagers/data_manager.go
@@ -7,7 +7,6 @@ import (
 	"github.com/momentohq/client-sdk-go/internal/interceptor"
 	"github.com/momentohq/client-sdk-go/internal/models"
 	"github.com/momentohq/client-sdk-go/internal/momentoerrors"
-
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"

--- a/internal/grpcmanagers/topic_manager.go
+++ b/internal/grpcmanagers/topic_manager.go
@@ -1,0 +1,43 @@
+package grpcmanagers
+
+import (
+	"crypto/tls"
+	"fmt"
+
+	"github.com/momentohq/client-sdk-go/internal/interceptor"
+	"github.com/momentohq/client-sdk-go/internal/models"
+	"github.com/momentohq/client-sdk-go/internal/momentoerrors"
+	pb "github.com/momentohq/client-sdk-go/internal/protos"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+)
+
+type TopicGrpcManager struct {
+	Conn         *grpc.ClientConn
+	StreamClient pb.PubsubClient
+}
+
+func NewStreamTopicGrpcManager(request *models.TopicStreamGrpcManagerRequest) (*TopicGrpcManager, momentoerrors.MomentoSvcErr) {
+	config := &tls.Config{
+		InsecureSkipVerify: false,
+	}
+	endpoint := fmt.Sprint(request.CredentialProvider.GetCacheEndpoint(), CachePort)
+	authToken := request.CredentialProvider.GetAuthToken()
+	conn, err := grpc.Dial(
+		endpoint,
+		grpc.WithTransportCredentials(credentials.NewTLS(config)),
+		grpc.WithChainStreamInterceptor(interceptor.AddStreamHeaderInterceptor(authToken)),
+	)
+
+	if err != nil {
+		return nil, momentoerrors.ConvertSvcErr(err)
+	}
+	return &TopicGrpcManager{
+		Conn:         conn,
+		StreamClient: pb.NewPubsubClient(conn),
+	}, nil
+}
+
+func (topicManager *TopicGrpcManager) Close() momentoerrors.MomentoSvcErr {
+	return momentoerrors.ConvertSvcErr(topicManager.Conn.Close())
+}

--- a/internal/models/requests.go
+++ b/internal/models/requests.go
@@ -23,6 +23,10 @@ type DataStreamGrpcManagerRequest struct {
 	CredentialProvider auth.CredentialProvider
 }
 
+type TopicStreamGrpcManagerRequest struct {
+	CredentialProvider auth.CredentialProvider
+}
+
 type PingGrpcManagerRequest struct {
 	CredentialProvider auth.CredentialProvider
 }

--- a/momento/pubsub_client.go
+++ b/momento/pubsub_client.go
@@ -28,6 +28,8 @@ func newPubSubClient(request *models.PubSubClientRequest) (*pubSubClient, moment
 	var numChannels uint32
 	numSubscriptions := float64(request.TopicsConfiguration.GetMaxSubscriptions())
 	if numSubscriptions > 0 {
+		// a single channel can support 100 streams, so we need to create enough
+		// channels to handle the maximum number of subscriptions
 		numChannels = uint32(math.Ceil(numSubscriptions / 100.0))
 	} else {
 		numChannels = 1

--- a/momento/pubsub_client.go
+++ b/momento/pubsub_client.go
@@ -2,6 +2,8 @@ package momento
 
 import (
 	"context"
+	"math"
+	"sync"
 
 	"github.com/momentohq/client-sdk-go/internal/grpcmanagers"
 	"github.com/momentohq/client-sdk-go/internal/models"
@@ -13,20 +15,35 @@ import (
 )
 
 type pubSubClient struct {
-	streamDataManager *grpcmanagers.DataGrpcManager
-	unaryDataManager  *grpcmanagers.DataGrpcManager
-	streamGrpcClient  pb.PubsubClient
-	unaryGrpcClient   pb.PubsubClient
-	endpoint          string
+	streamTopicManagers         []*grpcmanagers.TopicGrpcManager
+	unaryDataManager            *grpcmanagers.DataGrpcManager
+	unaryGrpcClient             pb.PubsubClient
+	endpoint                    string
+	nextStreamTopicManagerIndex int
 }
 
+var mut sync.Mutex
+
 func newPubSubClient(request *models.PubSubClientRequest) (*pubSubClient, momentoerrors.MomentoSvcErr) {
-	streamDataManager, err := grpcmanagers.NewStreamDataGrpcManager(&models.DataStreamGrpcManagerRequest{
-		CredentialProvider: request.CredentialProvider,
-	})
-	if err != nil {
-		return nil, err
+	var numChannels uint32
+	numSubscriptions := float64(request.TopicsConfiguration.GetMaxSubscriptions())
+	if numSubscriptions > 0 {
+		numChannels = uint32(math.Ceil(numSubscriptions / 100.0))
+	} else {
+		numChannels = 1
 	}
+	streamTopicManagers := make([]*grpcmanagers.TopicGrpcManager, 0)
+
+	for i := 0; uint32(i) < numChannels; i++ {
+		streamTopicManager, err := grpcmanagers.NewStreamTopicGrpcManager(&models.TopicStreamGrpcManagerRequest{
+			CredentialProvider: request.CredentialProvider,
+		})
+		if err != nil {
+			return nil, err
+		}
+		streamTopicManagers = append(streamTopicManagers, streamTopicManager)
+	}
+
 	unaryDataManager, err := grpcmanagers.NewUnaryDataGrpcManager(&models.DataGrpcManagerRequest{
 		CredentialProvider: request.CredentialProvider,
 		RetryStrategy:      retry.NewNeverRetryStrategy(),
@@ -34,23 +51,33 @@ func newPubSubClient(request *models.PubSubClientRequest) (*pubSubClient, moment
 	if err != nil {
 		return nil, err
 	}
+
 	return &pubSubClient{
-		streamDataManager: streamDataManager,
-		unaryDataManager:  unaryDataManager,
-		streamGrpcClient:  pb.NewPubsubClient(streamDataManager.Conn),
-		unaryGrpcClient:   pb.NewPubsubClient(unaryDataManager.Conn),
-		endpoint:          request.CredentialProvider.GetCacheEndpoint(),
+		streamTopicManagers: streamTopicManagers,
+		unaryDataManager:    unaryDataManager,
+		unaryGrpcClient:     pb.NewPubsubClient(unaryDataManager.Conn),
+		endpoint:            request.CredentialProvider.GetCacheEndpoint(),
 	}, nil
 }
 
-func (client *pubSubClient) TopicSubscribe(ctx context.Context, request *TopicSubscribeRequest) (grpc.ClientStream, error) {
-	streamClient, err := client.streamGrpcClient.Subscribe(ctx, &pb.XSubscriptionRequest{
+func (client *pubSubClient) getNextStreamTopicManager() *grpcmanagers.TopicGrpcManager {
+	mut.Lock()
+	topicManager := client.streamTopicManagers[client.nextStreamTopicManagerIndex]
+	client.nextStreamTopicManagerIndex = (client.nextStreamTopicManagerIndex + 1) % len(client.streamTopicManagers)
+	mut.Unlock()
+	return topicManager
+}
+
+func (client *pubSubClient) TopicSubscribe(ctx context.Context, request *TopicSubscribeRequest) (*grpcmanagers.TopicGrpcManager, grpc.ClientStream, error) {
+	topicManager := client.getNextStreamTopicManager()
+	clientStream, err := topicManager.StreamClient.Subscribe(ctx, &pb.XSubscriptionRequest{
 		CacheName:                   request.CacheName,
 		Topic:                       request.TopicName,
 		ResumeAtTopicSequenceNumber: request.ResumeAtTopicSequenceNumber,
 	})
-	return streamClient, err
+	return topicManager, clientStream, err
 }
+
 func (client *pubSubClient) TopicPublish(ctx context.Context, request *TopicPublishRequest) error {
 	switch value := request.Value.(type) {
 	case String:
@@ -88,6 +115,8 @@ func (client *pubSubClient) Endpoint() string {
 }
 
 func (client *pubSubClient) Close() {
-	defer client.streamDataManager.Close()
+	for clientIndex := range client.streamTopicManagers {
+		defer client.streamTopicManagers[clientIndex].Close()
+	}
 	defer client.unaryDataManager.Close()
 }

--- a/momento/pubsub_client.go
+++ b/momento/pubsub_client.go
@@ -15,11 +15,10 @@ import (
 )
 
 type pubSubClient struct {
-	streamTopicManagers         []*grpcmanagers.TopicGrpcManager
-	unaryDataManager            *grpcmanagers.DataGrpcManager
-	unaryGrpcClient             pb.PubsubClient
-	endpoint                    string
-	nextStreamTopicManagerIndex int
+	streamTopicManagers []*grpcmanagers.TopicGrpcManager
+	unaryDataManager    *grpcmanagers.DataGrpcManager
+	unaryGrpcClient     pb.PubsubClient
+	endpoint            string
 }
 
 var streamTopicManagerCount uint64

--- a/momento/pubsub_client.go
+++ b/momento/pubsub_client.go
@@ -70,7 +70,7 @@ func (client *pubSubClient) getNextStreamTopicManager() *grpcmanagers.TopicGrpcM
 	return topicManager
 }
 
-func (client *pubSubClient) TopicSubscribe(ctx context.Context, request *TopicSubscribeRequest) (*grpcmanagers.TopicGrpcManager, grpc.ClientStream, error) {
+func (client *pubSubClient) topicSubscribe(ctx context.Context, request *TopicSubscribeRequest) (*grpcmanagers.TopicGrpcManager, grpc.ClientStream, error) {
 	topicManager := client.getNextStreamTopicManager()
 	clientStream, err := topicManager.StreamClient.Subscribe(ctx, &pb.XSubscriptionRequest{
 		CacheName:                   request.CacheName,
@@ -80,7 +80,7 @@ func (client *pubSubClient) TopicSubscribe(ctx context.Context, request *TopicSu
 	return topicManager, clientStream, err
 }
 
-func (client *pubSubClient) TopicPublish(ctx context.Context, request *TopicPublishRequest) error {
+func (client *pubSubClient) topicPublish(ctx context.Context, request *TopicPublishRequest) error {
 	switch value := request.Value.(type) {
 	case String:
 		_, err := client.unaryGrpcClient.Publish(ctx, &pb.XPublishRequest{

--- a/momento/test_helpers/shared_context.go
+++ b/momento/test_helpers/shared_context.go
@@ -27,6 +27,7 @@ type SharedContext struct {
 	Ctx                        context.Context
 	DefaultTtl                 time.Duration
 	Configuration              config.Configuration
+	TopicConfigration          config.TopicsConfiguration
 	CredentialProvider         auth.CredentialProvider
 }
 
@@ -40,6 +41,7 @@ func NewSharedContext() SharedContext {
 	}
 	shared.CredentialProvider = credentialProvider
 	shared.Configuration = config.LaptopLatestWithLogger(logger.NewNoopMomentoLoggerFactory()).WithClientTimeout(15 * time.Second)
+	shared.TopicConfigration = config.TopicsDefaultWithLogger(logger.NewNoopMomentoLoggerFactory())
 	shared.DefaultTtl = 3 * time.Second
 
 	client, err := momento.NewCacheClient(shared.Configuration, shared.CredentialProvider, shared.DefaultTtl)
@@ -55,7 +57,7 @@ func NewSharedContext() SharedContext {
 		panic(err)
 	}
 
-	topicClient, err := momento.NewTopicClient(shared.Configuration, shared.CredentialProvider)
+	topicClient, err := momento.NewTopicClient(shared.TopicConfigration, shared.CredentialProvider)
 	if err != nil {
 		panic(err)
 	}

--- a/momento/topic_client.go
+++ b/momento/topic_client.go
@@ -21,7 +21,7 @@ type TopicClient interface {
 	Close()
 }
 
-// defaultScsClient represents all information needed for momento client to enable cache control and data operations.
+// defaultTopicClient represents all information needed for momento client to enable publish and subscribe operations.
 type defaultTopicClient struct {
 	credentialProvider auth.CredentialProvider
 	pubSubClient       *pubSubClient
@@ -57,7 +57,7 @@ func (c defaultTopicClient) Subscribe(ctx context.Context, request *TopicSubscri
 		return nil, err
 	}
 
-	clientStream, err := c.pubSubClient.TopicSubscribe(ctx, &TopicSubscribeRequest{
+	topicManager, clientStream, err := c.pubSubClient.TopicSubscribe(ctx, &TopicSubscribeRequest{
 		CacheName: request.CacheName,
 		TopicName: request.TopicName,
 	})
@@ -83,6 +83,7 @@ func (c defaultTopicClient) Subscribe(ctx context.Context, request *TopicSubscri
 	}
 
 	return &topicSubscription{
+		topicManager:       topicManager,
 		grpcClient:         clientStream,
 		momentoTopicClient: c.pubSubClient,
 		cacheName:          request.CacheName,

--- a/momento/topic_client.go
+++ b/momento/topic_client.go
@@ -57,7 +57,7 @@ func (c defaultTopicClient) Subscribe(ctx context.Context, request *TopicSubscri
 		return nil, err
 	}
 
-	topicManager, clientStream, err := c.pubSubClient.TopicSubscribe(ctx, &TopicSubscribeRequest{
+	topicManager, clientStream, err := c.pubSubClient.topicSubscribe(ctx, &TopicSubscribeRequest{
 		CacheName: request.CacheName,
 		TopicName: request.TopicName,
 	})
@@ -109,7 +109,7 @@ func (c defaultTopicClient) Publish(ctx context.Context, request *TopicPublishRe
 		)
 	}
 
-	err := c.pubSubClient.TopicPublish(ctx, &TopicPublishRequest{
+	err := c.pubSubClient.topicPublish(ctx, &TopicPublishRequest{
 		CacheName: request.CacheName,
 		TopicName: request.TopicName,
 		Value:     request.Value,

--- a/momento/topic_client.go
+++ b/momento/topic_client.go
@@ -124,5 +124,5 @@ func (c defaultTopicClient) Publish(ctx context.Context, request *TopicPublishRe
 }
 
 func (c defaultTopicClient) Close() {
-	defer c.pubSubClient.Close()
+	defer c.pubSubClient.close()
 }

--- a/momento/topic_client_test.go
+++ b/momento/topic_client_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -24,7 +25,7 @@ var _ = Describe("Pubsub", func() {
 		})
 	})
 
-	DescribeTable(`Validates the names`,
+	DescribeTable("Validates the names",
 		func(cacheName string, collectionName string, expectedError string) {
 			ctx := sharedContext.Ctx
 			client := sharedContext.TopicClient

--- a/momento/topic_subscription.go
+++ b/momento/topic_subscription.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/momentohq/client-sdk-go/config/logger"
+	"github.com/momentohq/client-sdk-go/internal/grpcmanagers"
 	pb "github.com/momentohq/client-sdk-go/internal/protos"
 
 	"google.golang.org/grpc"
@@ -17,6 +18,7 @@ type TopicSubscription interface {
 }
 
 type topicSubscription struct {
+	topicManager            *grpcmanagers.TopicGrpcManager
 	grpcClient              grpc.ClientStream
 	momentoTopicClient      *pubSubClient
 	cacheName               string
@@ -59,8 +61,8 @@ func (s *topicSubscription) Item(ctx context.Context) (TopicValue, error) {
 }
 
 func (s *topicSubscription) attemptReconnect(ctx context.Context) {
-	// make sure the connection isnt ready, if its ready no need to reconnect
-	if s.momentoTopicClient.streamDataManager.Conn.GetState() == connectivity.Ready {
+	// make sure the connection isn't ready, if its ready no need to reconnect
+	if s.topicManager.Conn.GetState() == connectivity.Ready {
 		s.log.Debug("connection is in ready state, not reconnecting")
 		return
 	}
@@ -69,7 +71,7 @@ func (s *topicSubscription) attemptReconnect(ctx context.Context) {
 	for {
 		s.log.Debug("Attempting reconnecting to client stream")
 		time.Sleep(seconds)
-		newStream, err := s.momentoTopicClient.TopicSubscribe(ctx, &TopicSubscribeRequest{
+		newTopicManager, newStream, err := s.momentoTopicClient.TopicSubscribe(ctx, &TopicSubscribeRequest{
 			CacheName:                   s.cacheName,
 			TopicName:                   s.topicName,
 			ResumeAtTopicSequenceNumber: s.lastKnownSequenceNumber,
@@ -79,6 +81,7 @@ func (s *topicSubscription) attemptReconnect(ctx context.Context) {
 			s.log.Debug("failed to reconnect to stream, will continue to try in %s seconds", fmt.Sprint(seconds))
 		} else {
 			s.log.Debug("successfully reconnected to subscription stream")
+			s.topicManager = newTopicManager
 			s.grpcClient = newStream
 			return
 		}

--- a/momento/topic_subscription.go
+++ b/momento/topic_subscription.go
@@ -71,7 +71,7 @@ func (s *topicSubscription) attemptReconnect(ctx context.Context) {
 	for {
 		s.log.Debug("Attempting reconnecting to client stream")
 		time.Sleep(seconds)
-		newTopicManager, newStream, err := s.momentoTopicClient.TopicSubscribe(ctx, &TopicSubscribeRequest{
+		newTopicManager, newStream, err := s.momentoTopicClient.topicSubscribe(ctx, &TopicSubscribeRequest{
 			CacheName:                   s.cacheName,
 			TopicName:                   s.topicName,
 			ResumeAtTopicSequenceNumber: s.lastKnownSequenceNumber,


### PR DESCRIPTION
This commit adds a `maxSubscriptions` configuration option to the topics configuration. This allows users to set an upper limit on the number of subscriptions for a single topic client and allows us to create a sufficient number of channels to handle the subscriber connections.

These changes were verified using a loadgen script that will be added to the SDK in an upcoming PR, which confirmed that > 100 subscriptions were created and reported receiving messages. I was also able to verify using `lsof` that a new network connection to our backend was created for every 100 subscriptions specified via `WithMaxSubscriptions`.