### PR TITLE
feat: warn users if approaching grpc max concurrent streams limit, add method to close topics subscriptions

### DIFF
--- a/internal/models/requests.go
+++ b/internal/models/requests.go
@@ -3,6 +3,7 @@ package models
 import (
 	"time"
 
+	"github.com/momentohq/client-sdk-go/config/logger"
 	"github.com/momentohq/client-sdk-go/internal/retry"
 
 	"github.com/momentohq/client-sdk-go/auth"
@@ -61,6 +62,7 @@ type DataClientRequest struct {
 type PubSubClientRequest struct {
 	TopicsConfiguration config.TopicsConfiguration
 	CredentialProvider  auth.CredentialProvider
+	Log                 logger.MomentoLogger
 }
 
 type PingClientRequest struct {

--- a/momento/pubsub_client.go
+++ b/momento/pubsub_client.go
@@ -92,7 +92,7 @@ func (client *pubSubClient) topicSubscribe(ctx context.Context, request *TopicSu
 	}
 
 	if numGrpcStreams > 0 && (int64(numChannels*100)-numGrpcStreams < 10) {
-		client.log.Info(fmt.Sprintf("WARNING: approaching grpc maximum concurrent stream limit, %d remaining of total %d streams\n", int64(numChannels*100)-numGrpcStreams, numChannels*100))
+		client.log.Warn(fmt.Sprintf("WARNING: approaching grpc maximum concurrent stream limit, %d remaining of total %d streams\n", int64(numChannels*100)-numGrpcStreams, numChannels*100))
 	}
 
 	return topicManager, clientStream, cancelContext, cancelFunction, err

--- a/momento/pubsub_client.go
+++ b/momento/pubsub_client.go
@@ -146,6 +146,6 @@ func (client *pubSubClient) close() {
 
 func checkNumConcurrentStreams(log logger.MomentoLogger) {
 	if numGrpcStreams > 0 && numGrpcStreams >= int64(numChannels*100) {
-		log.Info("Already at maximum number of concurrent grpc streams, cannot make new publish or subscribe requests")
+		log.Warn("Already at maximum number of concurrent grpc streams, cannot make new publish or subscribe requests")
 	}
 }

--- a/momento/topic_client.go
+++ b/momento/topic_client.go
@@ -58,7 +58,7 @@ func (c defaultTopicClient) Subscribe(ctx context.Context, request *TopicSubscri
 		return nil, err
 	}
 
-	topicManager, clientStream, err := c.pubSubClient.topicSubscribe(ctx, &TopicSubscribeRequest{
+	topicManager, clientStream, cancelContext, cancelFunction, err := c.pubSubClient.topicSubscribe(ctx, &TopicSubscribeRequest{
 		CacheName: request.CacheName,
 		TopicName: request.TopicName,
 	})
@@ -90,6 +90,8 @@ func (c defaultTopicClient) Subscribe(ctx context.Context, request *TopicSubscri
 		cacheName:          request.CacheName,
 		topicName:          request.TopicName,
 		log:                c.log,
+		cancelContext:      cancelContext,
+		cancelFunction:     cancelFunction,
 	}, nil
 }
 

--- a/momento/topic_client.go
+++ b/momento/topic_client.go
@@ -38,6 +38,7 @@ func NewTopicClient(topicsConfiguration config.TopicsConfiguration, credentialPr
 	pubSubClient, err := newPubSubClient(&models.PubSubClientRequest{
 		CredentialProvider:  credentialProvider,
 		TopicsConfiguration: topicsConfiguration,
+		Log:                 client.log,
 	})
 	if err != nil {
 		return nil, convertMomentoSvcErrorToCustomerError(momentoerrors.ConvertSvcErr(err))

--- a/momento/topic_client_test.go
+++ b/momento/topic_client_test.go
@@ -10,7 +10,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/momentohq/client-sdk-go/momento"
 	. "github.com/momentohq/client-sdk-go/momento"
 	. "github.com/momentohq/client-sdk-go/momento/test_helpers"
 )
@@ -205,9 +204,9 @@ var _ = Describe("Pubsub", func() {
 			panic(err)
 		}
 		switch msg := item.(type) {
-		case momento.String:
+		case String:
 			Expect(msg).To(Equal(String("hello-1")))
-		case momento.Bytes:
+		case Bytes:
 			Fail("Expected topic item to be a string")
 		}
 
@@ -216,9 +215,9 @@ var _ = Describe("Pubsub", func() {
 			panic(err)
 		}
 		switch msg := item.(type) {
-		case momento.String:
+		case String:
 			Expect(msg).To(Equal(String("hello-2")))
-		case momento.Bytes:
+		case Bytes:
 			Fail("Expected topic item to be a string")
 		}
 
@@ -254,9 +253,9 @@ var _ = Describe("Pubsub", func() {
 			panic(err)
 		}
 		switch msg := item.(type) {
-		case momento.String:
+		case String:
 			Expect(msg).To(Equal(String("hello-again-2")))
-		case momento.Bytes:
+		case Bytes:
 			Fail("Expected topic item to be a string")
 		}
 	})

--- a/momento/topic_subscription.go
+++ b/momento/topic_subscription.go
@@ -3,6 +3,7 @@ package momento
 import (
 	"context"
 	"fmt"
+	"sync/atomic"
 	"time"
 
 	"github.com/momentohq/client-sdk-go/config/logger"
@@ -112,5 +113,6 @@ func (s *topicSubscription) attemptReconnect(ctx context.Context) {
 }
 
 func (s *topicSubscription) Close() {
+	atomic.AddInt64(&numGrpcStreams, -1)
 	s.cancelFunction()
 }


### PR DESCRIPTION
Addresses https://github.com/momentohq/dev-eco-issue-tracker/issues/530

Uses an atomic int to count the number of actively used concurrent grpc streams. Allows us to warn users if they are approaching the grpc max concurrent streams limit given the number of grpc channels they have created. Currently warns users if they have <= 10 streams available given a maximum of 100*numGrpcChannels streams.

- Increment before calling `Subscribe`
- Decrement if `Subscribe` returned an error
- Increment before calling `Publish`
- Decrement after calling `Publish`
- Decrement after calling `Close` on a `TopicSubscription`
- Set number of streams to 0 when `Close` is called