### PR TITLE
feat: add number of grpc channels as cache client config

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -15,6 +15,8 @@ type ConfigurationProps struct {
 	TransportStrategy TransportStrategy
 	// RetryStrategy defines a contract for how and when to retry a request.
 	RetryStrategy retry.Strategy
+	// NumGrpcChannels is the number of GRPC channels the client should open and work with.
+	NumGrpcChannels uint32
 }
 
 type Configuration interface {
@@ -30,23 +32,32 @@ type Configuration interface {
 	// GetClientSideTimeout Returns the current configuration options for client side timeout with the Momento service
 	GetClientSideTimeout() time.Duration
 
+	// GetNumGrpcChannels Returns the configuration option for the number of GRPC channels
+	// the cache client should open and work with.
+	GetNumGrpcChannels() uint32
+
 	// WithRetryStrategy Copy constructor for overriding TransportStrategy returns a new Configuration object
 	// with the specified momento.TransportStrategy
 	WithRetryStrategy(retryStrategy retry.Strategy) Configuration
 
 	// WithClientTimeout Copy constructor for overriding TransportStrategy client side timeout. Returns a new
-	//Configuration object with the specified momento.TransportStrategy using passed client side timeout.
+	// Configuration object with the specified momento.TransportStrategy using passed client side timeout.
 	WithClientTimeout(clientTimeout time.Duration) Configuration
 
 	// WithTransportStrategy Copy constructor for overriding TransportStrategy returns a new Configuration object
 	// with the specified momento.TransportStrategy
 	WithTransportStrategy(transportStrategy TransportStrategy) Configuration
+
+	// WithNumGrpcChannels Copy constructor for overriding NumGrpcChannels returns a new Configuration object
+	// with the specified NumGrpcChannels
+	WithNumGrpcChannels(numGrpcChannels uint32) Configuration
 }
 
 type cacheConfiguration struct {
 	loggerFactory     logger.MomentoLoggerFactory
 	transportStrategy TransportStrategy
 	retryStrategy     retry.Strategy
+	numGrpcChannels   uint32
 }
 
 func (s *cacheConfiguration) GetLoggerFactory() logger.MomentoLoggerFactory {
@@ -62,6 +73,7 @@ func NewCacheConfiguration(props *ConfigurationProps) Configuration {
 		loggerFactory:     props.LoggerFactory,
 		transportStrategy: props.TransportStrategy,
 		retryStrategy:     props.RetryStrategy,
+		numGrpcChannels:   props.NumGrpcChannels,
 	}
 }
 
@@ -73,11 +85,16 @@ func (s *cacheConfiguration) GetRetryStrategy() retry.Strategy {
 	return s.retryStrategy
 }
 
+func (s *cacheConfiguration) GetNumGrpcChannels() uint32 {
+	return s.numGrpcChannels
+}
+
 func (s *cacheConfiguration) WithClientTimeout(clientTimeout time.Duration) Configuration {
 	return &cacheConfiguration{
 		loggerFactory:     s.loggerFactory,
 		transportStrategy: s.transportStrategy.WithClientTimeout(clientTimeout),
 		retryStrategy:     s.retryStrategy,
+		numGrpcChannels:   s.numGrpcChannels,
 	}
 }
 
@@ -86,12 +103,24 @@ func (s *cacheConfiguration) WithRetryStrategy(strategy retry.Strategy) Configur
 		loggerFactory:     s.loggerFactory,
 		transportStrategy: s.transportStrategy,
 		retryStrategy:     strategy,
+		numGrpcChannels:   s.numGrpcChannels,
 	}
 }
+
 func (s *cacheConfiguration) WithTransportStrategy(transportStrategy TransportStrategy) Configuration {
 	return &cacheConfiguration{
 		loggerFactory:     s.loggerFactory,
 		transportStrategy: transportStrategy,
 		retryStrategy:     s.retryStrategy,
+		numGrpcChannels:   s.numGrpcChannels,
+	}
+}
+
+func (s *cacheConfiguration) WithNumGrpcChannels(numGrpcChannels uint32) Configuration {
+	return &cacheConfiguration{
+		loggerFactory:     s.loggerFactory,
+		transportStrategy: s.transportStrategy,
+		retryStrategy:     s.retryStrategy,
+		numGrpcChannels:   numGrpcChannels,
 	}
 }

--- a/config/configurations.go
+++ b/config/configurations.go
@@ -25,7 +25,8 @@ func LaptopLatestWithLogger(loggerFactory logger.MomentoLoggerFactory) Configura
 				deadline: 5 * time.Second,
 			}),
 		}),
-		RetryStrategy: retry.NewFixedCountRetryStrategy(loggerFactory),
+		RetryStrategy:   retry.NewFixedCountRetryStrategy(loggerFactory),
+		NumGrpcChannels: 1,
 	})
 }
 
@@ -44,7 +45,8 @@ func InRegionLatestWithLogger(loggerFactory logger.MomentoLoggerFactory) Configu
 				deadline: 1100 * time.Millisecond,
 			}),
 		}),
-		RetryStrategy: retry.NewFixedCountRetryStrategy(loggerFactory),
+		RetryStrategy:   retry.NewFixedCountRetryStrategy(loggerFactory),
+		NumGrpcChannels: 1,
 	})
 }
 
@@ -63,6 +65,7 @@ func LambdaWithLogger(loggerFactory logger.MomentoLoggerFactory) Configuration {
 				deadline: 1100 * time.Millisecond,
 			}),
 		}),
-		RetryStrategy: retry.NewFixedCountRetryStrategy(loggerFactory),
+		RetryStrategy:   retry.NewFixedCountRetryStrategy(loggerFactory),
+		NumGrpcChannels: 1,
 	})
 }


### PR DESCRIPTION
Config allows creation of `numGrpcChannels` number of data clients in the CacheClient.

Did local testing and observed in the default case, there's 3 TCP connections (1 control client, 1 data client, 1 ping client). 
When using `WithNumGrpcChannels(4)`, there are 6 TCP connections (1 control client, 4 data client, 1 ping client). 