### PR TITLE
fix: fix populating results from channel

### DIFF
--- a/batchutils/batch_set_test.go
+++ b/batchutils/batch_set_test.go
@@ -189,6 +189,7 @@ var _ = Describe("Batch set operations", func() {
 				Items:     items,
 			})
 
+			Expect(len(setBatch.Responses())).To(Equal(len(batchSetSuccessfulKeys)))
 			// Assuming errors is an instance of *BatchSetError
 			Expect(len(errors.Errors())).To(Equal(len(batchSetErrorKeys)))
 			for v, e := range errors.Errors() {


### PR DESCRIPTION
Earlier we used two separate channels in the `batch_get` and `batch_set` operations for results and errors. This had a unwanted side-effect where we couldn't exactly determine when the workers populate the respective channels, and had a minor bug where we didn't take the correct value from one of the channels. This PR changes the two operations to use a single channel for both results and errors, and populate the final responses appropriately. `batch_delete` just uses one channel for errors.