### PR TITLE
feat: add request and response for set if not exists

### DIFF
--- a/momento/set_if_not_exists.go
+++ b/momento/set_if_not_exists.go
@@ -77,9 +77,11 @@ func (r *SetIfNotExistsRequest) interpretGrpcResponse() error {
 
 	switch grpcResp.Result.(type) {
 	case *pb.XSetIfNotExistsResponse_Stored:
-		resp = responses.NewSetIfNotExistsStored(r.Key.asBytes(), r.Value.asBytes())
+		resp = &responses.SetIfNotExistsStored{}
 	case *pb.XSetIfNotExistsResponse_NotStored:
 		resp = &responses.SetIfNotExistsNotStored{}
+	default:
+		return errUnexpectedGrpcResponse(r, r.grpcResponse)
 	}
 
 	r.response = resp

--- a/momento/set_if_not_exists.go
+++ b/momento/set_if_not_exists.go
@@ -1,0 +1,87 @@
+package momento
+
+import (
+	"context"
+	"time"
+
+	"github.com/momentohq/client-sdk-go/responses"
+
+	pb "github.com/momentohq/client-sdk-go/internal/protos"
+)
+
+type SetIfNotExistsRequest struct {
+	// Name of the cache to store the item in.
+	CacheName string
+	// string or byte key to be used to store item.
+	Key Key
+	// string ot byte value to be stored.
+	Value Value
+	// Optional Time to live in cache in seconds.
+	// If not provided, then default TTL for the cache client instance is used.
+	Ttl time.Duration
+
+	grpcRequest  *pb.XSetIfNotExistsRequest
+	grpcResponse *pb.XSetIfNotExistsResponse
+	response     responses.SetIfNotExistsResponse
+}
+
+func (r *SetIfNotExistsRequest) cacheName() string { return r.CacheName }
+
+func (r *SetIfNotExistsRequest) key() Key { return r.Key }
+
+func (r *SetIfNotExistsRequest) value() Value { return r.Value }
+
+func (r *SetIfNotExistsRequest) ttl() time.Duration { return r.Ttl }
+
+func (r *SetIfNotExistsRequest) requestName() string { return "SetIfNotExists" }
+
+func (r *SetIfNotExistsRequest) initGrpcRequest(client scsDataClient) error {
+	var err error
+
+	var key []byte
+	if key, err = prepareKey(r); err != nil {
+		return err
+	}
+
+	var value []byte
+	if value, err = prepareValue(r); err != nil {
+		return err
+	}
+
+	var ttl uint64
+	if ttl, err = prepareTtl(r, client.defaultTtl); err != nil {
+		return err
+	}
+
+	r.grpcRequest = &pb.XSetIfNotExistsRequest{
+		CacheKey:        key,
+		CacheBody:       value,
+		TtlMilliseconds: ttl,
+	}
+
+	return nil
+}
+
+func (r *SetIfNotExistsRequest) makeGrpcRequest(metadata context.Context, client scsDataClient) (grpcResponse, error) {
+	resp, err := client.grpcClient.SetIfNotExists(metadata, r.grpcRequest)
+	if err != nil {
+		return nil, err
+	}
+	r.grpcResponse = resp
+	return resp, nil
+}
+
+func (r *SetIfNotExistsRequest) interpretGrpcResponse() error {
+	grpcResp := r.grpcResponse
+	var resp responses.SetIfNotExistsResponse
+
+	switch grpcResp.Result.(type) {
+	case *pb.XSetIfNotExistsResponse_Stored:
+		resp = responses.NewSetIfNotExistsStored(r.Key.asBytes(), r.Value.asBytes())
+	case *pb.XSetIfNotExistsResponse_NotStored:
+		resp = &responses.SetIfNotExistsNotStored{}
+	}
+
+	r.response = resp
+	return nil
+}

--- a/responses/set_if_not_exists.go
+++ b/responses/set_if_not_exists.go
@@ -1,0 +1,44 @@
+package responses
+
+// SetIfNotExistsResponse is the base response type for a SetIfNotExists request
+type SetIfNotExistsResponse interface {
+	isSetIfNotExistsResponse()
+}
+
+// SetIfNotExistsNotStored indicates a successful set request where the value was already present.
+type SetIfNotExistsNotStored struct{}
+
+func (SetIfNotExistsNotStored) isSetIfNotExistsResponse() {}
+
+// SetIfNotExistsStored indicates a successful set request where the value was stored.
+type SetIfNotExistsStored struct {
+	key   []byte
+	value []byte
+}
+
+func (SetIfNotExistsStored) isSetIfNotExistsResponse() {}
+
+// ValueString returns value stored in the cache.
+func (resp SetIfNotExistsStored) ValueString() string {
+	return string(resp.value)
+}
+
+// ValueByte Returns value stored in the cache as bytes.
+func (resp SetIfNotExistsStored) ValueByte() []byte {
+	return resp.value
+}
+
+// KeyString returns key stored in the cache.
+func (resp SetIfNotExistsStored) KeyString() string {
+	return string(resp.key)
+}
+
+// KeyByte Returns key stored in the cache as bytes.
+func (resp SetIfNotExistsStored) KeyByte() []byte {
+	return resp.key
+}
+
+// NewSetIfNotExistsStored returns a new SetIfNotExistsStored containing the supplied key and value.
+func NewSetIfNotExistsStored(key, value []byte) *SetIfNotExistsStored {
+	return &SetIfNotExistsStored{key: key, value: value}
+}

--- a/responses/set_if_not_exists.go
+++ b/responses/set_if_not_exists.go
@@ -11,34 +11,6 @@ type SetIfNotExistsNotStored struct{}
 func (SetIfNotExistsNotStored) isSetIfNotExistsResponse() {}
 
 // SetIfNotExistsStored indicates a successful set request where the value was stored.
-type SetIfNotExistsStored struct {
-	key   []byte
-	value []byte
-}
+type SetIfNotExistsStored struct{}
 
 func (SetIfNotExistsStored) isSetIfNotExistsResponse() {}
-
-// ValueString returns value stored in the cache.
-func (resp SetIfNotExistsStored) ValueString() string {
-	return string(resp.value)
-}
-
-// ValueByte Returns value stored in the cache as bytes.
-func (resp SetIfNotExistsStored) ValueByte() []byte {
-	return resp.value
-}
-
-// KeyString returns key stored in the cache.
-func (resp SetIfNotExistsStored) KeyString() string {
-	return string(resp.key)
-}
-
-// KeyByte Returns key stored in the cache as bytes.
-func (resp SetIfNotExistsStored) KeyByte() []byte {
-	return resp.key
-}
-
-// NewSetIfNotExistsStored returns a new SetIfNotExistsStored containing the supplied key and value.
-func NewSetIfNotExistsStored(key, value []byte) *SetIfNotExistsStored {
-	return &SetIfNotExistsStored{key: key, value: value}
-}


### PR DESCRIPTION
Added request and response for ```SetIfNotExists```. Next PR will update the cache client to have the method and the integration tests. I actually did wire the cache client and wrote a vanilla integ test for the new API and it succeeded. Will expand with wholistic tests and have it as a new PR.