### PR TITLE
feat: add batch set if not exists to batchutils

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.20.x
+          go-version: 1.19.x
 
       - name: Install devtools
         run: make install-devtools

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.19.x
+          go-version: 1.20.x
 
       - name: Install devtools
         run: make install-devtools

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-GOFILES_NOT_NODE = $(shell find . -type f -name '*.go' -not -path "./examples/lambda-examples/simple-get/infrastructure/*")
+GOFILES_NOT_NODE = $(shell find . -type f -name '*.go' -not -path "./examples/aws-lambda/infrastructure/*")
 
 .PHONY: install-devtools
 install-devtools:

--- a/batchutils/batch_set_if_not_exists.go
+++ b/batchutils/batch_set_if_not_exists.go
@@ -3,6 +3,7 @@ package batchutils
 import (
 	"context"
 	"errors"
+	"fmt"
 	"time"
 
 	"github.com/momentohq/client-sdk-go/momento"
@@ -48,7 +49,8 @@ func BatchSetIfNotExists(ctx context.Context, props *BatchSetIfNotExistsRequest)
 			}
 		}
 	default:
-		return nil, nil, err
+		var message = fmt.Sprintf("Unexpected KeysExistResponse type: %T\n", resp)
+		return nil, nil, momento.NewMomentoError(momento.ClientSdkError, message, errors.New(message))
 	}
 
 	// If none of the keys exist, set the items using BatchSet

--- a/batchutils/batch_set_if_not_exists.go
+++ b/batchutils/batch_set_if_not_exists.go
@@ -29,15 +29,43 @@ func ExtractKeys(items Items) []momento.Key {
 	return list
 }
 
+// BatchSetIfNotExistsError contains a map associating failing cache keys with their specific errors.
+// Errors may be related to keys already existing or batch set failing.
+// It may be necessary to use a type assertion to access the errors:
+//
+// errors := (err.(*BatchSetIfNotExistsError)).Errors()
+type BatchSetIfNotExistsError struct {
+	errors map[momento.Key]error
+}
+
+func (e *BatchSetIfNotExistsError) Error() string {
+	return "Errors occurred during BatchSetIfNotExists; call Errors() to get a map of key -> errorType"
+}
+
+// Errors contains a map associating errors with their cache keys.
+func (e *BatchSetIfNotExistsError) Errors() map[momento.Key]error {
+	return e.errors
+}
+
+func CreateErrorMapping(keys []momento.Key, err error) map[momento.Key]error {
+	var errors = make(map[momento.Key]error, len(keys))
+	for i := 0; i < len(keys); i++ {
+		errors[keys[i]] = err
+	}
+	return errors
+}
+
 // BatchSetIfNotExists will set the key-value pairs ONLY if all keys don't already exist
-func BatchSetIfNotExists(ctx context.Context, props *BatchSetIfNotExistsRequest) (*BatchSetResponse, error) {
+func BatchSetIfNotExists(ctx context.Context, props *BatchSetIfNotExistsRequest) (*BatchSetResponse, *BatchSetIfNotExistsError) {
 	// First check if all keys exist or not
+	keys := ExtractKeys(props.Items)
 	resp, err := props.Client.KeysExist(ctx, &momento.KeysExistRequest{
 		CacheName: props.CacheName,
-		Keys:      ExtractKeys(props.Items),
+		Keys:      keys,
 	})
 	if err != nil {
-		return nil, err
+		var keysExistsError = &BatchSetIfNotExistsError{errors: CreateErrorMapping(keys, err)}
+		return nil, keysExistsError
 	}
 
 	switch result := resp.(type) {
@@ -45,12 +73,16 @@ func BatchSetIfNotExists(ctx context.Context, props *BatchSetIfNotExistsRequest)
 		// Check if any of the keys already exist
 		for _, keyExists := range result.Exists() {
 			if keyExists {
-				return nil, momento.NewMomentoError(momento.AlreadyExistsError, "At least one key already exists", errors.New("at least one key already exists"))
+				var momentoError = momento.NewMomentoError(momento.AlreadyExistsError, "At least one key already exists", errors.New("at least one key already exists"))
+				var atLeastOneKeyExistsError = &BatchSetIfNotExistsError{errors: CreateErrorMapping(keys, momentoError)}
+				return nil, atLeastOneKeyExistsError
 			}
 		}
 	default:
 		var message = fmt.Sprintf("Unexpected KeysExistResponse type: %T\n", resp)
-		return nil, momento.NewMomentoError(momento.ClientSdkError, message, errors.New(message))
+		var unexpectedError = momento.NewMomentoError(momento.ClientSdkError, message, errors.New(message))
+		var unexpectedResponseError = &BatchSetIfNotExistsError{errors: CreateErrorMapping(keys, unexpectedError)}
+		return nil, unexpectedResponseError
 	}
 
 	// If none of the keys exist, set the items using BatchSet
@@ -59,6 +91,8 @@ func BatchSetIfNotExists(ctx context.Context, props *BatchSetIfNotExistsRequest)
 		CacheName: props.CacheName,
 		Items:     props.Items,
 	})
