### PR TITLE
fix: race condition that can cause batchutils to leak goroutines

### DIFF
--- a/batchutils/batch_delete.go
+++ b/batchutils/batch_delete.go
@@ -95,7 +95,7 @@ func BatchDelete(ctx context.Context, props *BatchDeleteRequest) *BatchDeleteErr
 		}()
 	}
 
-	go keyDistributor(cancelCtx, props.Keys, keyChan)
+	go keyDistributor(cancelCtx, props.Client.Logger(), props.MaxConcurrentDeletes, props.Keys, keyChan)
 
 	// wait for the workers to return
 	wg.Wait()

--- a/batchutils/batch_get.go
+++ b/batchutils/batch_get.go
@@ -118,7 +118,7 @@ func BatchGet(ctx context.Context, props *BatchGetRequest) (*BatchGetResponse, *
 		}()
 	}
 
-	go keyDistributor(cancelCtx, props.Keys, keyChan)
+	go keyDistributor(cancelCtx, props.Client.Logger(), props.MaxConcurrentGets, props.Keys, keyChan)
 
 	// wait for the workers to return
 	wg.Wait()

--- a/batchutils/batch_operations.go
+++ b/batchutils/batch_operations.go
@@ -2,8 +2,9 @@ package batchutils
 
 import (
 	"context"
-	"github.com/momentohq/client-sdk-go/config/logger"
 	"time"
+
+	"github.com/momentohq/client-sdk-go/config/logger"
 
 	"github.com/momentohq/client-sdk-go/momento"
 )

--- a/batchutils/batch_operations.go
+++ b/batchutils/batch_operations.go
@@ -33,12 +33,9 @@ func keyDistributor(ctx context.Context, logger logger.MomentoLogger, numWorkers
 
 	logger.Trace("keyDistributor has put a nil on the channel for each worker")
 
-	for {
-		select {
-		case <-ctx.Done():
-			logger.Trace("keyDistributor context done, exiting for loop")
-			return
-		}
+	for range ctx.Done() {
+		logger.Trace("keyDistributor context done, exiting for loop")
+		return
 	}
 }
 

--- a/batchutils/batch_set.go
+++ b/batchutils/batch_set.go
@@ -2,9 +2,10 @@ package batchutils
 
 import (
 	"context"
-	"github.com/momentohq/client-sdk-go/config/logger"
 	"sync"
 	"time"
+
+	"github.com/momentohq/client-sdk-go/config/logger"
 
 	"github.com/momentohq/client-sdk-go/momento"
 	"github.com/momentohq/client-sdk-go/responses"

--- a/batchutils/batch_set.go
+++ b/batchutils/batch_set.go
@@ -116,12 +116,9 @@ func itemDistributor(ctx context.Context, logger logger.MomentoLogger, numWorker
 
 	logger.Trace("itemDistributor has put a nil on the channel for each worker")
 
-	for {
-		select {
-		case <-ctx.Done():
-			logger.Trace("itemDistributor context done, exiting for loop")
-			return
-		}
+	for range ctx.Done() {
+		logger.Trace("itemDistributor context done, exiting for loop")
+		return
 	}
 }
 

--- a/momento/cache_client.go
+++ b/momento/cache_client.go
@@ -21,6 +21,8 @@ import (
 var dataClientCount uint64
 
 type CacheClient interface {
+	Logger() logger.MomentoLogger
+
 	// CreateCache Creates a cache if it does not exist.
 	CreateCache(ctx context.Context, request *CreateCacheRequest) (responses.CreateCacheResponse, error)
 	// DeleteCache deletes a cache and all the items within it.
@@ -288,6 +290,10 @@ func NewCacheClientWithDefaultCache(configuration config.Configuration, credenti
 		EagerConnectTimeout: 30 * time.Second,
 	}
 	return commonCacheClient(props)
+}
+
+func (c defaultScsClient) Logger() logger.MomentoLogger {
+	return c.logger
 }
 
 func (c defaultScsClient) getCacheNameForRequest(request hasCacheName) string {


### PR DESCRIPTION
The batchutils use a goroutine to distribute items/keys to the
workers for batchget, batchset, batchdelete.

In these goroutines, we have a `select` block in a `for` loop,
which is blocking waiting until the context is closed. However,
in the `default` case of that select block, we try to push a
`nil` onto the channel. This is intended to be a signaling mechanism
to tell the workers that they can exit.

However, this `default` branch of the `select` may be reached
many times between when the workers complete and when the context
is cancelled. If they hit it enough times, they will fill up the
channel to its maximum size, and enter into a blocking state
where they are trying to push another `nil` onto the channel even
after all of the workers have exited. This push will never succeed
because the channel is full and no more workers are in existence
to empty the channel.

In this scenario, even though the context has been cancelled, the
goroutine will never exit the default branch of the select so that
it can execute the next iteration of the for loop, where it would
notice the cancellation and exit. Thus, the goroutine remains
running forever and leaks memory for all of the objects that it
has a reference to.

In this commit we get rid of the `default` branch of the `select`,
and instead, we simply require the caller to pass in the number of
workers as an argument. This allows us to push exactly one `nil`
onto the channel for each worker, thus preventing the race condition
and the goroutine leak.
