### PR TITLE
feat: add timeout to individual requests in batch call

### DIFF
--- a/batchutils/batch_operations.go
+++ b/batchutils/batch_operations.go
@@ -2,9 +2,21 @@ package batchutils
 
 import (
 	"context"
+	"time"
 
 	"github.com/momentohq/client-sdk-go/momento"
 )
+
+const defaultRequestTimeout = 10 * time.Second
+
+func getRequestTimeout(propsTimeout *time.Duration) (requestTimeout time.Duration) {
+	if propsTimeout == nil {
+		requestTimeout = defaultRequestTimeout
+	} else {
+		requestTimeout = *propsTimeout
+	}
+	return
+}
 
 func keyDistributor(ctx context.Context, keys []momento.Key, keyChan chan momento.Key) {
 	for _, k := range keys {

--- a/batchutils/batch_operations_test.go
+++ b/batchutils/batch_operations_test.go
@@ -28,7 +28,7 @@ var _ = Describe("Batch operations", func() {
 	BeforeEach(func() {
 		ctx = context.Background()
 		cacheName = fmt.Sprintf("golang-%s", uuid.NewString())
-		credentialProvider, err := auth.FromString("eyJlbmRwb2ludCI6ImNlbGwtNC11cy13ZXN0LTItMS5wcm9kLmEubW9tZW50b2hxLmNvbSIsImFwaV9rZXkiOiJleUpoYkdjaU9pSklVekkxTmlKOS5leUp6ZFdJaU9pSndjbUYwYVd0QWJXOXRaVzUwYjJoeExtTnZiU0lzSW5abGNpSTZNU3dpY0NJNklrTkJRVDBpTENKbGVIQWlPakUyT1RVNE1qQTFNREI5Lk50cVdwYVBpNnNBVmd1WFNlVDg4OFFVa3JDOW5ldVlqbFk2TXp4ZW9DUVkifQ==")
+		credentialProvider, err := auth.FromEnvironmentVariable("TEST_AUTH_TOKEN")
 		if err != nil {
 			panic(err)
 		}

--- a/batchutils/batch_operations_test.go
+++ b/batchutils/batch_operations_test.go
@@ -28,7 +28,7 @@ var _ = Describe("Batch operations", func() {
 	BeforeEach(func() {
 		ctx = context.Background()
 		cacheName = fmt.Sprintf("golang-%s", uuid.NewString())
-		credentialProvider, err := auth.FromEnvironmentVariable("TEST_AUTH_TOKEN")
+		credentialProvider, err := auth.FromString("eyJlbmRwb2ludCI6ImNlbGwtNC11cy13ZXN0LTItMS5wcm9kLmEubW9tZW50b2hxLmNvbSIsImFwaV9rZXkiOiJleUpoYkdjaU9pSklVekkxTmlKOS5leUp6ZFdJaU9pSndjbUYwYVd0QWJXOXRaVzUwYjJoeExtTnZiU0lzSW5abGNpSTZNU3dpY0NJNklrTkJRVDBpTENKbGVIQWlPakUyT1RVNE1qQTFNREI5Lk50cVdwYVBpNnNBVmd1WFNlVDg4OFFVa3JDOW5ldVlqbFk2TXp4ZW9DUVkifQ==")
 		if err != nil {
 			panic(err)
 		}
@@ -103,6 +103,21 @@ var _ = Describe("Batch operations", func() {
 			})
 			Expect(errors).To(BeNil())
 		})
+
+		It("super small request timeout test", func() {
+			timeout := 1 * time.Millisecond
+			errors := batchutils.BatchDelete(ctx, &batchutils.BatchDeleteRequest{
+				Client:         client,
+				CacheName:      cacheName,
+				Keys:           keys[5:21],
+				RequestTimeout: &timeout,
+			})
+
+			Expect(len(errors.Errors())).To(Equal(16))
+			for _, err := range errors.Errors() {
+				Expect(err.Error()).To(ContainSubstring("TimeoutError: context deadline exceeded"))
+			}
+		})
 	})
 
 	Describe("batch get", func() {
@@ -156,6 +171,22 @@ var _ = Describe("Batch operations", func() {
 				} else {
 					Expect(resp).To(BeAssignableToTypeOf(&responses.GetMiss{}))
 				}
+			}
+		})
+
+		It("super small request timeout test", func() {
+			timeout := 1 * time.Millisecond
+			getBatch, errors := batchutils.BatchGet(ctx, &batchutils.BatchGetRequest{
+				Client:         client,
+				CacheName:      cacheName,
+				Keys:           keys[5:21],
+				RequestTimeout: &timeout,
+			})
+
+			Expect(getBatch).To(BeNil())
+			Expect(len(errors.Errors())).To(Equal(16))
+			for _, err := range errors.Errors() {
+				Expect(err.Error()).To(ContainSubstring("TimeoutError: context deadline exceeded"))
 			}
 		})
 	})

--- a/batchutils/batch_set_test.go
+++ b/batchutils/batch_set_test.go
@@ -27,7 +27,7 @@ var _ = Describe("Batch set operations", func() {
 	BeforeEach(func() {
 		ctx = context.Background()
 		cacheName = fmt.Sprintf("golang-%s", uuid.NewString())
-		credentialProvider, err := auth.FromString("eyJlbmRwb2ludCI6ImNlbGwtNC11cy13ZXN0LTItMS5wcm9kLmEubW9tZW50b2hxLmNvbSIsImFwaV9rZXkiOiJleUpoYkdjaU9pSklVekkxTmlKOS5leUp6ZFdJaU9pSndjbUYwYVd0QWJXOXRaVzUwYjJoeExtTnZiU0lzSW5abGNpSTZNU3dpY0NJNklrTkJRVDBpTENKbGVIQWlPakUyT1RVNE1qQTFNREI5Lk50cVdwYVBpNnNBVmd1WFNlVDg4OFFVa3JDOW5ldVlqbFk2TXp4ZW9DUVkifQ==")
+		credentialProvider, err := auth.FromEnvironmentVariable("TEST_AUTH_TOKEN")
 		if err != nil {
 			panic(err)
 		}


### PR DESCRIPTION
Added timeout to individual requests within the batch operations. This will prevent a single co-routine to block the entire operation.