-	// Join will return nil if there are no errors in setBatchError
-	return setBatchResponse, errors.Join(setBatchError)
+	if setBatchError != nil {
+		return nil, &BatchSetIfNotExistsError{errors: setBatchError.Errors()}
+	}
+	return setBatchResponse, nil
 }

--- a/batchutils/batch_set_if_not_exists.go
+++ b/batchutils/batch_set_if_not_exists.go
@@ -1,0 +1,61 @@
+package batchutils
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/momentohq/client-sdk-go/momento"
+	"github.com/momentohq/client-sdk-go/responses"
+)
+
+type BatchSetIfNotExistsRequest struct {
+	Client            momento.CacheClient
+	CacheName         string
+	Items             []BatchSetItem
+	MaxConcurrentSets int
+	// timeout for individual requests, defaults to 10 seconds
+	RequestTimeout *time.Duration
+}
+
+type Items []BatchSetItem
+
+func ExtractKeys(items Items) []momento.Key {
+	var list []momento.Key
+	for _, item := range items {
+		list = append(list, item.Key)
+	}
+	return list
+}
+
+// BatchSetIfNotExists will set the key-value pairs ONLY if all keys don't already exist
+func BatchSetIfNotExists(ctx context.Context, props *BatchSetIfNotExistsRequest) (*BatchSetResponse, *BatchSetError, error) {
+	// First check if all keys exist or not
+	resp, err := props.Client.KeysExist(ctx, &momento.KeysExistRequest{
+		CacheName: props.CacheName,
+		Keys:      ExtractKeys(props.Items),
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+
+	switch result := resp.(type) {
+	case *responses.KeysExistSuccess:
+		// Check if any of the keys already exist
+		for _, keyExists := range result.Exists() {
+			if keyExists {
+				return nil, nil, momento.NewMomentoError(momento.AlreadyExistsError, "At least one key already exists", errors.New("at least one key already exists"))
+			}
+		}
+	default:
+		return nil, nil, err
+	}
+
+	// If none of the keys exist, set the items using BatchSet
+	setBatchResponse, setBatchError := BatchSet(ctx, &BatchSetRequest{
+		Client:    props.Client,
+		CacheName: props.CacheName,
+		Items:     props.Items,
+	})
+	return setBatchResponse, setBatchError, nil
+}

--- a/batchutils/batch_set_test.go
+++ b/batchutils/batch_set_test.go
@@ -307,7 +307,7 @@ var _ = Describe("Batch set operations", func() {
 				Items:     items,
 			})
 
-			Expect(errors.Unwrap(err)).To(BeNil())
+			Expect(err).To(BeNil())
 
 			setResponses := setBatchResponse.Responses()
 			Expect(len(setResponses)).To(Equal(len(items)))
@@ -368,7 +368,12 @@ var _ = Describe("Batch set operations", func() {
 				Items:     items,
 			})
 
-			Expect(err).To(Equal(NewMomentoError(AlreadyExistsError, "At least one key already exists", errors.New("at least one key already exists"))))
+			Expect(len(err.Errors())).To(Equal(len(items)))
+			Expect(err.Error()).To(Equal("Errors occurred during BatchSetIfNotExists; call Errors() to get a map of key -> errorType"))
+			for i := 0; i < 10; i++ {
+				var key = items[i].Key
+				Expect(err.Errors()[key]).To(Equal(NewMomentoError(AlreadyExistsError, "At least one key already exists", errors.New("at least one key already exists"))))
+			}
 
 			getBatch, _ := batchutils.BatchGet(ctx, &batchutils.BatchGetRequest{
 				Client:    client,

--- a/batchutils/batch_set_test.go
+++ b/batchutils/batch_set_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/momentohq/client-sdk-go/batchutils"
 	"github.com/momentohq/client-sdk-go/config"
 	"github.com/momentohq/client-sdk-go/config/logger"
-	"github.com/momentohq/client-sdk-go/momento"
 	. "github.com/momentohq/client-sdk-go/momento"
 	"github.com/momentohq/client-sdk-go/responses"
 	. "github.com/onsi/ginkgo/v2"
@@ -336,14 +335,12 @@ var _ = Describe("Batch set operations", func() {
 		})
 
 		It("some keys already exist", func() {
-			var batchSetKeys []Key
 			var unsetKeys []Key
 			var items []batchutils.BatchSetItem
 			var setItems []batchutils.BatchSetItem
 
 			for i := 0; i < 10; i++ {
 				key := String(fmt.Sprintf("MSETNXk%d", i))
-				batchSetKeys = append(batchSetKeys, key)
 				item := batchutils.BatchSetItem{
 					Key:   key,
 					Value: String(fmt.Sprintf("MSETNXv%d", i)),
@@ -371,7 +368,7 @@ var _ = Describe("Batch set operations", func() {
 				Items:     items,
 			})
 
-			Expect(err).To(Equal(momento.NewMomentoError(momento.AlreadyExistsError, "At least one key already exists", errors.New("at least one key already exists"))))
+			Expect(err).To(Equal(NewMomentoError(AlreadyExistsError, "At least one key already exists", errors.New("at least one key already exists"))))
 
 			getBatch, _ := batchutils.BatchGet(ctx, &batchutils.BatchGetRequest{
 				Client:    client,

--- a/batchutils/batch_set_test.go
+++ b/batchutils/batch_set_test.go
@@ -301,13 +301,13 @@ var _ = Describe("Batch set operations", func() {
 				items = append(items, item)
 			}
 
-			setBatchResponse, _, err := batchutils.BatchSetIfNotExists(ctx, &batchutils.BatchSetIfNotExistsRequest{
+			setBatchResponse, err := batchutils.BatchSetIfNotExists(ctx, &batchutils.BatchSetIfNotExistsRequest{
 				Client:    client,
 				CacheName: cacheName,
 				Items:     items,
 			})
 
-			Expect(err).To(BeNil())
+			Expect(errors.Unwrap(err)).To(BeNil())
 
 			setResponses := setBatchResponse.Responses()
 			Expect(len(setResponses)).To(Equal(len(items)))
@@ -362,7 +362,7 @@ var _ = Describe("Batch set operations", func() {
 			setResponses := setBatch.Responses()
 			Expect(len(setResponses)).To(Equal(len(setItems)))
 
-			_, _, err := batchutils.BatchSetIfNotExists(ctx, &batchutils.BatchSetIfNotExistsRequest{
+			_, err := batchutils.BatchSetIfNotExists(ctx, &batchutils.BatchSetIfNotExistsRequest{
 				Client:    client,
 				CacheName: cacheName,
 				Items:     items,

--- a/examples/go.mod
+++ b/examples/go.mod
@@ -1,6 +1,6 @@
 module github.com/momentohq/go-example
 
-go 1.20
+go 1.19
 
 require (
 	// the hrtime and hdrhistogram-go modules are not required to use momento, but

--- a/examples/go.mod
+++ b/examples/go.mod
@@ -1,6 +1,6 @@
 module github.com/momentohq/go-example
 
-go 1.17
+go 1.20
 
 require (
 	// the hrtime and hdrhistogram-go modules are not required to use momento, but

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/momentohq/client-sdk-go
 
-go 1.20
+go 1.19
 
 require (
 	github.com/golang-jwt/jwt/v4 v4.3.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/momentohq/client-sdk-go
 
-go 1.18
+go 1.20
 
 require (
 	github.com/golang-jwt/jwt/v4 v4.3.0


### PR DESCRIPTION
Addresses [#463](https://github.com/momentohq/dev-eco-issue-tracker/issues/463) by adding a client-side implementation of `MSETNX`, named `batchSetIfNotExists` here, as part of the `batchutils` package.

Also corrected a line in the makefile that was preventing `make lint` from working properly.