### PR TITLE
fix: return an invalid argument error if the interpreted ttl is 0 milliseconds

### DIFF
--- a/momento/requester.go
+++ b/momento/requester.go
@@ -200,7 +200,7 @@ func prepareTtl(r hasTtl, defaultTtl time.Duration) (uint64, error) {
 	if uint64(ttl.Milliseconds()) == 0 {
 		return 0, buildError(
 			momentoerrors.InvalidArgumentError, "ttl must greater than 0 when interpreting it as milliseconds."+
-				" The default unit is nanoseconds. Did you provide a unit while specifying the TTL?", nil,
+				" The default unit is nanoseconds. Did you provide a unit while specifying the TTL, such as 60 * time.Second?", nil,
 		)
 	}
 

--- a/momento/scalar_test.go
+++ b/momento/scalar_test.go
@@ -249,6 +249,28 @@ var _ = Describe("Scalar methods", func() {
 			).To(BeAssignableToTypeOf(&GetMiss{}))
 		})
 
+		It("Overrides the default TTL without unit and invalid", func() {
+			key := String("key")
+			value := String("value")
+
+			resp, err := sharedContext.Client.Set(sharedContext.Ctx, &SetRequest{
+				CacheName: sharedContext.CacheName,
+				Key:       key,
+				Value:     value,
+				Ttl:       2,
+			})
+
+			Expect(resp).To(BeNil())
+			Expect(err).To(HaveMomentoErrorCode(InvalidArgumentError))
+
+			Expect(
+				sharedContext.Client.Get(sharedContext.Ctx, &GetRequest{
+					CacheName: sharedContext.CacheName,
+					Key:       key,
+				}),
+			).To(BeAssignableToTypeOf(&GetMiss{}))
+		})
+
 		It("returns an error for a nil value", func() {
 			key := String("key")
 			Expect(


### PR DESCRIPTION
Added details to the issue https://github.com/momentohq/dev-eco-issue-tracker/issues/378

I believe since that issue isn't a part of the repo, Git isn't allowing me to link the PR to that issue. 