### PR TITLE
chore: update pubsub example to branch on string vs bytes and rename MOMENTO_AUTH_TOKEN var to MOMENTO_API_KEY

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ import (
 func main() {
 	context := context.Background()
 	configuration := config.LaptopLatestWithLogger(logger.NewNoopMomentoLoggerFactory()).WithClientTimeout(15 * time.Second)
-	credentialProvider, err := auth.NewEnvMomentoTokenProvider("MOMENTO_AUTH_TOKEN")
+	credentialProvider, err := auth.NewEnvMomentoTokenProvider("MOMENTO_API_KEY")
 	if err != nil {
 		panic(err)
 	}

--- a/examples/README.md
+++ b/examples/README.md
@@ -10,10 +10,10 @@
 
 Each example is a main.go file in its own directory.
 
-To run an example, provide your Momento Auth Token as the MOMENTO_AUTH_TOKEN environment variable and `go run` the example's main.go. For example, to run the get/set/delete example...
+To run an example, provide your Momento Auth Token as the MOMENTO_API_KEY environment variable and `go run` the example's main.go. For example, to run the get/set/delete example...
 
 ```
-MOMENTO_AUTH_TOKEN=<YOUR_TOKEN> go run scalar-example/main.go
+MOMENTO_API_KEY=<YOUR_TOKEN> go run scalar-example/main.go
 ```
 
 ## Using SDK in your project

--- a/examples/aws-lambda/README.md
+++ b/examples/aws-lambda/README.md
@@ -40,7 +40,7 @@ You will also need a superuser token generated from the [Momento Console](https:
 Then run:
 
 ```
-npm run cdk -- deploy --parameters MomentoAuthToken=<YOUR_MOMENTO_AUTH_TOKEN>
+npm run cdk -- deploy --parameters MomentoAuthToken=<YOUR_MOMENTO_API_KEY>
 ```
 
 The lambda does not set up a way to access itself externally, so to run it, you will have to go to MomentoSimpleGet in AWS Lambda and run a test.

--- a/examples/aws-lambda/infrastructure/lib/momento-lambda-stack.ts
+++ b/examples/aws-lambda/infrastructure/lib/momento-lambda-stack.ts
@@ -27,7 +27,7 @@ export class MomentoLambdaStack extends cdk.Stack {
       timeout: cdk.Duration.seconds(30),
       memorySize: 128,
       environment: {
-        MOMENTO_AUTH_TOKEN_SECRET_NAME: authTokenSecret.secretName,
+        MOMENTO_API_KEY_SECRET_NAME: authTokenSecret.secretName,
       },
     });
 

--- a/examples/aws-lambda/lambda/main.go
+++ b/examples/aws-lambda/lambda/main.go
@@ -87,7 +87,7 @@ func getSecret(secretName string) (string, error) {
 }
 
 func getCacheClient() (momento.CacheClient, error) {
-	authToken, secretErr := getSecret("MOMENTO_AUTH_TOKEN_SECRET_NAME")
+	authToken, secretErr := getSecret("MOMENTO_API_KEY_SECRET_NAME")
 	if secretErr != nil {
 		panic(secretErr)
 	}

--- a/examples/dictionary-example/main.go
+++ b/examples/dictionary-example/main.go
@@ -26,7 +26,7 @@ var (
 
 func setup() {
 	ctx = context.Background()
-	var credentialProvider, err = auth.NewEnvMomentoTokenProvider("MOMENTO_AUTH_TOKEN")
+	var credentialProvider, err = auth.NewEnvMomentoTokenProvider("MOMENTO_API_KEY")
 	if err != nil {
 		panic(err)
 	}

--- a/examples/doc-examples-go-apis.go
+++ b/examples/doc-examples-go-apis.go
@@ -20,7 +20,7 @@ var (
 
 func example_API_InstantiateCacheClient() {
 	context := context.Background()
-	credentialProvider, err := auth.NewEnvMomentoTokenProvider("MOMENTO_AUTH_TOKEN")
+	credentialProvider, err := auth.NewEnvMomentoTokenProvider("MOMENTO_API_KEY")
 	if err != nil {
 		panic(err)
 	}

--- a/examples/list-example/main.go
+++ b/examples/list-example/main.go
@@ -144,7 +144,7 @@ func removeValue(value momento.Value) {
 
 func main() {
 	ctx = context.Background()
-	var credentialProvider, err = auth.NewEnvMomentoTokenProvider("MOMENTO_AUTH_TOKEN")
+	var credentialProvider, err = auth.NewEnvMomentoTokenProvider("MOMENTO_API_KEY")
 	if err != nil {
 		panic(err)
 	}

--- a/examples/loadgen-topics/main.go
+++ b/examples/loadgen-topics/main.go
@@ -69,7 +69,7 @@ func newLoadGenerator(config config.TopicsConfiguration, options topicsLoadGener
 
 func (r *loadGenerator) init(ctx context.Context) (momento.TopicClient, momento.CacheClient) {
 	CacheName := r.options.cacheName
-	credentialProvider, err := auth.FromEnvironmentVariable("MOMENTO_AUTH_TOKEN")
+	credentialProvider, err := auth.FromEnvironmentVariable("MOMENTO_API_KEY")
 	if err != nil {
 		panic(err)
 	}

--- a/examples/loadgen/main.go
+++ b/examples/loadgen/main.go
@@ -60,7 +60,7 @@ func newLoadGenerator(config config.Configuration, options loadGeneratorOptions)
 }
 
 func (r *loadGenerator) init(ctx context.Context) (momento.CacheClient, time.Duration) {
-	credentialProvider, err := auth.FromEnvironmentVariable("MOMENTO_AUTH_TOKEN")
+	credentialProvider, err := auth.FromEnvironmentVariable("MOMENTO_API_KEY")
 	if err != nil {
 		panic(err)
 	}

--- a/examples/logging-example/main.go
+++ b/examples/logging-example/main.go
@@ -20,7 +20,7 @@ choice, so that Momento's logs will be written to the same destinations as the r
 application's logs.`)
 	fmt.Println("")
 
-	creds, err := auth.FromEnvironmentVariable("MOMENTO_AUTH_TOKEN")
+	creds, err := auth.FromEnvironmentVariable("MOMENTO_API_KEY")
 	if err != nil {
 		panic(err)
 	}

--- a/examples/pubsub-example/main.go
+++ b/examples/pubsub-example/main.go
@@ -47,12 +47,19 @@ func pollForMessages(ctx context.Context, sub momento.TopicSubscription) {
 		if err != nil {
 			panic(err)
 		}
-		fmt.Printf("received message: '%v'\n", item)
+		switch msg := item.(type) {
+		case momento.String:
+			fmt.Printf("received message as string: '%v'\n", msg)
+			continue
+		case momento.Bytes:
+			fmt.Printf("received message as bytes: '%v'\n", msg)
+			continue
+		}
 	}
 }
 
 func getTopicClient() momento.TopicClient {
-	credProvider, err := auth.NewEnvMomentoTokenProvider("MOMENTO_AUTH_TOKEN")
+	credProvider, err := auth.NewEnvMomentoTokenProvider("MOMENTO_API_KEY")
 	if err != nil {
 		panic(err)
 	}
@@ -67,7 +74,7 @@ func getTopicClient() momento.TopicClient {
 }
 
 func getCacheClient() momento.CacheClient {
-	credProvider, err := auth.NewEnvMomentoTokenProvider("MOMENTO_AUTH_TOKEN")
+	credProvider, err := auth.NewEnvMomentoTokenProvider("MOMENTO_API_KEY")
 	if err != nil {
 		panic(err)
 	}
@@ -93,12 +100,24 @@ func setupCache(client momento.CacheClient, ctx context.Context) {
 }
 
 func publishMessages(client momento.TopicClient, ctx context.Context) {
-	for i := 0; i < 100; i++ {
+	for i := 0; i < 5; i++ {
 		fmt.Printf("publishing message %d\n", i)
 		_, err := client.Publish(ctx, &momento.TopicPublishRequest{
 			CacheName: cacheName,
 			TopicName: topicName,
 			Value:     momento.String(fmt.Sprintf("hello %d", i)),
+		})
+		if err != nil {
+			panic(err)
+		}
+		time.Sleep(time.Second)
+	}
+	for i := 0; i < 5; i++ {
+		fmt.Printf("publishing message %d\n", i)
+		_, err := client.Publish(ctx, &momento.TopicPublishRequest{
+			CacheName: cacheName,
+			TopicName: topicName,
+			Value:     momento.Bytes(fmt.Sprintf("hello %d", i)),
 		})
 		if err != nil {
 			panic(err)

--- a/examples/readme.go
+++ b/examples/readme.go
@@ -16,7 +16,7 @@ import (
 func main() {
 	context := context.Background()
 	configuration := config.LaptopLatestWithLogger(logger.NewNoopMomentoLoggerFactory()).WithClientTimeout(15 * time.Second)
-	credentialProvider, err := auth.NewEnvMomentoTokenProvider("MOMENTO_AUTH_TOKEN")
+	credentialProvider, err := auth.NewEnvMomentoTokenProvider("MOMENTO_API_KEY")
 	if err != nil {
 		panic(err)
 	}

--- a/examples/scalar-example/main.go
+++ b/examples/scalar-example/main.go
@@ -15,7 +15,7 @@ import (
 
 func main() {
 	ctx := context.Background()
-	var credentialProvider, err = auth.NewEnvMomentoTokenProvider("MOMENTO_AUTH_TOKEN")
+	var credentialProvider, err = auth.NewEnvMomentoTokenProvider("MOMENTO_API_KEY")
 	if err != nil {
 		panic(err)
 	}

--- a/examples/set-example/main.go
+++ b/examples/set-example/main.go
@@ -25,7 +25,7 @@ var (
 
 func setup() {
 	ctx = context.Background()
-	var credentialProvider, err = auth.NewEnvMomentoTokenProvider("MOMENTO_AUTH_TOKEN")
+	var credentialProvider, err = auth.NewEnvMomentoTokenProvider("MOMENTO_API_KEY")
 	if err != nil {
 		panic(err)
 	}

--- a/examples/sortedset-example/main.go
+++ b/examples/sortedset-example/main.go
@@ -85,7 +85,7 @@ func main() {
 }
 
 func getClient() momento.CacheClient {
-	credProvider, err := auth.NewEnvMomentoTokenProvider("MOMENTO_AUTH_TOKEN")
+	credProvider, err := auth.NewEnvMomentoTokenProvider("MOMENTO_API_KEY")
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
Addresses the golang task in [#452](https://github.com/momentohq/dev-eco-issue-tracker/issues/452) and also renames the environment variable used in the examples from MOMENTO_AUTH_TOKEN to MOMENTO_API_KEY as per recent changes (might not be necessary though, can undo renaming if so).