### PR TITLE
feat: add request and responses for sorted set length and length by score

### DIFF
--- a/momento/sorted_set_length.go
+++ b/momento/sorted_set_length.go
@@ -1,0 +1,56 @@
+package momento
+
+import (
+	"context"
+
+	"github.com/momentohq/client-sdk-go/responses"
+
+	pb "github.com/momentohq/client-sdk-go/internal/protos"
+)
+
+type SortedSetLengthRequest struct {
+	CacheName string
+	SetName   string
+
+	grpcRequest  *pb.XSortedSetLengthRequest
+	grpcResponse *pb.XSortedSetLengthResponse
+	response     responses.SortedSetLengthResponse
+}
+
+func (r *SortedSetLengthRequest) cacheName() string { return r.CacheName }
+
+func (r *SortedSetLengthRequest) requestName() string { return "SortedSetLength" }
+
+func (r *SortedSetLengthRequest) initGrpcRequest(scsDataClient) error {
+	if _, err := prepareName(r.SetName, "Set name"); err != nil {
+		return err
+	}
+
+	r.grpcRequest = &pb.XSortedSetLengthRequest{
+		SetName: []byte(r.SetName),
+	}
+
+	return nil
+}
+
+func (r *SortedSetLengthRequest) makeGrpcRequest(metadata context.Context, client scsDataClient) (grpcResponse, error) {
+	resp, err := client.grpcClient.SortedSetLength(metadata, r.grpcRequest)
+	if err != nil {
+		return nil, err
+	}
+	r.grpcResponse = resp
+	return resp, nil
+}
+
+func (r *SortedSetLengthRequest) interpretGrpcResponse() error {
+	resp := r.grpcResponse
+	switch rtype := resp.SortedSet.(type) {
+	case *pb.XSortedSetLengthResponse_Found:
+		r.response = responses.NewSortedSetLengthHit(rtype.Found.Length)
+	case *pb.XSortedSetLengthResponse_Missing:
+		r.response = &responses.SortedSetLengthMiss{}
+	default:
+		return errUnexpectedGrpcResponse(r, r.grpcResponse)
+	}
+	return nil
+}

--- a/momento/sorted_set_length_by_score.go
+++ b/momento/sorted_set_length_by_score.go
@@ -1,0 +1,58 @@
+package momento
+
+import (
+	"context"
+
+	"github.com/momentohq/client-sdk-go/responses"
+
+	pb "github.com/momentohq/client-sdk-go/internal/protos"
+)
+
+type SortedSetLengthByScoreRequest struct {
+	CacheName string
+	SetName   string
+	MinScore  *float64
+	MaxScore  *float64
+
+	grpcRequest  *pb.XSortedSetLengthByScoreRequest
+	grpcResponse *pb.XSortedSetLengthByScoreResponse
+	response     responses.SortedSetLengthByScoreResponse
+}
+
+func (r *SortedSetLengthByScoreRequest) cacheName() string { return r.CacheName }
+
+func (r *SortedSetLengthByScoreRequest) requestName() string { return "SortedSetLengthByScore" }
+
+func (r *SortedSetLengthByScoreRequest) initGrpcRequest(scsDataClient) error {
+	if _, err := prepareName(r.SetName, "Set name"); err != nil {
+		return err
+	}
+
+	r.grpcRequest = &pb.XSortedSetLengthByScoreRequest{
+		SetName: []byte(r.SetName),
+	}
+
+	return nil
+}
+
+func (r *SortedSetLengthByScoreRequest) makeGrpcRequest(metadata context.Context, client scsDataClient) (grpcResponse, error) {
+	resp, err := client.grpcClient.SortedSetLengthByScore(metadata, r.grpcRequest)
+	if err != nil {
+		return nil, err
+	}
+	r.grpcResponse = resp
+	return resp, nil
+}
+
+func (r *SortedSetLengthByScoreRequest) interpretGrpcResponse() error {
+	resp := r.grpcResponse
+	switch rtype := resp.SortedSet.(type) {
+	case *pb.XSortedSetLengthByScoreResponse_Found:
+		r.response = responses.NewSortedSetLengthByScoreHit(rtype.Found.Length)
+	case *pb.XSortedSetLengthByScoreResponse_Missing:
+		r.response = &responses.SortedSetLengthByScoreMiss{}
+	default:
+		return errUnexpectedGrpcResponse(r, r.grpcResponse)
+	}
+	return nil
+}

--- a/responses/sorted_set_length.go
+++ b/responses/sorted_set_length.go
@@ -1,0 +1,28 @@
+package responses
+
+// SortedSetLengthResponse is the base response type for a sorted set length request.
+type SortedSetLengthResponse interface {
+	isSortedSetLengthResponse()
+}
+
+// SortedSetLengthHit indicates a sorted set length request was a hit.
+type SortedSetLengthHit struct {
+	value uint32
+}
+
+func (SortedSetLengthHit) isSortedSetLengthResponse() {}
+
+// Length returns the length of the sorted set.
+func (resp SortedSetLengthHit) Length() uint32 {
+	return resp.value
+}
+
+// SortedSetLengthMiss indicates a sorted set length request was a miss.
+type SortedSetLengthMiss struct{}
+
+func (SortedSetLengthMiss) isSortedSetLengthResponse() {}
+
+// NewSortedSetLengthHit returns a new SortedSetLengthHit containing the supplied value.
+func NewSortedSetLengthHit(value uint32) *SortedSetLengthHit {
+	return &SortedSetLengthHit{value: value}
+}

--- a/responses/sorted_set_length_by_score.go
+++ b/responses/sorted_set_length_by_score.go
@@ -1,0 +1,28 @@
+package responses
+
+// SortedSetLengthByScoreResponse is the base response type for a sorted set length request.
+type SortedSetLengthByScoreResponse interface {
+	isSortedSetLengthByScoreResponse()
+}
+
+// SortedSetLengthByScoreHit indicates a sorted set length request was a hit.
+type SortedSetLengthByScoreHit struct {
+	value uint32
+}
+
+func (SortedSetLengthByScoreHit) isSortedSetLengthByScoreResponse() {}
+
+// Length returns the length of the sorted set.
+func (resp SortedSetLengthByScoreHit) Length() uint32 {
+	return resp.value
+}
+
+// SortedSetLengthByScoreMiss indicates a sorted set length request was a miss.
+type SortedSetLengthByScoreMiss struct{}
+
+func (SortedSetLengthByScoreMiss) isSortedSetLengthByScoreResponse() {}
+
+// NewSortedSetLengthByScoreHit returns a new SortedSetLengthByScoreHit containing the supplied value.
+func NewSortedSetLengthByScoreHit(value uint32) *SortedSetLengthByScoreHit {
+	return &SortedSetLengthByScoreHit{value: value}
+}


### PR DESCRIPTION
- feat: add request and responses for sorted-set-length and sorted-set-length-by-score
