### PR TITLE
feat: add Momento Leaderboards

### DIFF
--- a/config/leaderboard_config.go
+++ b/config/leaderboard_config.go
@@ -1,0 +1,72 @@
+package config
+
+import (
+	"time"
+
+	"github.com/momentohq/client-sdk-go/config/logger"
+)
+
+type LeaderboardConfigurationProps struct {
+	// LoggerFactory represents a type used to configure the Momento logging system.
+	LoggerFactory logger.MomentoLoggerFactory
+
+	// TransportStrategy is responsible for configuring network tunables.
+	TransportStrategy TransportStrategy
+}
+
+type LeaderboardConfiguration interface {
+	// GetLoggerFactory Returns the current configuration options for logging verbosity and format
+	GetLoggerFactory() logger.MomentoLoggerFactory
+
+	// GetTransportStrategy Returns the current configuration options for wire interactions with the Momento service
+	GetTransportStrategy() TransportStrategy
+
+	// WithTransportStrategy Copy constructor for overriding TransportStrategy returns a new Configuration object
+	// with the specified momento.TransportStrategy
+	WithTransportStrategy(transportStrategy TransportStrategy) LeaderboardConfiguration
+
+	// GetClientSideTimeout Returns the current configuration options for client side timeout with the Momento service
+	GetClientSideTimeout() time.Duration
+
+	// WithClientTimeout Copy constructor for overriding TransportStrategy client side timeout. Returns a new
+	// Configuration object with the specified momento.TransportStrategy using passed client side timeout.
+	WithClientTimeout(clientTimeout time.Duration) LeaderboardConfiguration
+}
+
+type leaderboardConfiguration struct {
+	loggerFactory     logger.MomentoLoggerFactory
+	transportStrategy TransportStrategy
+}
+
+func NewLeaderboardConfiguration(props *LeaderboardConfigurationProps) LeaderboardConfiguration {
+	return &leaderboardConfiguration{
+		loggerFactory:     props.LoggerFactory,
+		transportStrategy: props.TransportStrategy,
+	}
+}
+
+func (c *leaderboardConfiguration) GetLoggerFactory() logger.MomentoLoggerFactory {
+	return c.loggerFactory
+}
+
+func (c *leaderboardConfiguration) GetTransportStrategy() TransportStrategy {
+	return c.transportStrategy
+}
+
+func (c *leaderboardConfiguration) WithTransportStrategy(transportStrategy TransportStrategy) LeaderboardConfiguration {
+	return &leaderboardConfiguration{
+		loggerFactory:     c.loggerFactory,
+		transportStrategy: transportStrategy,
+	}
+}
+
+func (c *leaderboardConfiguration) GetClientSideTimeout() time.Duration {
+	return c.transportStrategy.GetClientSideTimeout()
+}
+
+func (c *leaderboardConfiguration) WithClientTimeout(clientTimeout time.Duration) LeaderboardConfiguration {
+	return &leaderboardConfiguration{
+		loggerFactory:     c.loggerFactory,
+		transportStrategy: c.transportStrategy.WithClientTimeout(clientTimeout),
+	}
+}

--- a/config/leaderboard_configurations.go
+++ b/config/leaderboard_configurations.go
@@ -1,0 +1,26 @@
+// Package config provides pre-built configurations.
+package config
+
+import (
+	"time"
+
+	"github.com/momentohq/client-sdk-go/config/logger/momento_default_logger"
+
+	"github.com/momentohq/client-sdk-go/config/logger"
+)
+
+// LeaderboardDefault provides defaults configuration for a Leaderboard Client
+func LeaderboardDefault() LeaderboardConfiguration {
+	return LeaderboardDefaultWithLogger(momento_default_logger.NewDefaultMomentoLoggerFactory(momento_default_logger.INFO))
+}
+
+func LeaderboardDefaultWithLogger(loggerFactory logger.MomentoLoggerFactory) LeaderboardConfiguration {
+	return NewLeaderboardConfiguration(&LeaderboardConfigurationProps{
+		LoggerFactory: loggerFactory,
+		TransportStrategy: NewStaticTransportStrategy(&TransportStrategyProps{
+			GrpcConfiguration: NewStaticGrpcConfiguration(&GrpcConfigurationProps{
+				deadline: 5 * time.Second,
+			}),
+		}),
+	})
+}

--- a/internal/grpcmanagers/leaderboard_manager.go
+++ b/internal/grpcmanagers/leaderboard_manager.go
@@ -1,0 +1,38 @@
+package grpcmanagers
+
+import (
+	"fmt"
+
+	"github.com/momentohq/client-sdk-go/internal/interceptor"
+	"github.com/momentohq/client-sdk-go/internal/models"
+	"github.com/momentohq/client-sdk-go/internal/momentoerrors"
+
+	"google.golang.org/grpc"
+)
+
+type LeaderboardGrpcManager struct {
+	Conn *grpc.ClientConn
+}
+
+const LeaderboardPort = ":443"
+
+func NewLeaderboardGrpcManager(request *models.LeaderboardGrpcManagerRequest) (*LeaderboardGrpcManager, momentoerrors.MomentoSvcErr) {
+	endpoint := fmt.Sprint(request.CredentialProvider.GetCacheEndpoint(), LeaderboardPort)
+	authToken := request.CredentialProvider.GetAuthToken()
+	// TODO make NewClient
+	conn, err := grpc.Dial(
+		endpoint,
+		AllDialOptions(
+			request.GrpcConfiguration,
+			grpc.WithUnaryInterceptor(interceptor.AddAuthHeadersInterceptor(authToken)),
+		)...,
+	)
+	if err != nil {
+		return nil, momentoerrors.ConvertSvcErr(err)
+	}
+	return &LeaderboardGrpcManager{Conn: conn}, nil
+}
+
+func (grpcManager *LeaderboardGrpcManager) Close() momentoerrors.MomentoSvcErr {
+	return momentoerrors.ConvertSvcErr(grpcManager.Conn.Close())
+}

--- a/internal/models/requests.go
+++ b/internal/models/requests.go
@@ -44,6 +44,11 @@ type PingGrpcManagerRequest struct {
 	GrpcConfiguration  config.GrpcConfiguration
 }
 
+type LeaderboardGrpcManagerRequest struct {
+	CredentialProvider auth.CredentialProvider
+	GrpcConfiguration  config.GrpcConfiguration
+}
+
 type LocalDataGrpcManagerRequest struct {
 	Endpoint string
 }
