### PR TITLE
chore: simplify logic of batchutils functions

### DIFF
--- a/batchutils/batch_operations.go
+++ b/batchutils/batch_operations.go
@@ -1,10 +1,7 @@
 package batchutils
 
 import (
-	"context"
 	"time"
-
-	"github.com/momentohq/client-sdk-go/config/logger"
 
 	"github.com/momentohq/client-sdk-go/momento"
 )
@@ -18,26 +15,6 @@ func getRequestTimeout(propsTimeout *time.Duration) (requestTimeout time.Duratio
 		requestTimeout = *propsTimeout
 	}
 	return
-}
-
-func keyDistributor(ctx context.Context, logger logger.MomentoLogger, numWorkers int, keys []momento.Key, keyChan chan momento.Key) {
-	for _, k := range keys {
-		keyChan <- k
-	}
-
-	logger.Trace("keyDistributor has put all of the keys on the channel")
-
-	// after we have put all the keys onto the channel, we add one nil for each worker to signal that they should exit
-	for i := 0; i < numWorkers; i++ {
-		keyChan <- nil
-	}
-
-	logger.Trace("keyDistributor has put a nil on the channel for each worker")
-
-	for range ctx.Done() {
-		logger.Trace("keyDistributor context done, exiting for loop")
-		return
-	}
 }
 
 type errKeyVal struct {

--- a/batchutils/batch_set.go
+++ b/batchutils/batch_set.go
@@ -5,8 +5,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/momentohq/client-sdk-go/config/logger"
-
 	"github.com/momentohq/client-sdk-go/momento"
 	"github.com/momentohq/client-sdk-go/responses"
 )
@@ -103,32 +101,9 @@ func (e *BatchSetResponse) Responses() map[momento.Value]responses.SetResponse {
 	return e.responses
 }
 
-func itemDistributor(ctx context.Context, logger logger.MomentoLogger, numWorkers int, items []BatchSetItem, itemChan chan BatchSetItem) {
-	for _, item := range items {
-		itemChan <- item
-	}
-
-	logger.Trace("itemDistributor has put all of the items on the channel")
-
-	// after we have put all the keys onto the channel, we add one nil for each worker to signal that they should exit
-	for i := 0; i < numWorkers; i++ {
-		itemChan <- BatchSetItem{}
-	}
-
-	logger.Trace("itemDistributor has put a nil on the channel for each worker")
-
-	for range ctx.Done() {
-		logger.Trace("itemDistributor context done, exiting for loop")
-		return
-	}
-}
-
 // BatchSet sets a slice of keys to the cache, returning a map from failing cache keys to their specific errors.
 func BatchSet(ctx context.Context, props *BatchSetRequest) (*BatchSetResponse, *BatchSetError) {
 	// initialize return value
-	cancelCtx, cancelFunc := context.WithCancel(ctx)
-	// stop the key distributor when we return
-	defer cancelFunc()
 	var wg sync.WaitGroup
 
 	if props.MaxConcurrentSets == 0 {
@@ -137,7 +112,7 @@ func BatchSet(ctx context.Context, props *BatchSetRequest) (*BatchSetResponse, *
 	if len(props.Items) < props.MaxConcurrentSets {
 		props.MaxConcurrentSets = len(props.Items)
 	}
-	itemChan := make(chan BatchSetItem, props.MaxConcurrentSets)
+	itemChan := make(chan BatchSetItem, len(props.Items))
 	resultChan := make(chan *setResultOrError, len(props.Items))
 
 	for i := 0; i < props.MaxConcurrentSets; i++ {
@@ -149,7 +124,18 @@ func BatchSet(ctx context.Context, props *BatchSetRequest) (*BatchSetResponse, *
 		}()
 	}
 
-	go itemDistributor(cancelCtx, props.Client.Logger(), props.MaxConcurrentSets, props.Items, itemChan)
+	for _, k := range props.Items {
+		itemChan <- k
+	}
+
+	props.Client.Logger().Trace("BatchSet: put all of the items on the channel")
+
+	// after we have put all the keys onto the channel, we add one nil for each worker to signal that they should exit
+	for i := 0; i < props.MaxConcurrentSets; i++ {
+		itemChan <- BatchSetItem{}
+	}
+
+	props.Client.Logger().Trace("BatchSet: put a nil on the channel for each worker")
 
 	// wait for the workers to return
 	wg.Wait()


### PR DESCRIPTION
This commit gets rid of a goroutine in the batch utils functions that is arguably unnecessary.

When we are populating the worker input channels, we were restricting the size of the channel to be only as large as the max number of workers. Then we needed a producer goroutine to feed the keys into that channel as the workers removed them.

However, since the response channel is already sized to handle the entire result set, and the items we put into the input channel are already in memory, sizing the channel so that it is large enough to hold pointers to all of them seems like a reasonable thing to do. It shouldn't increase memory usage much, and it simplifies the code considerably. We get rid of a goroutine and a context that we would otherwise need to be careful about leaking.