### PR TITLE
fix: use just one grpc connection for topics

### DIFF
--- a/internal/grpcmanagers/topic_manager.go
+++ b/internal/grpcmanagers/topic_manager.go
@@ -27,6 +27,7 @@ func NewStreamTopicGrpcManager(request *models.TopicStreamGrpcManagerRequest) (*
 		endpoint,
 		grpc.WithTransportCredentials(credentials.NewTLS(config)),
 		grpc.WithChainStreamInterceptor(interceptor.AddStreamHeaderInterceptor(authToken)),
+		grpc.WithChainUnaryInterceptor(interceptor.AddHeadersInterceptor(authToken)),
 	)
 
 	if err != nil {


### PR DESCRIPTION
Addresses https://github.com/momentohq/dev-eco-issue-tracker/issues/503

Publish and Subscribe now share grpc connections rather than having one for each.