### PR TITLE
feat: add timeout to individual requests in batch call

### DIFF
--- a/batchutils/batch_operations.go
+++ b/batchutils/batch_operations.go
@@ -2,9 +2,21 @@ package batchutils
 
 import (
 	"context"
+	"time"
 
 	"github.com/momentohq/client-sdk-go/momento"
 )
+
+const defaultRequestTimeout = 10 * time.Second
+
+func getRequestTimeout(propsTimeout *time.Duration) (requestTimeout time.Duration) {
+	if propsTimeout == nil {
+		requestTimeout = defaultRequestTimeout
+	} else {
+		requestTimeout = *propsTimeout
+	}
+	return
+}
 
 func keyDistributor(ctx context.Context, keys []momento.Key, keyChan chan momento.Key) {
 	for _, k := range keys {

--- a/batchutils/batch_operations_test.go
+++ b/batchutils/batch_operations_test.go
@@ -103,6 +103,21 @@ var _ = Describe("Batch operations", func() {
 			})
 			Expect(errors).To(BeNil())
 		})
+
+		It("super small request timeout test", func() {
+			timeout := 1 * time.Millisecond
+			errors := batchutils.BatchDelete(ctx, &batchutils.BatchDeleteRequest{
+				Client:         client,
+				CacheName:      cacheName,
+				Keys:           keys[5:21],
+				RequestTimeout: &timeout,
+			})
+
+			Expect(len(errors.Errors())).To(Equal(16))
+			for _, err := range errors.Errors() {
+				Expect(err.Error()).To(ContainSubstring("TimeoutError: context deadline exceeded"))
+			}
+		})
 	})
 
 	Describe("batch get", func() {
@@ -156,6 +171,22 @@ var _ = Describe("Batch operations", func() {
 				} else {
 					Expect(resp).To(BeAssignableToTypeOf(&responses.GetMiss{}))
 				}
+			}
+		})
+
+		It("super small request timeout test", func() {
+			timeout := 1 * time.Millisecond
+			getBatch, errors := batchutils.BatchGet(ctx, &batchutils.BatchGetRequest{
+				Client:         client,
+				CacheName:      cacheName,
+				Keys:           keys[5:21],
+				RequestTimeout: &timeout,
+			})
+
+			Expect(getBatch).To(BeNil())
+			Expect(len(errors.Errors())).To(Equal(16))
+			for _, err := range errors.Errors() {
+				Expect(err.Error()).To(ContainSubstring("TimeoutError: context deadline exceeded"))
 			}
 		})
 	})


### PR DESCRIPTION
This PR adds a `request_timeout` for each individual `set`, `get`, or `delete` calls we make within the batch operations. This is just a hardening mechanism such that one if of the go-routines doesn't hang indefinitely and blocks the entire operation.