@@ -89,5 +94,10 @@ type TokenClientRequest struct {
 
 type PingClientRequest struct {
 	Configuration      config.Configuration
+	CredentialProvider auth.CredentialProvider
+}
+
+type LeaderboardClientRequest struct {
+	Configuration      config.LeaderboardConfiguration
 	CredentialProvider auth.CredentialProvider
 }

--- a/momento/leaderboard.go
+++ b/momento/leaderboard.go
@@ -8,13 +8,30 @@ import (
 	"github.com/momentohq/client-sdk-go/responses"
 )
 
+// Defines the set of operations that can be performed on a leaderboard object.
 type Leaderboard interface {
+	// Deletes the leaderboard, i.e. removes all elements from the leaderboard.
 	Delete(ctx context.Context) (responses.LeaderboardDeleteResponse, error)
+
+	// Fetches elements that fall within the specified min and max ranks.
 	FetchByRank(ctx context.Context, request LeaderboardFetchByRankRequest) (responses.LeaderboardFetchResponse, error)
+
+	// Fetches elements that fall within the specified min and max scores. Elements with the same score will be
+	// returned in alphanumerical order based on their ID (e.g. IDs of elements with the same score would be
+	// returned in the order [1, 10, 123, 2, 234, ...] rather than [1, 2, 10, 123, 234, ...]).
 	FetchByScore(ctx context.Context, request LeaderboardFetchByScoreRequest) (responses.LeaderboardFetchResponse, error)
+
+	// Fetches elements (including rank, score, and ID) given a list of element IDs.
 	GetRank(ctx context.Context, request LeaderboardGetRankRequest) (responses.LeaderboardFetchResponse, error)
+
+	// Gets the number of entries in the leaderboard.
 	Length(ctx context.Context) (responses.LeaderboardLengthResponse, error)
+
+	// Removes elements with the specified IDs from the leaderboard.
 	RemoveElements(ctx context.Context, request LeaderboardRemoveElementsRequest) (responses.LeaderboardRemoveElementsResponse, error)
+
+	// Inserts elements if they do not already exist in the leaderboard. Updates elements if they do already exist
+	// in the leaderboard. There are no partial failures; an upsert call will either succeed or fail.
 	Upsert(ctx context.Context, request LeaderboardUpsertRequest) (responses.LeaderboardUpsertResponse, error)
 }
 
@@ -24,7 +41,7 @@ type leaderboard struct {
 	leaderboardDataClient *leaderboardDataClient
 }
 
-// Delete implements Leaderboard.
+// Deletes the leaderboard, i.e. removes all elements from the leaderboard.
 func (l *leaderboard) Delete(ctx context.Context) (responses.LeaderboardDeleteResponse, error) {
 	r := &LeaderboardInternalDeleteRequest{
 		CacheName:       l.cacheName,
@@ -36,7 +53,7 @@ func (l *leaderboard) Delete(ctx context.Context) (responses.LeaderboardDeleteRe
 	return &responses.LeaderboardDeleteSuccess{}, nil
 }
 
-// FetchByRank implements Leaderboard.
+// Fetches elements that fall within the specified min and max ranks.
 func (l *leaderboard) FetchByRank(ctx context.Context, request LeaderboardFetchByRankRequest) (responses.LeaderboardFetchResponse, error) {
 	if request.StartRank >= request.EndRank {
 		return nil, momentoerrors.NewMomentoSvcErr(momentoerrors.InvalidArgumentError, "start rank must be less than end rank", nil)
@@ -55,7 +72,9 @@ func (l *leaderboard) FetchByRank(ctx context.Context, request LeaderboardFetchB
 	return responses.NewLeaderboardFetchSuccess(leaderboardFetchGrpcElementToModel(elements)), nil
 }
 
-// FetchByScore implements Leaderboard.
+// Fetches elements that fall within the specified min and max scores. Elements with the same score will be
+// returned in alphanumerical order based on their ID (e.g. IDs of elements with the same score would be
+// returned in the order [1, 10, 123, 2, 234, ...] rather than [1, 2, 10, 123, 234, ...]).
 func (l *leaderboard) FetchByScore(ctx context.Context, request LeaderboardFetchByScoreRequest) (responses.LeaderboardFetchResponse, error) {
 	if request.MinScore != nil && request.MaxScore != nil && *request.MinScore >= *request.MaxScore {
 		return nil, momentoerrors.NewMomentoSvcErr(momentoerrors.InvalidArgumentError, "min score must be less than max score", nil)
@@ -76,7 +95,7 @@ func (l *leaderboard) FetchByScore(ctx context.Context, request LeaderboardFetch
 	return responses.NewLeaderboardFetchSuccess(leaderboardFetchGrpcElementToModel(elements)), nil
 }
 
-// GetRank implements Leaderboard.
+// Fetches elements (including rank, score, and ID) given a list of element IDs.
 func (l *leaderboard) GetRank(ctx context.Context, request LeaderboardGetRankRequest) (responses.LeaderboardFetchResponse, error) {
 	r := &LeaderboardInternalGetRankRequest{
 		CacheName:       l.cacheName,
@@ -91,7 +110,7 @@ func (l *leaderboard) GetRank(ctx context.Context, request LeaderboardGetRankReq
 	return responses.NewLeaderboardFetchSuccess(leaderboardFetchGrpcElementToModel(elements)), nil
 }
 
-// Length implements Leaderboard.
+// Gets the number of entries in the leaderboard.
 func (l *leaderboard) Length(ctx context.Context) (responses.LeaderboardLengthResponse, error) {
 	r := &LeaderboardInternalLengthRequest{
 		CacheName:       l.cacheName,
@@ -104,7 +123,7 @@ func (l *leaderboard) Length(ctx context.Context) (responses.LeaderboardLengthRe
 	return responses.NewLeaderboardLengthSuccess(length), nil
 }
 
-// RemoveElements implements Leaderboard.
+// Removes elements with the specified IDs from the leaderboard.
 func (l *leaderboard) RemoveElements(ctx context.Context, request LeaderboardRemoveElementsRequest) (responses.LeaderboardRemoveElementsResponse, error) {
 	if len(request.Ids) == 0 {
 		return nil, momentoerrors.NewMomentoSvcErr(momentoerrors.InvalidArgumentError, "List of elements to remove cannot be empty", nil)
@@ -120,7 +139,8 @@ func (l *leaderboard) RemoveElements(ctx context.Context, request LeaderboardRem
 	return &responses.LeaderboardRemoveElementsSuccess{}, nil
 }
 
-// Upsert implements Leaderboard.
+// Inserts elements if they do not already exist in the leaderboard. Updates elements if they do already exist
+// in the leaderboard. There are no partial failures; an upsert call will either succeed or fail.
 func (l *leaderboard) Upsert(ctx context.Context, request LeaderboardUpsertRequest) (responses.LeaderboardUpsertResponse, error) {
 	if len(request.Elements) == 0 {
 		return nil, momentoerrors.NewMomentoSvcErr(momentoerrors.InvalidArgumentError, "List of elements to upsert cannot be empty", nil)

--- a/momento/leaderboard.go
+++ b/momento/leaderboard.go
@@ -30,7 +30,7 @@ func (l *leaderboard) Delete(ctx context.Context) (responses.LeaderboardDeleteRe
 		CacheName:       l.cacheName,
 		LeaderboardName: l.leaderboardName,
 	}
-	if err := l.leaderboardDataClient.Delete(ctx, r); err != nil {
+	if err := l.leaderboardDataClient.delete(ctx, r); err != nil {
 		return nil, err
 	}
 	return &responses.LeaderboardDeleteSuccess{}, nil
@@ -48,7 +48,7 @@ func (l *leaderboard) FetchByRank(ctx context.Context, request LeaderboardFetchB
 		EndRank:         request.EndRank,
 		Order:           request.Order,
 	}
-	elements, err := l.leaderboardDataClient.FetchByRank(ctx, r)
+	elements, err := l.leaderboardDataClient.fetchByRank(ctx, r)
 	if err != nil {
 		return nil, err
 	}
@@ -69,7 +69,7 @@ func (l *leaderboard) FetchByScore(ctx context.Context, request LeaderboardFetch
 		Count:           request.Count,
 		Order:           request.Order,
 	}
-	elements, err := l.leaderboardDataClient.FetchByScore(ctx, r)
+	elements, err := l.leaderboardDataClient.fetchByScore(ctx, r)
 	if err != nil {
 		return nil, err
 	}
@@ -84,7 +84,7 @@ func (l *leaderboard) GetRank(ctx context.Context, request LeaderboardGetRankReq
 		Ids:             request.Ids,
 		Order:           request.Order,
 	}
-	elements, err := l.leaderboardDataClient.GetRank(ctx, r)
+	elements, err := l.leaderboardDataClient.getRank(ctx, r)
 	if err != nil {
 		return nil, err
 	}
@@ -97,7 +97,7 @@ func (l *leaderboard) Length(ctx context.Context) (responses.LeaderboardLengthRe
 		CacheName:       l.cacheName,
 		LeaderboardName: l.leaderboardName,
 	}
-	length, err := l.leaderboardDataClient.Length(ctx, r)
+	length, err := l.leaderboardDataClient.length(ctx, r)
 	if err != nil {
 		return nil, err
 	}
@@ -114,7 +114,7 @@ func (l *leaderboard) RemoveElements(ctx context.Context, request LeaderboardRem
 		LeaderboardName: l.leaderboardName,
 		Ids:             request.Ids,
 	}
-	if err := l.leaderboardDataClient.RemoveElements(ctx, r); err != nil {
+	if err := l.leaderboardDataClient.removeElements(ctx, r); err != nil {
 		return nil, err
 	}
 	return &responses.LeaderboardRemoveElementsSuccess{}, nil
@@ -130,7 +130,7 @@ func (l *leaderboard) Upsert(ctx context.Context, request LeaderboardUpsertReque
 		LeaderboardName: l.leaderboardName,
 		Elements:        request.Elements,
 	}
-	if err := l.leaderboardDataClient.Upsert(ctx, r); err != nil {
+	if err := l.leaderboardDataClient.upsert(ctx, r); err != nil {
 		return nil, err
 	}
 	return &responses.LeaderboardUpsertSuccess{}, nil

--- a/momento/leaderboard.go
+++ b/momento/leaderboard.go
@@ -1,0 +1,149 @@
+package momento
+
+import (
+	"context"
+
+	"github.com/momentohq/client-sdk-go/internal/momentoerrors"
+	pb "github.com/momentohq/client-sdk-go/internal/protos"
+	"github.com/momentohq/client-sdk-go/responses"
+)
+
+type Leaderboard interface {
+	Delete(ctx context.Context) (responses.LeaderboardDeleteResponse, error)
+	FetchByRank(ctx context.Context, request LeaderboardFetchByRankRequest) (responses.LeaderboardFetchResponse, error)
+	FetchByScore(ctx context.Context, request LeaderboardFetchByScoreRequest) (responses.LeaderboardFetchResponse, error)
+	GetRank(ctx context.Context, request LeaderboardGetRankRequest) (responses.LeaderboardFetchResponse, error)
+	Length(ctx context.Context) (responses.LeaderboardLengthResponse, error)
+	RemoveElements(ctx context.Context, request LeaderboardRemoveElementsRequest) (responses.LeaderboardRemoveElementsResponse, error)
+	Upsert(ctx context.Context, request LeaderboardUpsertRequest) (responses.LeaderboardUpsertResponse, error)
+}
+
+type leaderboard struct {
+	cacheName             string
+	leaderboardName       string
+	leaderboardDataClient *leaderboardDataClient
+}
+
+// Delete implements Leaderboard.
+func (l *leaderboard) Delete(ctx context.Context) (responses.LeaderboardDeleteResponse, error) {
+	r := &LeaderboardInternalDeleteRequest{
+		CacheName:       l.cacheName,
+		LeaderboardName: l.leaderboardName,
+	}
+	if err := l.leaderboardDataClient.Delete(ctx, r); err != nil {
+		return nil, err
+	}
+	return &responses.LeaderboardDeleteSuccess{}, nil
+}
+
+// FetchByRank implements Leaderboard.
+func (l *leaderboard) FetchByRank(ctx context.Context, request LeaderboardFetchByRankRequest) (responses.LeaderboardFetchResponse, error) {
+	if request.StartRank >= request.EndRank {
+		return nil, momentoerrors.NewMomentoSvcErr(momentoerrors.InvalidArgumentError, "start rank must be less than end rank", nil)
+	}
+	r := &LeaderboardInternalFetchByRankRequest{
+		CacheName:       l.cacheName,
+		LeaderboardName: l.leaderboardName,
+		StartRank:       request.StartRank,
+		EndRank:         request.EndRank,
+		Order:           request.Order,
+	}
+	elements, err := l.leaderboardDataClient.FetchByRank(ctx, r)
+	if err != nil {
+		return nil, err
+	}
+	return responses.NewLeaderboardFetchSuccess(leaderboardFetchGrpcElementToModel(elements)), nil
+}
+
+// FetchByScore implements Leaderboard.
+func (l *leaderboard) FetchByScore(ctx context.Context, request LeaderboardFetchByScoreRequest) (responses.LeaderboardFetchResponse, error) {
+	if request.MinScore != nil && request.MaxScore != nil && *request.MinScore >= *request.MaxScore {
+		return nil, momentoerrors.NewMomentoSvcErr(momentoerrors.InvalidArgumentError, "min score must be less than max score", nil)
+	}
+	r := &LeaderboardInternalFetchByScoreRequest{
+		CacheName:       l.cacheName,
+		LeaderboardName: l.leaderboardName,
+		MinScore:        request.MinScore,
+		MaxScore:        request.MaxScore,
+		Offset:          request.Offset,
+		Count:           request.Count,
+		Order:           request.Order,
+	}
+	elements, err := l.leaderboardDataClient.FetchByScore(ctx, r)
+	if err != nil {
+		return nil, err
+	}
+	return responses.NewLeaderboardFetchSuccess(leaderboardFetchGrpcElementToModel(elements)), nil
+}
+
+// GetRank implements Leaderboard.
+func (l *leaderboard) GetRank(ctx context.Context, request LeaderboardGetRankRequest) (responses.LeaderboardFetchResponse, error) {
+	r := &LeaderboardInternalGetRankRequest{
+		CacheName:       l.cacheName,
+		LeaderboardName: l.leaderboardName,
+		Ids:             request.Ids,
+		Order:           request.Order,
+	}
+	elements, err := l.leaderboardDataClient.GetRank(ctx, r)
+	if err != nil {
+		return nil, err
+	}
+	return responses.NewLeaderboardFetchSuccess(leaderboardFetchGrpcElementToModel(elements)), nil
+}
+
+// Length implements Leaderboard.
+func (l *leaderboard) Length(ctx context.Context) (responses.LeaderboardLengthResponse, error) {
+	r := &LeaderboardInternalLengthRequest{
+		CacheName:       l.cacheName,
+		LeaderboardName: l.leaderboardName,
+	}
+	length, err := l.leaderboardDataClient.Length(ctx, r)
+	if err != nil {
+		return nil, err
+	}
+	return responses.NewLeaderboardLengthSuccess(length), nil
+}
+
+// RemoveElements implements Leaderboard.
+func (l *leaderboard) RemoveElements(ctx context.Context, request LeaderboardRemoveElementsRequest) (responses.LeaderboardRemoveElementsResponse, error) {
+	if len(request.Ids) == 0 {
+		return nil, momentoerrors.NewMomentoSvcErr(momentoerrors.InvalidArgumentError, "List of elements to remove cannot be empty", nil)
+	}
+	r := &LeaderboardInternalRemoveElementsRequest{
+		CacheName:       l.cacheName,
+		LeaderboardName: l.leaderboardName,
+		Ids:             request.Ids,
+	}
+	if err := l.leaderboardDataClient.RemoveElements(ctx, r); err != nil {
+		return nil, err
+	}
+	return &responses.LeaderboardRemoveElementsSuccess{}, nil
+}
+
+// Upsert implements Leaderboard.
+func (l *leaderboard) Upsert(ctx context.Context, request LeaderboardUpsertRequest) (responses.LeaderboardUpsertResponse, error) {
+	if len(request.Elements) == 0 {
+		return nil, momentoerrors.NewMomentoSvcErr(momentoerrors.InvalidArgumentError, "List of elements to upsert cannot be empty", nil)
+	}
+	r := &LeaderboardInternalUpsertRequest{
+		CacheName:       l.cacheName,
+		LeaderboardName: l.leaderboardName,
+		Elements:        request.Elements,
+	}
+	if err := l.leaderboardDataClient.Upsert(ctx, r); err != nil {
+		return nil, err
+	}
+	return &responses.LeaderboardUpsertSuccess{}, nil
+}
+
+func leaderboardFetchGrpcElementToModel(grpcRankedElements []*pb.XRankedElement) []responses.LeaderboardElement {
+	var returnList []responses.LeaderboardElement
+	for _, element := range grpcRankedElements {
+		returnList = append(returnList, responses.LeaderboardElement{
+			Id:    element.Id,
+			Rank:  element.Rank,
+			Score: element.Score,
+		})
+	}
+	return returnList
+}

--- a/momento/leaderboard.go
+++ b/momento/leaderboard.go
@@ -8,30 +8,30 @@ import (
 	"github.com/momentohq/client-sdk-go/responses"
 )
 
-// Defines the set of operations that can be performed on a leaderboard object.
+// Leaderboard defines the set of operations that can be performed on a leaderboard object.
 type Leaderboard interface {
-	// Deletes the leaderboard, i.e. removes all elements from the leaderboard.
+	// Delete removes all elements from the leaderboard.
 	Delete(ctx context.Context) (responses.LeaderboardDeleteResponse, error)
 
-	// Fetches elements that fall within the specified min and max ranks.
+	// FetchByRank gets all elements that fall within the specified min and max ranks.
 	FetchByRank(ctx context.Context, request LeaderboardFetchByRankRequest) (responses.LeaderboardFetchResponse, error)
 
-	// Fetches elements that fall within the specified min and max scores. Elements with the same score will be
-	// returned in alphanumerical order based on their ID (e.g. IDs of elements with the same score would be
+	// FetchByScore gets elements that fall within the specified min and max scores. Elements with the same score
+	// will be returned in alphanumerical order based on their ID (e.g. IDs of elements with the same score would be
 	// returned in the order [1, 10, 123, 2, 234, ...] rather than [1, 2, 10, 123, 234, ...]).
 	FetchByScore(ctx context.Context, request LeaderboardFetchByScoreRequest) (responses.LeaderboardFetchResponse, error)
 
-	// Fetches elements (including rank, score, and ID) given a list of element IDs.
+	// GetRank fetches elements (with their rank, score, and ID) given a list of element IDs.
 	GetRank(ctx context.Context, request LeaderboardGetRankRequest) (responses.LeaderboardFetchResponse, error)
 
-	// Gets the number of entries in the leaderboard.
+	// Length gets the number of entries in the leaderboard.
 	Length(ctx context.Context) (responses.LeaderboardLengthResponse, error)
 
-	// Removes elements with the specified IDs from the leaderboard.
+	// RemoveElements deletes elements with the specified IDs from the leaderboard.
 	RemoveElements(ctx context.Context, request LeaderboardRemoveElementsRequest) (responses.LeaderboardRemoveElementsResponse, error)
 
-	// Inserts elements if they do not already exist in the leaderboard. Updates elements if they do already exist
-	// in the leaderboard. There are no partial failures; an upsert call will either succeed or fail.
+	// Upsert inserts elements if they do not already exist in the leaderboard and updates elements if they do
+	// already exist. There are no partial failures; an upsert call will either succeed or fail.
 	Upsert(ctx context.Context, request LeaderboardUpsertRequest) (responses.LeaderboardUpsertResponse, error)
 }
 
@@ -41,7 +41,7 @@ type leaderboard struct {
 	leaderboardDataClient *leaderboardDataClient
 }
 
-// Deletes the leaderboard, i.e. removes all elements from the leaderboard.
+// Delete removes all elements from the leaderboard.
 func (l *leaderboard) Delete(ctx context.Context) (responses.LeaderboardDeleteResponse, error) {
 	r := &LeaderboardInternalDeleteRequest{
 		CacheName:       l.cacheName,
@@ -53,7 +53,7 @@ func (l *leaderboard) Delete(ctx context.Context) (responses.LeaderboardDeleteRe
 	return &responses.LeaderboardDeleteSuccess{}, nil
 }
 
-// Fetches elements that fall within the specified min and max ranks.
+// FetchByRank gets all elements that fall within the specified min and max ranks.
 func (l *leaderboard) FetchByRank(ctx context.Context, request LeaderboardFetchByRankRequest) (responses.LeaderboardFetchResponse, error) {
 	if request.StartRank >= request.EndRank {
 		return nil, momentoerrors.NewMomentoSvcErr(momentoerrors.InvalidArgumentError, "start rank must be less than end rank", nil)
@@ -72,8 +72,8 @@ func (l *leaderboard) FetchByRank(ctx context.Context, request LeaderboardFetchB
 	return responses.NewLeaderboardFetchSuccess(leaderboardFetchGrpcElementToModel(elements)), nil
 }
 
-// Fetches elements that fall within the specified min and max scores. Elements with the same score will be
-// returned in alphanumerical order based on their ID (e.g. IDs of elements with the same score would be
+// FetchByScore gets elements that fall within the specified min and max scores. Elements with the same score
+// will be returned in alphanumerical order based on their ID (e.g. IDs of elements with the same score would be
 // returned in the order [1, 10, 123, 2, 234, ...] rather than [1, 2, 10, 123, 234, ...]).
 func (l *leaderboard) FetchByScore(ctx context.Context, request LeaderboardFetchByScoreRequest) (responses.LeaderboardFetchResponse, error) {
 	if request.MinScore != nil && request.MaxScore != nil && *request.MinScore >= *request.MaxScore {
@@ -95,7 +95,7 @@ func (l *leaderboard) FetchByScore(ctx context.Context, request LeaderboardFetch
 	return responses.NewLeaderboardFetchSuccess(leaderboardFetchGrpcElementToModel(elements)), nil
 }
 
-// Fetches elements (including rank, score, and ID) given a list of element IDs.
+// GetRank fetches elements (with their rank, score, and ID) given a list of element IDs.
 func (l *leaderboard) GetRank(ctx context.Context, request LeaderboardGetRankRequest) (responses.LeaderboardFetchResponse, error) {
 	r := &LeaderboardInternalGetRankRequest{
 		CacheName:       l.cacheName,
@@ -110,7 +110,7 @@ func (l *leaderboard) GetRank(ctx context.Context, request LeaderboardGetRankReq
 	return responses.NewLeaderboardFetchSuccess(leaderboardFetchGrpcElementToModel(elements)), nil
 }
 
-// Gets the number of entries in the leaderboard.
+// Length gets the number of entries in the leaderboard.
 func (l *leaderboard) Length(ctx context.Context) (responses.LeaderboardLengthResponse, error) {
 	r := &LeaderboardInternalLengthRequest{
 		CacheName:       l.cacheName,
@@ -123,7 +123,7 @@ func (l *leaderboard) Length(ctx context.Context) (responses.LeaderboardLengthRe
 	return responses.NewLeaderboardLengthSuccess(length), nil
 }
 
-// Removes elements with the specified IDs from the leaderboard.
+// RemoveElements deletes elements with the specified IDs from the leaderboard.
 func (l *leaderboard) RemoveElements(ctx context.Context, request LeaderboardRemoveElementsRequest) (responses.LeaderboardRemoveElementsResponse, error) {
 	if len(request.Ids) == 0 {
 		return nil, momentoerrors.NewMomentoSvcErr(momentoerrors.InvalidArgumentError, "List of elements to remove cannot be empty", nil)
@@ -139,8 +139,8 @@ func (l *leaderboard) RemoveElements(ctx context.Context, request LeaderboardRem
 	return &responses.LeaderboardRemoveElementsSuccess{}, nil
 }
 
-// Inserts elements if they do not already exist in the leaderboard. Updates elements if they do already exist
-// in the leaderboard. There are no partial failures; an upsert call will either succeed or fail.
+// Upsert inserts elements if they do not already exist in the leaderboard and updates elements if they do
+// already exist. There are no partial failures; an upsert call will either succeed or fail.
 func (l *leaderboard) Upsert(ctx context.Context, request LeaderboardUpsertRequest) (responses.LeaderboardUpsertResponse, error) {
 	if len(request.Elements) == 0 {
 		return nil, momentoerrors.NewMomentoSvcErr(momentoerrors.InvalidArgumentError, "List of elements to upsert cannot be empty", nil)

--- a/momento/leaderboard_client.go
+++ b/momento/leaderboard_client.go
@@ -11,9 +11,9 @@ import (
 )
 
 type PreviewLeaderboardClient interface {
-	// Creates a new leaderboard object in a given cache with the provided leaderboard name.
+	// Leaderboard creates a new leaderboard object in a given cache with the provided leaderboard name.
 	Leaderboard(ctx context.Context, request *LeaderboardRequest) (Leaderboard, error)
-	// Closes the leaderboard client.
+	// Close will shut down the leaderboard client and related resources.
 	Close()
 }
 
@@ -23,7 +23,7 @@ type previewLeaderboardClient struct {
 	log                   logger.MomentoLogger
 }
 
-// Creates a new instance of a Preview Leaderboard Client.
+// NewPreviewLeaderboardClient creates a new instance of a Preview Leaderboard Client.
 func NewPreviewLeaderboardClient(leaderboardConfiguration config.LeaderboardConfiguration, credentialProvider auth.CredentialProvider) (PreviewLeaderboardClient, error) {
 	dataClient, err := newLeaderboardDataClient(&models.LeaderboardClientRequest{
 		CredentialProvider: credentialProvider,
@@ -41,7 +41,7 @@ func NewPreviewLeaderboardClient(leaderboardConfiguration config.LeaderboardConf
 	return client, nil
 }
 
-// Creates a new leaderboard object in a given cache with the provided leaderboard name.
+// Leaderboard creates a new leaderboard object in a given cache with the provided leaderboard name.
 func (c previewLeaderboardClient) Leaderboard(ctx context.Context, request *LeaderboardRequest) (Leaderboard, error) {
 	if err := utils.ValidateName(request.CacheName, "cache name"); err != nil {
 		return nil, err
@@ -57,7 +57,7 @@ func (c previewLeaderboardClient) Leaderboard(ctx context.Context, request *Lead
 	return newLeaderboard, nil
 }
 
-// Closes the leaderboard client.
+// Close will shut down the leaderboard client and related resources.
 func (c previewLeaderboardClient) Close() {
 	c.leaderboardDataClient.close()
 }

--- a/momento/leaderboard_client.go
+++ b/momento/leaderboard_client.go
@@ -10,7 +10,7 @@ import (
 	"github.com/momentohq/client-sdk-go/utils"
 )
 
-type LeaderboardClient interface {
+type PreviewLeaderboardClient interface {
 	Leaderboard(ctx context.Context, request *LeaderboardRequest) (Leaderboard, error)
 	Close()
 }

--- a/momento/leaderboard_client.go
+++ b/momento/leaderboard_client.go
@@ -21,8 +21,8 @@ type previewLeaderboardClient struct {
 	log                   logger.MomentoLogger
 }
 
-func NewPreviewLeaderboardClient(leaderboardConfiguration config.LeaderboardConfiguration, credentialProvider auth.CredentialProvider) (LeaderboardClient, error) {
-	dataClient, err := NewLeaderboardDataClient(&models.LeaderboardClientRequest{
+func NewPreviewLeaderboardClient(leaderboardConfiguration config.LeaderboardConfiguration, credentialProvider auth.CredentialProvider) (PreviewLeaderboardClient, error) {
+	dataClient, err := newLeaderboardDataClient(&models.LeaderboardClientRequest{
 		CredentialProvider: credentialProvider,
 		Configuration:      leaderboardConfiguration,
 	})
@@ -54,5 +54,5 @@ func (c previewLeaderboardClient) Leaderboard(ctx context.Context, request *Lead
 }
 
 func (c previewLeaderboardClient) Close() {
-	c.leaderboardDataClient.Close()
+	c.leaderboardDataClient.close()
 }

--- a/momento/leaderboard_client.go
+++ b/momento/leaderboard_client.go
@@ -21,7 +21,7 @@ type previewLeaderboardClient struct {
 	log                   logger.MomentoLogger
 }
 
-func NewLeaderboardClient(leaderboardConfiguration config.LeaderboardConfiguration, credentialProvider auth.CredentialProvider) (LeaderboardClient, error) {
+func NewPreviewLeaderboardClient(leaderboardConfiguration config.LeaderboardConfiguration, credentialProvider auth.CredentialProvider) (LeaderboardClient, error) {
 	dataClient, err := NewLeaderboardDataClient(&models.LeaderboardClientRequest{
 		CredentialProvider: credentialProvider,
 		Configuration:      leaderboardConfiguration,

--- a/momento/leaderboard_client.go
+++ b/momento/leaderboard_client.go
@@ -1,0 +1,58 @@
+package momento
+
+import (
+	"context"
+
+	"github.com/momentohq/client-sdk-go/auth"
+	"github.com/momentohq/client-sdk-go/config"
+	"github.com/momentohq/client-sdk-go/config/logger"
+	"github.com/momentohq/client-sdk-go/internal/models"
+	"github.com/momentohq/client-sdk-go/utils"
+)
+
+type LeaderboardClient interface {
+	Leaderboard(ctx context.Context, request *LeaderboardRequest) (Leaderboard, error)
+	Close()
+}
+
+type previewLeaderboardClient struct {
+	credentialProvider    auth.CredentialProvider
+	leaderboardDataClient *leaderboardDataClient
+	log                   logger.MomentoLogger
+}
+
+func NewLeaderboardClient(leaderboardConfiguration config.LeaderboardConfiguration, credentialProvider auth.CredentialProvider) (LeaderboardClient, error) {
+	dataClient, err := NewLeaderboardDataClient(&models.LeaderboardClientRequest{
+		CredentialProvider: credentialProvider,
+		Configuration:      leaderboardConfiguration,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	client := &previewLeaderboardClient{
+		credentialProvider:    credentialProvider,
+		leaderboardDataClient: dataClient,
+		log:                   leaderboardConfiguration.GetLoggerFactory().GetLogger("topic-client"),
+	}
+	return client, nil
+}
+
+func (c previewLeaderboardClient) Leaderboard(ctx context.Context, request *LeaderboardRequest) (Leaderboard, error) {
+	if err := utils.ValidateName(request.CacheName, "cache name"); err != nil {
+		return nil, err
+	}
+	if err := utils.ValidateName(request.LeaderboardName, "leaderboard name"); err != nil {
+		return nil, err
+	}
+	newLeaderboard := &leaderboard{
+		cacheName:             request.CacheName,
+		leaderboardName:       request.LeaderboardName,
+		leaderboardDataClient: c.leaderboardDataClient,
+	}
+	return newLeaderboard, nil
+}
+
+func (c previewLeaderboardClient) Close() {
+	c.leaderboardDataClient.Close()
+}

--- a/momento/leaderboard_client.go
+++ b/momento/leaderboard_client.go
@@ -11,7 +11,9 @@ import (
 )
 
 type PreviewLeaderboardClient interface {
+	// Creates a new leaderboard object in a given cache with the provided leaderboard name.
 	Leaderboard(ctx context.Context, request *LeaderboardRequest) (Leaderboard, error)
+	// Closes the leaderboard client.
 	Close()
 }
 
@@ -21,6 +23,7 @@ type previewLeaderboardClient struct {
 	log                   logger.MomentoLogger
 }
 
+// Creates a new instance of a Preview Leaderboard Client.
 func NewPreviewLeaderboardClient(leaderboardConfiguration config.LeaderboardConfiguration, credentialProvider auth.CredentialProvider) (PreviewLeaderboardClient, error) {
 	dataClient, err := newLeaderboardDataClient(&models.LeaderboardClientRequest{
 		CredentialProvider: credentialProvider,
@@ -38,6 +41,7 @@ func NewPreviewLeaderboardClient(leaderboardConfiguration config.LeaderboardConf
 	return client, nil
 }
 
+// Creates a new leaderboard object in a given cache with the provided leaderboard name.
 func (c previewLeaderboardClient) Leaderboard(ctx context.Context, request *LeaderboardRequest) (Leaderboard, error) {
 	if err := utils.ValidateName(request.CacheName, "cache name"); err != nil {
 		return nil, err
@@ -53,6 +57,7 @@ func (c previewLeaderboardClient) Leaderboard(ctx context.Context, request *Lead
 	return newLeaderboard, nil
 }
 
+// Closes the leaderboard client.
 func (c previewLeaderboardClient) Close() {
 	c.leaderboardDataClient.close()
 }

--- a/momento/leaderboard_data_client.go
+++ b/momento/leaderboard_data_client.go
@@ -10,17 +10,6 @@ import (
 	pb "github.com/momentohq/client-sdk-go/internal/protos"
 )
 
-type LeaderboardDataClient interface {
-	Close() momentoerrors.MomentoSvcErr
-	Delete(ctx context.Context, request *LeaderboardInternalDeleteRequest) momentoerrors.MomentoSvcErr
-	FetchByRank(ctx context.Context, request *LeaderboardInternalFetchByRankRequest) ([]*pb.XRankedElement, momentoerrors.MomentoSvcErr)
-	FetchByScore(ctx context.Context, request *LeaderboardInternalFetchByScoreRequest) ([]*pb.XRankedElement, momentoerrors.MomentoSvcErr)
-	GetRank(ctx context.Context, request *LeaderboardInternalGetRankRequest) ([]*pb.XRankedElement, momentoerrors.MomentoSvcErr)
-	Length(ctx context.Context, request *LeaderboardInternalLengthRequest) (uint32, momentoerrors.MomentoSvcErr)
-	RemoveElements(ctx context.Context, request *LeaderboardInternalRemoveElementsRequest) momentoerrors.MomentoSvcErr
-	Upsert(ctx context.Context, request *LeaderboardInternalUpsertRequest) momentoerrors.MomentoSvcErr
-}
-
 type leaderboardDataClient struct {
 	requestTimeout         time.Duration
 	leaderboardGrpcManager *grpcmanagers.LeaderboardGrpcManager
@@ -42,11 +31,11 @@ func newLeaderboardDataClient(request *models.LeaderboardClientRequest) (*leader
 	}, nil
 }
 
-func (client *leaderboardDataClient) Close() momentoerrors.MomentoSvcErr {
+func (client *leaderboardDataClient) close() momentoerrors.MomentoSvcErr {
 	return client.leaderboardGrpcManager.Close()
 }
 
-func (client *leaderboardDataClient) Delete(ctx context.Context, request *LeaderboardInternalDeleteRequest) momentoerrors.MomentoSvcErr {
+func (client *leaderboardDataClient) delete(ctx context.Context, request *LeaderboardInternalDeleteRequest) momentoerrors.MomentoSvcErr {
 	ctx, cancel := context.WithTimeout(ctx, client.requestTimeout)
 	defer cancel()
 	_, err := client.leaderboardClient.DeleteLeaderboard(ctx, &pb.XDeleteLeaderboardRequest{
@@ -59,7 +48,7 @@ func (client *leaderboardDataClient) Delete(ctx context.Context, request *Leader
 	return nil
 }
 
-func (client *leaderboardDataClient) FetchByRank(ctx context.Context, request *LeaderboardInternalFetchByRankRequest) ([]*pb.XRankedElement, momentoerrors.MomentoSvcErr) {
+func (client *leaderboardDataClient) fetchByRank(ctx context.Context, request *LeaderboardInternalFetchByRankRequest) ([]*pb.XRankedElement, momentoerrors.MomentoSvcErr) {
 	ctx, cancel := context.WithTimeout(ctx, client.requestTimeout)
 	defer cancel()
 
@@ -85,7 +74,7 @@ func (client *leaderboardDataClient) FetchByRank(ctx context.Context, request *L
 	return result.Elements, nil
 }
 
-func (client *leaderboardDataClient) FetchByScore(ctx context.Context, request *LeaderboardInternalFetchByScoreRequest) ([]*pb.XRankedElement, momentoerrors.MomentoSvcErr) {
+func (client *leaderboardDataClient) fetchByScore(ctx context.Context, request *LeaderboardInternalFetchByScoreRequest) ([]*pb.XRankedElement, momentoerrors.MomentoSvcErr) {
 	ctx, cancel := context.WithTimeout(ctx, client.requestTimeout)
 	defer cancel()
 
@@ -132,7 +121,7 @@ func (client *leaderboardDataClient) FetchByScore(ctx context.Context, request *
 	return result.Elements, nil
 }
 
-func (client *leaderboardDataClient) GetRank(ctx context.Context, request *LeaderboardInternalGetRankRequest) ([]*pb.XRankedElement, momentoerrors.MomentoSvcErr) {
+func (client *leaderboardDataClient) getRank(ctx context.Context, request *LeaderboardInternalGetRankRequest) ([]*pb.XRankedElement, momentoerrors.MomentoSvcErr) {
 	ctx, cancel := context.WithTimeout(ctx, client.requestTimeout)
 	defer cancel()
 
@@ -153,7 +142,7 @@ func (client *leaderboardDataClient) GetRank(ctx context.Context, request *Leade
 	return result.Elements, nil
 }
 
-func (client *leaderboardDataClient) Length(ctx context.Context, request *LeaderboardInternalLengthRequest) (uint32, momentoerrors.MomentoSvcErr) {
+func (client *leaderboardDataClient) length(ctx context.Context, request *LeaderboardInternalLengthRequest) (uint32, momentoerrors.MomentoSvcErr) {
 	ctx, cancel := context.WithTimeout(ctx, client.requestTimeout)
 	defer cancel()
 
@@ -167,7 +156,7 @@ func (client *leaderboardDataClient) Length(ctx context.Context, request *Leader
 	return result.Count, nil
 }
 
-func (client *leaderboardDataClient) RemoveElements(ctx context.Context, request *LeaderboardInternalRemoveElementsRequest) momentoerrors.MomentoSvcErr {
+func (client *leaderboardDataClient) removeElements(ctx context.Context, request *LeaderboardInternalRemoveElementsRequest) momentoerrors.MomentoSvcErr {
 	ctx, cancel := context.WithTimeout(ctx, client.requestTimeout)
 	defer cancel()
 
@@ -182,7 +171,7 @@ func (client *leaderboardDataClient) RemoveElements(ctx context.Context, request
 	return nil
 }
 
-func (client *leaderboardDataClient) Upsert(ctx context.Context, request *LeaderboardInternalUpsertRequest) momentoerrors.MomentoSvcErr {
+func (client *leaderboardDataClient) upsert(ctx context.Context, request *LeaderboardInternalUpsertRequest) momentoerrors.MomentoSvcErr {
 	ctx, cancel := context.WithTimeout(ctx, client.requestTimeout)
 	defer cancel()
 

--- a/momento/leaderboard_data_client.go
+++ b/momento/leaderboard_data_client.go
@@ -27,7 +27,7 @@ type leaderboardDataClient struct {
 	leaderboardClient      pb.LeaderboardClient
 }
 
-func NewLeaderboardDataClient(request *models.LeaderboardClientRequest) (*leaderboardDataClient, momentoerrors.MomentoSvcErr) {
+func newLeaderboardDataClient(request *models.LeaderboardClientRequest) (*leaderboardDataClient, momentoerrors.MomentoSvcErr) {
 	grpcManager, err := grpcmanagers.NewLeaderboardGrpcManager(&models.LeaderboardGrpcManagerRequest{
 		CredentialProvider: request.CredentialProvider,
 		GrpcConfiguration:  request.Configuration.GetTransportStrategy().GetGrpcConfig(),

--- a/momento/leaderboard_data_client.go
+++ b/momento/leaderboard_data_client.go
@@ -1,0 +1,209 @@
+package momento
+
+import (
+	"context"
+	"time"
+
+	"github.com/momentohq/client-sdk-go/internal/grpcmanagers"
+	"github.com/momentohq/client-sdk-go/internal/models"
+	"github.com/momentohq/client-sdk-go/internal/momentoerrors"
+	pb "github.com/momentohq/client-sdk-go/internal/protos"
+)
+
+type LeaderboardDataClient interface {
+	Close() momentoerrors.MomentoSvcErr
+	Delete(ctx context.Context, request *LeaderboardInternalDeleteRequest) momentoerrors.MomentoSvcErr
+	FetchByRank(ctx context.Context, request *LeaderboardInternalFetchByRankRequest) ([]*pb.XRankedElement, momentoerrors.MomentoSvcErr)
+	FetchByScore(ctx context.Context, request *LeaderboardInternalFetchByScoreRequest) ([]*pb.XRankedElement, momentoerrors.MomentoSvcErr)
+	GetRank(ctx context.Context, request *LeaderboardInternalGetRankRequest) ([]*pb.XRankedElement, momentoerrors.MomentoSvcErr)
+	Length(ctx context.Context, request *LeaderboardInternalLengthRequest) (uint32, momentoerrors.MomentoSvcErr)
+	RemoveElements(ctx context.Context, request *LeaderboardInternalRemoveElementsRequest) momentoerrors.MomentoSvcErr
+	Upsert(ctx context.Context, request *LeaderboardInternalUpsertRequest) momentoerrors.MomentoSvcErr
+}
+
+type leaderboardDataClient struct {
+	requestTimeout         time.Duration
+	leaderboardGrpcManager *grpcmanagers.LeaderboardGrpcManager
+	leaderboardClient      pb.LeaderboardClient
+}
+
+func NewLeaderboardDataClient(request *models.LeaderboardClientRequest) (*leaderboardDataClient, momentoerrors.MomentoSvcErr) {
+	grpcManager, err := grpcmanagers.NewLeaderboardGrpcManager(&models.LeaderboardGrpcManagerRequest{
+		CredentialProvider: request.CredentialProvider,
+		GrpcConfiguration:  request.Configuration.GetTransportStrategy().GetGrpcConfig(),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &leaderboardDataClient{
+		requestTimeout:         request.Configuration.GetClientSideTimeout(),
+		leaderboardGrpcManager: grpcManager,
+		leaderboardClient:      pb.NewLeaderboardClient(grpcManager.Conn),
+	}, nil
+}
+
+func (client *leaderboardDataClient) Close() momentoerrors.MomentoSvcErr {
+	return client.leaderboardGrpcManager.Close()
+}
+
+func (client *leaderboardDataClient) Delete(ctx context.Context, request *LeaderboardInternalDeleteRequest) momentoerrors.MomentoSvcErr {
+	ctx, cancel := context.WithTimeout(ctx, client.requestTimeout)
+	defer cancel()
+	_, err := client.leaderboardClient.DeleteLeaderboard(ctx, &pb.XDeleteLeaderboardRequest{
+		CacheName:   request.CacheName,
+		Leaderboard: request.LeaderboardName,
+	})
+	if err != nil {
+		return momentoerrors.ConvertSvcErr(err)
+	}
+	return nil
+}
+
+func (client *leaderboardDataClient) FetchByRank(ctx context.Context, request *LeaderboardInternalFetchByRankRequest) ([]*pb.XRankedElement, momentoerrors.MomentoSvcErr) {
+	ctx, cancel := context.WithTimeout(ctx, client.requestTimeout)
+	defer cancel()
+
+	rankRange := &pb.XRankRange{
+		StartInclusive: request.StartRank,
+		EndExclusive:   request.EndRank,
+	}
+
+	leaderboardOrder := pb.XOrder_ASCENDING
+	if request.Order != nil && *request.Order == DESCENDING {
+		leaderboardOrder = pb.XOrder_DESCENDING
+	}
+
+	result, err := client.leaderboardClient.GetByRank(ctx, &pb.XGetByRankRequest{
+		CacheName:   request.CacheName,
+		Leaderboard: request.LeaderboardName,
+		RankRange:   rankRange,
+		Order:       leaderboardOrder,
+	})
+	if err != nil {
+		return nil, momentoerrors.ConvertSvcErr(err)
+	}
+	return result.Elements, nil
+}
+
+func (client *leaderboardDataClient) FetchByScore(ctx context.Context, request *LeaderboardInternalFetchByScoreRequest) ([]*pb.XRankedElement, momentoerrors.MomentoSvcErr) {
+	ctx, cancel := context.WithTimeout(ctx, client.requestTimeout)
+	defer cancel()
+
+	scoreRange := &pb.XScoreRange{}
+
+	if request.MinScore == nil {
+		scoreRange.Min = &pb.XScoreRange_UnboundedMin{UnboundedMin: &pb.XUnbounded{}}
+	} else {
+		scoreRange.Min = &pb.XScoreRange_MinInclusive{MinInclusive: *request.MinScore}
+	}
+
+	if request.MaxScore == nil {
+		scoreRange.Max = &pb.XScoreRange_UnboundedMax{UnboundedMax: &pb.XUnbounded{}}
+	} else {
+		scoreRange.Max = &pb.XScoreRange_MaxExclusive{MaxExclusive: *request.MaxScore}
+	}
+
+	leaderboardOrder := pb.XOrder_ASCENDING
+	if request.Order != nil && *request.Order == DESCENDING {
+		leaderboardOrder = pb.XOrder_DESCENDING
+	}
+
+	offset := uint32(0)
+	if request.Offset != nil {
+		offset = *request.Offset
+	}
+
+	count := uint32(8192)
+	if request.Count != nil {
+		count = *request.Count
+	}
+
+	result, err := client.leaderboardClient.GetByScore(ctx, &pb.XGetByScoreRequest{
+		CacheName:     request.CacheName,
+		Leaderboard:   request.LeaderboardName,
+		ScoreRange:    scoreRange,
+		Offset:        offset,
+		LimitElements: count,
+		Order:         leaderboardOrder,
+	})
+	if err != nil {
+		return nil, momentoerrors.ConvertSvcErr(err)
+	}
+	return result.Elements, nil
+}
+
+func (client *leaderboardDataClient) GetRank(ctx context.Context, request *LeaderboardInternalGetRankRequest) ([]*pb.XRankedElement, momentoerrors.MomentoSvcErr) {
+	ctx, cancel := context.WithTimeout(ctx, client.requestTimeout)
+	defer cancel()
+
+	leaderboardOrder := pb.XOrder_ASCENDING
+	if request.Order != nil && *request.Order == DESCENDING {
+		leaderboardOrder = pb.XOrder_DESCENDING
+	}
+
+	result, err := client.leaderboardClient.GetRank(ctx, &pb.XGetRankRequest{
+		CacheName:   request.CacheName,
+		Leaderboard: request.LeaderboardName,
+		Ids:         request.Ids,
+		Order:       leaderboardOrder,
+	})
+	if err != nil {
+		return nil, momentoerrors.ConvertSvcErr(err)
+	}
+	return result.Elements, nil
+}
+
+func (client *leaderboardDataClient) Length(ctx context.Context, request *LeaderboardInternalLengthRequest) (uint32, momentoerrors.MomentoSvcErr) {
+	ctx, cancel := context.WithTimeout(ctx, client.requestTimeout)
+	defer cancel()
+
+	result, err := client.leaderboardClient.GetLeaderboardLength(ctx, &pb.XGetLeaderboardLengthRequest{
+		CacheName:   request.CacheName,
+		Leaderboard: request.LeaderboardName,
+	})
+	if err != nil {
+		return 0, momentoerrors.ConvertSvcErr(err)
+	}
+	return result.Count, nil
+}
+
+func (client *leaderboardDataClient) RemoveElements(ctx context.Context, request *LeaderboardInternalRemoveElementsRequest) momentoerrors.MomentoSvcErr {
+	ctx, cancel := context.WithTimeout(ctx, client.requestTimeout)
+	defer cancel()
+
+	_, err := client.leaderboardClient.RemoveElements(ctx, &pb.XRemoveElementsRequest{
+		CacheName:   request.CacheName,
+		Leaderboard: request.LeaderboardName,
+		Ids:         request.Ids,
+	})
+	if err != nil {
+		return momentoerrors.ConvertSvcErr(err)
+	}
+	return nil
+}
+
+func (client *leaderboardDataClient) Upsert(ctx context.Context, request *LeaderboardInternalUpsertRequest) momentoerrors.MomentoSvcErr {
+	ctx, cancel := context.WithTimeout(ctx, client.requestTimeout)
+	defer cancel()
+
+	_, err := client.leaderboardClient.UpsertElements(ctx, &pb.XUpsertElementsRequest{
+		CacheName:   request.CacheName,
+		Leaderboard: request.LeaderboardName,
+		Elements:    leaderboardUpsertElementToGrpc(request.Elements),
+	})
+	if err != nil {
+		return momentoerrors.ConvertSvcErr(err)
+	}
+	return nil
+}
+
+func leaderboardUpsertElementToGrpc(elements []LeaderboardUpsertElement) []*pb.XElement {
+	var grpcElements []*pb.XElement
+	for _, element := range elements {
+		grpcElements = append(grpcElements, &pb.XElement{
+			Id:    element.Id,
+			Score: element.Score,
+		})
+	}
+	return grpcElements
+}

--- a/momento/leaderboard_delete.go
+++ b/momento/leaderboard_delete.go
@@ -1,0 +1,6 @@
+package momento
+
+type LeaderboardInternalDeleteRequest struct {
+	CacheName       string
+	LeaderboardName string
+}

--- a/momento/leaderboard_fetch_by_rank.go
+++ b/momento/leaderboard_fetch_by_rank.go
@@ -1,0 +1,15 @@
+package momento
+
+type LeaderboardFetchByRankRequest struct {
+	StartRank uint32
+	EndRank   uint32
+	Order     *LeaderboardOrder
+}
+
+type LeaderboardInternalFetchByRankRequest struct {
+	CacheName       string
+	LeaderboardName string
+	StartRank       uint32
+	EndRank         uint32
+	Order           *LeaderboardOrder
+}

--- a/momento/leaderboard_fetch_by_score.go
+++ b/momento/leaderboard_fetch_by_score.go
@@ -1,0 +1,19 @@
+package momento
+
+type LeaderboardFetchByScoreRequest struct {
+	MinScore *float64
+	MaxScore *float64
+	Order    *LeaderboardOrder
+	Offset   *uint32
+	Count    *uint32
+}
+
+type LeaderboardInternalFetchByScoreRequest struct {
+	CacheName       string
+	LeaderboardName string
+	MinScore        *float64
+	MaxScore        *float64
+	Order           *LeaderboardOrder
+	Offset          *uint32
+	Count           *uint32
+}

--- a/momento/leaderboard_get_rank.go
+++ b/momento/leaderboard_get_rank.go
@@ -1,0 +1,13 @@
+package momento
+
+type LeaderboardGetRankRequest struct {
+	Ids   []uint32
+	Order *LeaderboardOrder
+}
+
+type LeaderboardInternalGetRankRequest struct {
+	CacheName       string
+	LeaderboardName string
+	Ids             []uint32
+	Order           *LeaderboardOrder
+}

--- a/momento/leaderboard_length.go
+++ b/momento/leaderboard_length.go
@@ -1,0 +1,6 @@
+package momento
+
+type LeaderboardInternalLengthRequest struct {
+	CacheName       string
+	LeaderboardName string
+}

--- a/momento/leaderboard_remove_elements.go
+++ b/momento/leaderboard_remove_elements.go
@@ -1,0 +1,11 @@
+package momento
+
+type LeaderboardRemoveElementsRequest struct {
+	Ids []uint32
+}
+
+type LeaderboardInternalRemoveElementsRequest struct {
+	CacheName       string
+	LeaderboardName string
+	Ids             []uint32
+}

--- a/momento/leaderboard_request.go
+++ b/momento/leaderboard_request.go
@@ -1,0 +1,6 @@
+package momento
+
+type LeaderboardRequest struct {
+	CacheName       string
+	LeaderboardName string
+}

--- a/momento/leaderboard_test.go
+++ b/momento/leaderboard_test.go
@@ -1,0 +1,519 @@
+package momento_test
+
+import (
+	"fmt"
+
+	. "github.com/momentohq/client-sdk-go/momento"
+	. "github.com/momentohq/client-sdk-go/momento/test_helpers"
+	. "github.com/momentohq/client-sdk-go/responses"
+
+	"github.com/google/uuid"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Leaderboards", func() {
+	var sharedContext SharedContext
+
+	BeforeEach(func() {
+		sharedContext = NewSharedContext()
+		sharedContext.CreateDefaultCaches()
+
+		DeferCleanup(func() { sharedContext.Close() })
+	})
+
+	// Convenience method for creating temporary leaderboard
+	createLeaderboard := func() Leaderboard {
+		leaderboard, err := sharedContext.LeaderboardClient.Leaderboard(sharedContext.Ctx, &LeaderboardRequest{
+			CacheName:       sharedContext.CacheName,
+			LeaderboardName: fmt.Sprintf("golang-test-%s", uuid.NewString()),
+		})
+		if err != nil {
+			panic(fmt.Sprintf("Failed to create leaderboard before a test: %v", err))
+		}
+		return leaderboard
+	}
+
+	// Convenience method for deleting temporary leaderboard
+	deleteLeaderboard := func(leaderboard Leaderboard) LeaderboardDeleteResponse {
+		response, err := leaderboard.Delete(sharedContext.Ctx)
+		if err != nil {
+			panic(fmt.Sprintf("Failed to delete leaderboard after a test: %v", err))
+		}
+		return response
+	}
+
+	// Convenience method for adding elements to a leaderboard
+	upsertElements := func(leaderboard Leaderboard, elements []LeaderboardUpsertElement) LeaderboardUpsertResponse {
+		response, err := leaderboard.Upsert(sharedContext.Ctx, LeaderboardUpsertRequest{
+			Elements: elements,
+		})
+		if err != nil {
+			panic(fmt.Sprintf("Failed to upsert elements to leaderboard: %v", err))
+		}
+		return response
+	}
+
+	// Convenience method for fetching all elements from a leaderboard
+	fetchAllElements := func(leaderboard Leaderboard) []LeaderboardElement {
+		response, err := leaderboard.FetchByScore(sharedContext.Ctx, LeaderboardFetchByScoreRequest{})
+		if err != nil {
+			panic(fmt.Sprintf("Failed to fetch elements from leaderboard: %v", err))
+		}
+		switch response := response.(type) {
+		case *LeaderboardFetchSuccess:
+			return response.Values()
+		default:
+			panic(fmt.Sprintf("Unexpected fetch all elements response type: %T", response))
+		}
+	}
+
+	Describe("Leaderboard", func() {
+		var testLeaderboard Leaderboard
+		BeforeEach(func() {
+			testLeaderboard = createLeaderboard()
+			DeferCleanup(func() { deleteLeaderboard(testLeaderboard) })
+		})
+
+		It("Validates cache name before creating a leaderboard", func() {
+			Expect(
+				sharedContext.LeaderboardClient.Leaderboard(sharedContext.Ctx, &LeaderboardRequest{
+					CacheName:       "   ",
+					LeaderboardName: "test-leaderboard",
+				}),
+			).Error().To(HaveMomentoErrorCode(InvalidArgumentError))
+		})
+
+		It("Validates leaderboard name before creating a leaderboard", func() {
+			Expect(
+				sharedContext.LeaderboardClient.Leaderboard(sharedContext.Ctx, &LeaderboardRequest{
+					CacheName:       "test-cache",
+					LeaderboardName: "   ",
+				}),
+			).Error().To(HaveMomentoErrorCode(InvalidArgumentError))
+		})
+
+		It("Creates an empty leaderboard", func() {
+			Expect(createLeaderboard()).ToNot(BeNil())
+		})
+	})
+
+	Describe("Upsert", func() {
+		var testLeaderboard Leaderboard
+		BeforeEach(func() {
+			testLeaderboard = createLeaderboard()
+			DeferCleanup(func() { deleteLeaderboard(testLeaderboard) })
+		})
+
+		It("Validates number of elements", func() {
+			Expect(testLeaderboard.Upsert(sharedContext.Ctx, LeaderboardUpsertRequest{
+				Elements: []LeaderboardUpsertElement{},
+			})).Error().To(HaveMomentoErrorCode(InvalidArgumentError))
+		})
+
+		It("Inserts and updates elements", func() {
+			upsert1 := []LeaderboardUpsertElement{
+				{Id: 123, Score: 100.0},
+				{Id: 456, Score: 200.0},
+				{Id: 789, Score: 300.0},
+			}
+			Expect(upsertElements(testLeaderboard, upsert1)).To(BeAssignableToTypeOf(&LeaderboardUpsertSuccess{}))
+
+			fetch1 := fetchAllElements(testLeaderboard)
+			Expect(fetch1).To(HaveLen(3))
+			Expect(fetch1).To(ContainElements(
+				LeaderboardElement{Id: 123, Score: 100.0, Rank: 0},
+				LeaderboardElement{Id: 456, Score: 200.0, Rank: 1},
+				LeaderboardElement{Id: 789, Score: 300.0, Rank: 2},
+			))
+
+			upsert2 := []LeaderboardUpsertElement{
+				{Id: 456, Score: 50.0},
+				{Id: 1011, Score: 500.0},
+			}
+			Expect(upsertElements(testLeaderboard, upsert2)).To(BeAssignableToTypeOf(&LeaderboardUpsertSuccess{}))
+
+			fetch2 := fetchAllElements(testLeaderboard)
+			Expect(fetch2).To(HaveLen(4))
+			Expect(fetch2).To(ContainElements(
+				LeaderboardElement{Id: 456, Score: 50.0, Rank: 0},
+				LeaderboardElement{Id: 123, Score: 100.0, Rank: 1},
+				LeaderboardElement{Id: 789, Score: 300.0, Rank: 2},
+				LeaderboardElement{Id: 1011, Score: 500.0, Rank: 3},
+			))
+		})
+
+		It("Can work with double precision floats", func() {
+			upsert := []LeaderboardUpsertElement{
+				{Id: 123, Score: 27.004309862363737},
+				{Id: 456, Score: 16777217.0},
+				{Id: 789, Score: 300.5},
+			}
+			Expect(upsertElements(testLeaderboard, upsert)).To(BeAssignableToTypeOf(&LeaderboardUpsertSuccess{}))
+
+			fetchedElements := fetchAllElements(testLeaderboard)
+			Expect(fetchedElements).To(HaveLen(3))
+			Expect(fetchedElements).To(ContainElements(
+				LeaderboardElement{Id: 123, Score: 27.004309862363737, Rank: 0},
+				LeaderboardElement{Id: 789, Score: 300.5, Rank: 1},
+				LeaderboardElement{Id: 456, Score: 16777217.0, Rank: 2},
+			))
+		})
+	})
+
+	Describe("FetchByScore", func() {
+		var testLeaderboard Leaderboard
+		BeforeEach(func() {
+			testLeaderboard = createLeaderboard()
+			DeferCleanup(func() { deleteLeaderboard(testLeaderboard) })
+		})
+
+		It("Validates the score range", func() {
+			minScore := 100.0
+			maxScore := 50.0
+			Expect(testLeaderboard.FetchByScore(sharedContext.Ctx, LeaderboardFetchByScoreRequest{
+				MinScore: &minScore,
+				MaxScore: &maxScore,
+			})).Error().To(HaveMomentoErrorCode(InvalidArgumentError))
+		})
+
+		It("Returns Success response with no elements when leaderboard is empty", func() {
+			response := fetchAllElements(testLeaderboard)
+			Expect(response).To(BeEmpty())
+		})
+
+		It("Fetches elements by score given different optional arguments", func() {
+			upsert := []LeaderboardUpsertElement{
+				{Id: 123, Score: 10.0},
+				{Id: 234, Score: 100.0},
+				{Id: 345, Score: 250.0},
+				{Id: 456, Score: 500.0},
+				{Id: 567, Score: 750.0},
+				{Id: 678, Score: 1000.0},
+				{Id: 789, Score: 1500.0},
+				{Id: 890, Score: 2000.0},
+			}
+			Expect(upsertElements(testLeaderboard, upsert)).To(BeAssignableToTypeOf(&LeaderboardUpsertSuccess{}))
+
+			// Fetch using unbounded score range and specifc offset and count
+			offset := uint32(2)
+			count := uint32(2)
+			fetch1, err1 := testLeaderboard.FetchByScore(sharedContext.Ctx, LeaderboardFetchByScoreRequest{
+				Offset: &offset,
+				Count:  &count,
+			})
+			Expect(err1).To(BeNil())
+			Expect(fetch1).To(BeAssignableToTypeOf(&LeaderboardFetchSuccess{}))
+			Expect(fetch1.(*LeaderboardFetchSuccess).Values()).To(HaveLen(2))
+			Expect(fetch1.(*LeaderboardFetchSuccess).Values()).To(ContainElements(
+				LeaderboardElement{Id: 345, Score: 250.0, Rank: 2},
+				LeaderboardElement{Id: 456, Score: 500.0, Rank: 3},
+			))
+
+			// Fetch using score range
+			minScore := 750.0
+			maxScore := 1500.0
+			fetch2, err2 := testLeaderboard.FetchByScore(sharedContext.Ctx, LeaderboardFetchByScoreRequest{
+				MinScore: &minScore,
+				MaxScore: &maxScore,
+			})
+			Expect(err2).To(BeNil())
+			Expect(fetch2).To(BeAssignableToTypeOf(&LeaderboardFetchSuccess{}))
+			Expect(fetch2.(*LeaderboardFetchSuccess).Values()).To(HaveLen(2))
+			Expect(fetch2.(*LeaderboardFetchSuccess).Values()).To(ContainElements(
+				LeaderboardElement{Id: 567, Score: 750.0, Rank: 4},
+				LeaderboardElement{Id: 678, Score: 1000.0, Rank: 5},
+			))
+
+			// Fetch using all options
+			minScore = 0.0
+			maxScore = 800.0
+			offset = uint32(2)
+			count = uint32(10)
+			order := DESCENDING
+			fetch3, err3 := testLeaderboard.FetchByScore(sharedContext.Ctx, LeaderboardFetchByScoreRequest{
+				MinScore: &minScore,
+				MaxScore: &maxScore,
+				Offset:   &offset,
+				Count:    &count,
+				Order:    &order,
+			})
+			Expect(err3).To(BeNil())
+			Expect(fetch3).To(BeAssignableToTypeOf(&LeaderboardFetchSuccess{}))
+			Expect(fetch3.(*LeaderboardFetchSuccess).Values()).To(HaveLen(3))
+			Expect(fetch3.(*LeaderboardFetchSuccess).Values()).To(ContainElements(
+				LeaderboardElement{Id: 345, Score: 250.0, Rank: 5},
+				LeaderboardElement{Id: 234, Score: 100.0, Rank: 6},
+				LeaderboardElement{Id: 123, Score: 10.0, Rank: 7},
+			))
+		})
+	})
+
+	Describe("FetchByRank", func() {
+		var testLeaderboard Leaderboard
+		BeforeEach(func() {
+			testLeaderboard = createLeaderboard()
+			DeferCleanup(func() { deleteLeaderboard(testLeaderboard) })
+		})
+
+		It("Returns Success response with no elements when leaderboard is empty", func() {
+			response, err := testLeaderboard.FetchByRank(sharedContext.Ctx, LeaderboardFetchByRankRequest{
+				StartRank: uint32(0),
+				EndRank:   uint32(10),
+			})
+			Expect(err).To(BeNil())
+			elements := response.(*LeaderboardFetchSuccess).Values()
+			Expect(elements).To(BeEmpty())
+		})
+
+		It("Validates the rank range", func() {
+			// No range provided
+			startRank := uint32(0)
+			endRank := uint32(0)
+			Expect(testLeaderboard.FetchByRank(sharedContext.Ctx, LeaderboardFetchByRankRequest{
+				StartRank: startRank,
+				EndRank:   endRank,
+			})).Error().To(HaveMomentoErrorCode(InvalidArgumentError))
+
+			// Range with start > end
+			startRank = uint32(10)
+			endRank = uint32(5)
+			Expect(testLeaderboard.FetchByRank(sharedContext.Ctx, LeaderboardFetchByRankRequest{
+				StartRank: startRank,
+				EndRank:   endRank,
+			})).Error().To(HaveMomentoErrorCode(InvalidArgumentError))
+
+			// Range over the 8192 limit
+			startRank = uint32(0)
+			endRank = uint32(8193)
+			Expect(testLeaderboard.FetchByRank(sharedContext.Ctx, LeaderboardFetchByRankRequest{
+				StartRank: startRank,
+				EndRank:   endRank,
+			})).Error().To(HaveMomentoErrorCode(InvalidArgumentError))
+		})
+
+		It("Fetches elements by rank given different arguments", func() {
+			upsert := []LeaderboardUpsertElement{
+				{Id: 123, Score: 100.0},
+				{Id: 456, Score: 200.0},
+				{Id: 789, Score: 300.0},
+			}
+			Expect(upsertElements(testLeaderboard, upsert)).To(BeAssignableToTypeOf(&LeaderboardUpsertSuccess{}))
+
+			// Fetch in ascending order
+			ascendingOrder := ASCENDING
+			response1, err1 := testLeaderboard.FetchByRank(sharedContext.Ctx, LeaderboardFetchByRankRequest{
+				StartRank: uint32(0),
+				EndRank:   uint32(10),
+				Order:     &ascendingOrder,
+			})
+			Expect(err1).To(BeNil())
+			elements1 := response1.(*LeaderboardFetchSuccess).Values()
+			Expect(elements1).To(HaveLen(3))
+			Expect(elements1).To(ContainElements(
+				LeaderboardElement{Id: 123, Score: 100.0, Rank: 0},
+				LeaderboardElement{Id: 456, Score: 200.0, Rank: 1},
+				LeaderboardElement{Id: 789, Score: 300.0, Rank: 2},
+			))
+
+			// Fetch in descending order
+			descendingOrder := DESCENDING
+			response2, err2 := testLeaderboard.FetchByRank(sharedContext.Ctx, LeaderboardFetchByRankRequest{
+				StartRank: uint32(0),
+				EndRank:   uint32(10),
+				Order:     &descendingOrder,
+			})
+			Expect(err2).To(BeNil())
+			elements2 := response2.(*LeaderboardFetchSuccess).Values()
+			Expect(elements2).To(HaveLen(3))
+			Expect(elements2).To(ContainElements(
+				LeaderboardElement{Id: 789, Score: 300.0, Rank: 0},
+				LeaderboardElement{Id: 456, Score: 200.0, Rank: 1},
+				LeaderboardElement{Id: 123, Score: 100.0, Rank: 2},
+			))
+
+			// Fetch the top two
+			response3, err3 := testLeaderboard.FetchByRank(sharedContext.Ctx, LeaderboardFetchByRankRequest{
+				StartRank: uint32(0),
+				EndRank:   uint32(2),
+			})
+			Expect(err3).To(BeNil())
+			elements3 := response3.(*LeaderboardFetchSuccess).Values()
+			Expect(elements3).To(HaveLen(2))
+			Expect(elements3).To(ContainElements(
+				LeaderboardElement{Id: 123, Score: 100.0, Rank: 0},
+				LeaderboardElement{Id: 456, Score: 200.0, Rank: 1},
+			))
+		})
+	})
+
+	Describe("GetRank", func() {
+		var testLeaderboard Leaderboard
+		BeforeEach(func() {
+			testLeaderboard = createLeaderboard()
+			DeferCleanup(func() { deleteLeaderboard(testLeaderboard) })
+		})
+
+		It("Returns Success response with no elements when leaderboard is empty", func() {
+			response, err := testLeaderboard.GetRank(sharedContext.Ctx, LeaderboardGetRankRequest{
+				Ids: []uint32{123, 456, 789},
+			})
+			Expect(err).To(BeNil())
+			Expect(response).To(BeAssignableToTypeOf(&LeaderboardFetchSuccess{}))
+			Expect(response.(*LeaderboardFetchSuccess).Values()).To(BeEmpty())
+		})
+
+		It("Fetches elements given list of IDs", func() {
+			upsert := []LeaderboardUpsertElement{
+				{Id: 123, Score: 100.0},
+				{Id: 456, Score: 200.0},
+				{Id: 789, Score: 300.0},
+			}
+			Expect(upsertElements(testLeaderboard, upsert)).To(BeAssignableToTypeOf(&LeaderboardUpsertSuccess{}))
+
+			// Fetch given empty list of IDs
+			response1, err1 := testLeaderboard.GetRank(sharedContext.Ctx, LeaderboardGetRankRequest{
+				Ids: []uint32{},
+			})
+			Expect(err1).To(BeNil())
+			Expect(response1).To(BeAssignableToTypeOf(&LeaderboardFetchSuccess{}))
+			Expect(response1.(*LeaderboardFetchSuccess).Values()).To(BeEmpty())
+
+			// Fetch elements with ascending order
+			ascendingOrder := ASCENDING
+			response2, err2 := testLeaderboard.GetRank(sharedContext.Ctx, LeaderboardGetRankRequest{
+				Ids:   []uint32{123, 456, 789},
+				Order: &ascendingOrder,
+			})
+			Expect(err2).To(BeNil())
+			Expect(response2).To(BeAssignableToTypeOf(&LeaderboardFetchSuccess{}))
+			Expect(response2.(*LeaderboardFetchSuccess).Values()).To(HaveLen(3))
+			Expect(response2.(*LeaderboardFetchSuccess).Values()).To(ContainElements(
+				LeaderboardElement{Id: 123, Score: 100.0, Rank: 0},
+				LeaderboardElement{Id: 456, Score: 200.0, Rank: 1},
+				LeaderboardElement{Id: 789, Score: 300.0, Rank: 2},
+			))
+
+			// Fetch elements with descending order
+			descendingOrder := DESCENDING
+			response3, err3 := testLeaderboard.GetRank(sharedContext.Ctx, LeaderboardGetRankRequest{
+				Ids:   []uint32{123, 456, 789},
+				Order: &descendingOrder,
+			})
+			Expect(err3).To(BeNil())
+			Expect(response3).To(BeAssignableToTypeOf(&LeaderboardFetchSuccess{}))
+			Expect(response3.(*LeaderboardFetchSuccess).Values()).To(HaveLen(3))
+			Expect(response3.(*LeaderboardFetchSuccess).Values()).To(ContainElements(
+				LeaderboardElement{Id: 789, Score: 300.0, Rank: 0},
+				LeaderboardElement{Id: 456, Score: 200.0, Rank: 1},
+				LeaderboardElement{Id: 123, Score: 100.0, Rank: 2},
+			))
+		})
+	})
+
+	Describe("Length", func() {
+		var testLeaderboard Leaderboard
+		BeforeEach(func() {
+			testLeaderboard = createLeaderboard()
+			DeferCleanup(func() { deleteLeaderboard(testLeaderboard) })
+		})
+
+		It("Returns Success response with zero length when leaderboard is empty", func() {
+			response, err := testLeaderboard.Length(sharedContext.Ctx)
+			Expect(err).To(BeNil())
+			Expect(response).To(BeAssignableToTypeOf(&LeaderboardLengthSuccess{}))
+			Expect(response.(*LeaderboardLengthSuccess).Length()).To(BeZero())
+		})
+
+		It("Returns Success response with nonzero length when leaderboard has elements", func() {
+			upsert := []LeaderboardUpsertElement{
+				{Id: 123, Score: 100.0},
+				{Id: 456, Score: 200.0},
+				{Id: 789, Score: 300.0},
+			}
+			Expect(upsertElements(testLeaderboard, upsert)).To(BeAssignableToTypeOf(&LeaderboardUpsertSuccess{}))
+
+			response, err := testLeaderboard.Length(sharedContext.Ctx)
+			Expect(err).To(BeNil())
+			Expect(response).To(BeAssignableToTypeOf(&LeaderboardLengthSuccess{}))
+			Expect(response.(*LeaderboardLengthSuccess).Length()).To(Equal(uint32(3)))
+		})
+	})
+
+	Describe("RemoveElements", func() {
+		var testLeaderboard Leaderboard
+		BeforeEach(func() {
+			testLeaderboard = createLeaderboard()
+			DeferCleanup(func() { deleteLeaderboard(testLeaderboard) })
+		})
+
+		It("Returns Successful no-op response when leaderboard is empty", func() {
+			response, err := testLeaderboard.RemoveElements(sharedContext.Ctx, LeaderboardRemoveElementsRequest{
+				Ids: []uint32{123, 456, 789},
+			})
+			Expect(err).To(BeNil())
+			Expect(response).To(BeAssignableToTypeOf(&LeaderboardRemoveElementsSuccess{}))
+		})
+
+		It("Validates number of arguments", func() {
+			Expect(testLeaderboard.RemoveElements(sharedContext.Ctx, LeaderboardRemoveElementsRequest{
+				Ids: []uint32{},
+			})).Error().To(HaveMomentoErrorCode(InvalidArgumentError))
+		})
+
+		It("Removes elements when leaderboard has elements", func() {
+			upsert := []LeaderboardUpsertElement{
+				{Id: 123, Score: 100.0},
+				{Id: 456, Score: 200.0},
+				{Id: 789, Score: 300.0},
+			}
+			Expect(upsertElements(testLeaderboard, upsert)).To(BeAssignableToTypeOf(&LeaderboardUpsertSuccess{}))
+
+			response, err := testLeaderboard.RemoveElements(sharedContext.Ctx, LeaderboardRemoveElementsRequest{
+				Ids: []uint32{123, 789},
+			})
+			Expect(err).To(BeNil())
+			Expect(response).To(BeAssignableToTypeOf(&LeaderboardRemoveElementsSuccess{}))
+
+			// Check remaining elements are as expected
+			fetchedElements := fetchAllElements(testLeaderboard)
+			Expect(fetchedElements).To(HaveLen(1))
+			Expect(fetchedElements).To(ContainElements(
+				LeaderboardElement{Id: 456, Score: 200.0, Rank: 0},
+			))
+		})
+	})
+
+	Describe("Delete", func() {
+		var testLeaderboard Leaderboard
+		BeforeEach(func() {
+			testLeaderboard = createLeaderboard()
+			DeferCleanup(func() { deleteLeaderboard(testLeaderboard) })
+		})
+
+		It("Returns Successful no-op response when leaderboard is empty", func() {
+			response, err := testLeaderboard.Delete(sharedContext.Ctx)
+			Expect(err).To(BeNil())
+			Expect(response).To(BeAssignableToTypeOf(&LeaderboardDeleteSuccess{}))
+		})
+
+		It("Deletes non-empty leaderboard", func() {
+			upsert := []LeaderboardUpsertElement{
+				{Id: 123, Score: 100.0},
+				{Id: 456, Score: 200.0},
+				{Id: 789, Score: 300.0},
+			}
+			Expect(upsertElements(testLeaderboard, upsert)).To(BeAssignableToTypeOf(&LeaderboardUpsertSuccess{}))
+
+			response, err := testLeaderboard.Delete(sharedContext.Ctx)
+			Expect(err).To(BeNil())
+			Expect(response).To(BeAssignableToTypeOf(&LeaderboardDeleteSuccess{}))
+
+			// Check remaining elements are as expected
+			fetchedElements := fetchAllElements(testLeaderboard)
+			Expect(fetchedElements).To(HaveLen(0))
+			Expect(fetchedElements).To(BeEmpty())
+		})
+	})
+
+})

--- a/momento/leaderboard_upsert.go
+++ b/momento/leaderboard_upsert.go
@@ -1,0 +1,11 @@
+package momento
+
+type LeaderboardUpsertRequest struct {
+	Elements []LeaderboardUpsertElement
+}
+
+type LeaderboardInternalUpsertRequest struct {
+	CacheName       string
+	LeaderboardName string
+	Elements        []LeaderboardUpsertElement
+}

--- a/momento/test_helpers/shared_context.go
+++ b/momento/test_helpers/shared_context.go
@@ -35,6 +35,8 @@ type SharedContext struct {
 	CredentialProvider              auth.CredentialProvider
 	AuthClient                      momento.AuthClient
 	AuthConfiguration               config.AuthConfiguration
+	LeaderboardClient               momento.LeaderboardClient
+	LeaderboardConfiguration        config.LeaderboardConfiguration
 }
 
 func NewSharedContext() SharedContext {
@@ -49,6 +51,7 @@ func NewSharedContext() SharedContext {
 	shared.Configuration = config.LaptopLatestWithLogger(logger.NewNoopMomentoLoggerFactory()).WithClientTimeout(15 * time.Second)
 	shared.TopicConfigration = config.TopicsDefaultWithLogger(logger.NewNoopMomentoLoggerFactory())
 	shared.AuthConfiguration = config.AuthDefaultWithLogger(logger.NewNoopMomentoLoggerFactory())
+	shared.LeaderboardConfiguration = config.LeaderboardDefaultWithLogger(logger.NewNoopMomentoLoggerFactory())
 	shared.DefaultTtl = 3 * time.Second
 
 	client, err := momento.NewCacheClient(shared.Configuration, shared.CredentialProvider, shared.DefaultTtl)
@@ -88,6 +91,11 @@ func NewSharedContext() SharedContext {
 		panic(err)
 	}
 
+	leaderboardClient, err := momento.NewLeaderboardClient(shared.LeaderboardConfiguration, shared.CredentialProvider)
+	if err != nil {
+		panic(err)
+	}
+
 	shared.Client = client
 	shared.ClientWithDefaultCacheName = clientDefaultCacheName
 	shared.ClientWithConsistentReadConcern = consistentReadConcernClient
@@ -95,6 +103,7 @@ func NewSharedContext() SharedContext {
 	shared.DefaultCacheName = defaultCacheName
 	shared.TopicClient = topicClient
 	shared.AuthClient = authClient
+	shared.LeaderboardClient = leaderboardClient
 
 	shared.CacheName = fmt.Sprintf("golang-%s", uuid.NewString())
 	shared.CollectionName = uuid.NewString()
@@ -145,4 +154,7 @@ func (shared SharedContext) Close() {
 	}
 
 	shared.Client.Close()
+	shared.TopicClient.Close()
+	shared.AuthClient.Close()
+	shared.LeaderboardClient.Close()
 }

--- a/momento/test_helpers/shared_context.go
+++ b/momento/test_helpers/shared_context.go
@@ -35,7 +35,7 @@ type SharedContext struct {
 	CredentialProvider              auth.CredentialProvider
 	AuthClient                      momento.AuthClient
 	AuthConfiguration               config.AuthConfiguration
-	LeaderboardClient               momento.LeaderboardClient
+	LeaderboardClient               momento.PreviewLeaderboardClient
 	LeaderboardConfiguration        config.LeaderboardConfiguration
 }
 
@@ -91,7 +91,7 @@ func NewSharedContext() SharedContext {
 		panic(err)
 	}
 
-	leaderboardClient, err := momento.NewLeaderboardClient(shared.LeaderboardConfiguration, shared.CredentialProvider)
+	leaderboardClient, err := momento.NewPreviewLeaderboardClient(shared.LeaderboardConfiguration, shared.CredentialProvider)
 	if err != nil {
 		panic(err)
 	}

--- a/momento/value.go
+++ b/momento/value.go
@@ -120,3 +120,10 @@ func SortedSetElementsFromMap(theMap map[string]float64) []SortedSetElement {
 	}
 	return elements
 }
+
+type LeaderboardOrder = SortedSetOrder
+
+type LeaderboardUpsertElement struct {
+	Id    uint32
+	Score float64
+}

--- a/responses/leaderboard_delete.go
+++ b/responses/leaderboard_delete.go
@@ -1,0 +1,9 @@
+package responses
+
+type LeaderboardDeleteResponse interface {
+	isLeaderboardDeleteResponse()
+}
+
+type LeaderboardDeleteSuccess struct{}
+
+func (LeaderboardDeleteSuccess) isLeaderboardDeleteResponse() {}

--- a/responses/leaderboard_fetch.go
+++ b/responses/leaderboard_fetch.go
@@ -1,0 +1,29 @@
+package responses
+
+type LeaderboardFetchResponse interface {
+	isLeaderboardFetchResponse()
+}
+
+type LeaderboardElement struct {
+	Id    uint32
+	Score float64
+	Rank  uint32
+}
+
+type LeaderboardFetchSuccess struct {
+	elements []LeaderboardElement
+}
+
+func (LeaderboardFetchSuccess) isLeaderboardFetchResponse() {}
+
+// NewLeaderboardFetchSuccess returns a new LeaderboardFetchSuccess containing the supplied elements.
+func NewLeaderboardFetchSuccess(elements []LeaderboardElement) *LeaderboardFetchSuccess {
+	if elements == nil {
+		elements = []LeaderboardElement{}
+	}
+	return &LeaderboardFetchSuccess{elements: elements}
+}
+
+func (s LeaderboardFetchSuccess) Values() []LeaderboardElement {
+	return s.elements
+}

--- a/responses/leaderboard_length.go
+++ b/responses/leaderboard_length.go
@@ -1,0 +1,20 @@
+package responses
+
+type LeaderboardLengthResponse interface {
+	isLeaderboardLengthResponse()
+}
+
+type LeaderboardLengthSuccess struct {
+	length uint32
+}
+
+func (LeaderboardLengthSuccess) isLeaderboardLengthResponse() {}
+
+// NewLeaderboardLengthSuccess returns a new LeaderboardLengthSuccess containing the supplied elements.
+func NewLeaderboardLengthSuccess(length uint32) *LeaderboardLengthSuccess {
+	return &LeaderboardLengthSuccess{length: length}
+}
+
+func (s LeaderboardLengthSuccess) Length() uint32 {
+	return s.length
+}

--- a/responses/leaderboard_remove_elements.go
+++ b/responses/leaderboard_remove_elements.go
@@ -1,0 +1,9 @@
+package responses
+
+type LeaderboardRemoveElementsResponse interface {
+	isLeaderboardRemoveElementsResponse()
+}
+
+type LeaderboardRemoveElementsSuccess struct{}
+
+func (LeaderboardRemoveElementsSuccess) isLeaderboardRemoveElementsResponse() {}

--- a/responses/leaderboard_upsert.go
+++ b/responses/leaderboard_upsert.go
@@ -1,0 +1,9 @@
+package responses
+
+type LeaderboardUpsertResponse interface {
+	isLeaderboardUpsertResponse()
+}
+
+type LeaderboardUpsertSuccess struct{}
+
+func (LeaderboardUpsertSuccess) isLeaderboardUpsertResponse() {}

--- a/utils/validators.go
+++ b/utils/validators.go
@@ -1,6 +1,9 @@
 package utils
 
 import (
+	"fmt"
+	"strings"
+
 	"github.com/momentohq/client-sdk-go/internal/momentoerrors"
 )
 
@@ -18,6 +21,14 @@ func ValidateDisposableTokenExpiry(in ExpiresIn) momentoerrors.MomentoSvcErr {
 			"disposable tokens must expire within 1 hour",
 			nil,
 		)
+	}
+	return nil
+}
+
+func ValidateName(name string, label string) error {
+	if len(strings.TrimSpace(name)) < 1 {
+		errStr := fmt.Sprintf("%v cannot be empty or blank", label)
+		return momentoerrors.NewMomentoSvcErr(momentoerrors.InvalidArgumentError, errStr, nil)
 	}
 	return nil
 }


### PR DESCRIPTION
Addresses https://github.com/momentohq/dev-eco-issue-tracker/issues/768

* Adds `LeaderboardConfiguration` interface and a default prebuilt config
* `NewLeaderboardClient` creates a `previewLeaderboardClient` struct that contains an internal data client that can be used to interact with multiple leaderboards
* `previewLeaderboardClient`'s `Leaderboard()` method returns a `Leaderboard` object with public-facing APIs (these are called on the Leaderboard object so users don't need to pass in cache name and leaderboard name every time)
* `Leaderboard` object uses provided internal `LeaderboardDataClient` and `LeaderboardGrpcManager` to make requests
* Also added integration tests on par with the [JS sdk tests](https://github.com/momentohq/client-sdk-javascript/blob/main/packages/common-integration-tests/src/leaderboard-client.ts)

After this is released, will be following up with doc snippets PR to add code samples to the [Leaderboards docs](https://docs.momentohq.com/leaderboards/api-reference)