### PR TITLE
fix: don't check for connection state when trying to resubscribe

### DIFF
--- a/momento/topic_subscription.go
+++ b/momento/topic_subscription.go
@@ -10,7 +10,6 @@ import (
 	pb "github.com/momentohq/client-sdk-go/internal/protos"
 
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/connectivity"
 )
 
 type TopicSubscription interface {
@@ -82,11 +81,6 @@ func (s *topicSubscription) Item(ctx context.Context) (TopicValue, error) {
 }
 
 func (s *topicSubscription) attemptReconnect(ctx context.Context) {
-	// make sure the connection isn't ready, if its ready no need to reconnect
-	if s.topicManager.Conn.GetState() == connectivity.Ready {
-		s.log.Debug("connection is in ready state, not reconnecting")
-		return
-	}
 	// try and reconnect every n seconds. This will attempt to reconnect indefinetly
 	seconds := 5 * time.Second
 	for {


### PR DESCRIPTION
The `getConnectivityState` api is an experimental api. A customer got into a state where the connection thought that it was in a correct connected state, but kept erroring out when trying to receive a message from our service.

This change removes the connectivity state check because
- its an experimental api
- there was no pausing between us saying the connectivity state was in the correct state, and us trying to recieve a message and it failing, causing an infinite loop

I have not been able to reproduce the issue that the customer was facing, but based up the feedback they gave and what I see inside of the code, I believe this should fix their issue 