### PR TITLE
feat: use NumGrpcChannels to configure topic client instead of NumMaxSubscriptions

### DIFF
--- a/config/topics_config.go
+++ b/config/topics_config.go
@@ -28,12 +28,12 @@ type TopicsConfiguration interface {
 	// Deprecated: Use GetNumGrpcChannels instead.
 	GetMaxSubscriptions() uint32
 
-	// Deprecated: using maxSubscriptions can result in edge cases where the topics client could
-	// bottleneck the publishing a large volume of messages as each GRPC connection can multiplex
-	// only 100 requests and only one multiplex stream would be available for the publisher.
+	// Deprecated: maxSubscriptions is currently implemented to create one GRPC connection for every
+	// 100 subscribers. Can result in edge cases where subscribers and publishers are in contention
+	// and may bottleneck a large volume of publish requests.
 	//
-	// Please use WithNumGrpcChannels instead as per your use case. One GRPC connection can
-	// support 100 subscribers/publishers.
+	// Please use WithNumGrpcChannels instead as per your use case.
+	// One GRPC connection can multiplex 100 subscribers/publishers.
 	WithMaxSubscriptions(maxSubscriptions uint32) TopicsConfiguration
 
 	// GetNumGrpcChannels Returns the configuration option for the number of GRPC channels

--- a/config/topics_config.go
+++ b/config/topics_config.go
@@ -7,6 +7,7 @@ import (
 type topicsConfiguration struct {
 	loggerFactory    logger.MomentoLoggerFactory
 	maxSubscriptions uint32
+	numGrpcChannels  uint32
 }
 
 type TopicsConfigurationProps struct {
@@ -14,6 +15,8 @@ type TopicsConfigurationProps struct {
 	LoggerFactory logger.MomentoLoggerFactory
 
 	MaxSubscriptions uint32
+
+	NumGrpcChannels uint32
 }
 
 type TopicsConfiguration interface {
@@ -22,15 +25,29 @@ type TopicsConfiguration interface {
 
 	// GetMaxSubscriptions Returns the configuration option for the maximum number of subscriptions
 	// a client is allowed
+	// Deprecated: Use GetNumGrpcChannels instead.
 	GetMaxSubscriptions() uint32
 
+	// Deprecated: using maxSubscriptions can result in edge cases where the topics client could
+	// bottleneck the publishing a large volume of messages as each GRPC connection can multiplex
+	// only 100 requests and only one multiplex stream would be available for the publisher.
+	//
+	// Please use WithNumGrpcChannels instead as per your use case. One GRPC connection can
+	// support 100 subscribers/publishers.
 	WithMaxSubscriptions(maxSubscriptions uint32) TopicsConfiguration
+
+	// GetNumGrpcChannels Returns the configuration option for the number of GRPC channels
+	// the topic client should open and work with.
+	GetNumGrpcChannels() uint32
+
+	WithNumGrpcChannels(numGrpcChannels uint32) TopicsConfiguration
 }
 
 func NewTopicConfiguration(props *TopicsConfigurationProps) TopicsConfiguration {
 	return &topicsConfiguration{
 		loggerFactory:    props.LoggerFactory,
 		maxSubscriptions: props.MaxSubscriptions,
+		numGrpcChannels:  props.NumGrpcChannels,
 	}
 }
 
@@ -46,5 +63,16 @@ func (s *topicsConfiguration) WithMaxSubscriptions(maxSubscriptions uint32) Topi
 	return &topicsConfiguration{
 		loggerFactory:    s.loggerFactory,
 		maxSubscriptions: maxSubscriptions,
+	}
+}
+
+func (s *topicsConfiguration) GetNumGrpcChannels() uint32 {
+	return s.numGrpcChannels
+}
+
+func (s *topicsConfiguration) WithNumGrpcChannels(numGrpcChannels uint32) TopicsConfiguration {
+	return &topicsConfiguration{
+		loggerFactory:   s.loggerFactory,
+		numGrpcChannels: numGrpcChannels,
 	}
 }

--- a/momento/pubsub_client.go
+++ b/momento/pubsub_client.go
@@ -24,13 +24,20 @@ func newPubSubClient(request *models.PubSubClientRequest) (*pubSubClient, moment
 	var numChannels uint32
 	numSubscriptions := float64(request.TopicsConfiguration.GetMaxSubscriptions())
 	numGrpcChannels := request.TopicsConfiguration.GetNumGrpcChannels()
-	if numSubscriptions > 0 {
+
+	// numSubscriptions is deprecated. Nevertheless, check that numGrpcChannels and numSubscriptions
+	// are not both set. They should be mutually exclusive configs.
+	if numGrpcChannels > 0 && numSubscriptions > 0 {
+		return nil, NewMomentoError(momentoerrors.InvalidArgumentError, "Cannot accept both maxSubscriptions and numGrpcChannels as arguments; please use numGrpcChannels as maxSubscriptions is deprecated", nil)
+	}
+
+	if numGrpcChannels > 0 {
+		numChannels = numGrpcChannels
+	} else if numSubscriptions > 0 {
 		// a single channel can support 100 streams, so we need to create enough
 		// channels to handle the maximum number of subscriptions
 		// plus one for the publishing channel
 		numChannels = uint32(math.Ceil((numSubscriptions + 1) / 100.0))
-	} else if numGrpcChannels > 0 {
-		numChannels = numGrpcChannels
 	} else {
 		numChannels = 1
 	}

--- a/momento/pubsub_client.go
+++ b/momento/pubsub_client.go
@@ -23,11 +23,14 @@ var streamTopicManagerCount uint64
 func newPubSubClient(request *models.PubSubClientRequest) (*pubSubClient, momentoerrors.MomentoSvcErr) {
 	var numChannels uint32
 	numSubscriptions := float64(request.TopicsConfiguration.GetMaxSubscriptions())
+	numGrpcChannels := request.TopicsConfiguration.GetNumGrpcChannels()
 	if numSubscriptions > 0 {
 		// a single channel can support 100 streams, so we need to create enough
 		// channels to handle the maximum number of subscriptions
 		// plus one for the publishing channel
 		numChannels = uint32(math.Ceil((numSubscriptions + 1) / 100.0))
+	} else if numGrpcChannels > 0 {
+		numChannels = numGrpcChannels
 	} else {
 		numChannels = 1
 	}


### PR DESCRIPTION
Addresses https://github.com/momentohq/dev-eco-issue-tracker/issues/529