### PR TITLE
chore: add docs examples for topics and use switch to check message type

### DIFF
--- a/examples/pubsub-example/main.go
+++ b/examples/pubsub-example/main.go
@@ -47,7 +47,12 @@ func pollForMessages(ctx context.Context, sub momento.TopicSubscription) {
 		if err != nil {
 			panic(err)
 		}
-		fmt.Printf("received message: '%v'\n", item)
+		switch msg := item.(type) {
+		case momento.String:
+			fmt.Printf("received message as string: '%v'\n", msg)
+		case momento.Bytes:
+			fmt.Printf("received message as bytes: '%v'\n", msg)
+		}
 	}
 }
 
@@ -93,12 +98,24 @@ func setupCache(client momento.CacheClient, ctx context.Context) {
 }
 
 func publishMessages(client momento.TopicClient, ctx context.Context) {
-	for i := 0; i < 100; i++ {
+	for i := 0; i < 5; i++ {
 		fmt.Printf("publishing message %d\n", i)
 		_, err := client.Publish(ctx, &momento.TopicPublishRequest{
 			CacheName: cacheName,
 			TopicName: topicName,
 			Value:     momento.String(fmt.Sprintf("hello %d", i)),
+		})
+		if err != nil {
+			panic(err)
+		}
+		time.Sleep(time.Second)
+	}
+	for i := 0; i < 5; i++ {
+		fmt.Printf("publishing message %d\n", i)
+		_, err := client.Publish(ctx, &momento.TopicPublishRequest{
+			CacheName: cacheName,
+			TopicName: topicName,
+			Value:     momento.Bytes(fmt.Sprintf("hello %d", i)),
 		})
 		if err != nil {
 			panic(err)


### PR DESCRIPTION
Addresses the golang task in [#452](https://github.com/momentohq/dev-eco-issue-tracker/issues/452) by using a switch statement to branch on string vs binary received messages.

Addresses the golang part of [#459](https://github.com/momentohq/dev-eco-issue-tracker/issues/459) by adding code snippets for instantiating a topic client, publishing to a topic, and subscribing to a topic. These examples will be used [on this page](https://docs.momentohq.com/develop/api-reference/topics).