### PR TITLE
chore: update get/set perf test + loadgen test

### DIFF
--- a/examples/get-set-batch-perf-test/main.go
+++ b/examples/get-set-batch-perf-test/main.go
@@ -16,7 +16,7 @@ import (
 )
 
 const (
-	cacheName             = "js-perf-test"
+	cacheName             = "go-perf-test"
 	itemDefaultTTLSeconds = 60
 	requestTimeoutSeconds = 600 // 10 minutes
 	maxRequestsPerSecond  = 10_000
@@ -257,7 +257,7 @@ func sendSetBatchRequests(ctx context.Context, client momento.CacheClient, conte
 	if err != nil {
 		panic(err)
 	}
-	context.TotalNumberOfRequests += int64(setConfig.BatchSize)
+	context.TotalNumberOfRequests += 1
 	setBatchDuration := hrtime.Since(setBatchStartTime)
 	err = context.SetBatchLatencies.RecordValue(setBatchDuration.Milliseconds())
 	if err != nil {
@@ -279,7 +279,7 @@ func sendGetBatchRequests(ctx context.Context, client momento.CacheClient, conte
 	if err != nil {
 		panic(err)
 	}
-	context.TotalNumberOfRequests += int64(getConfig.BatchSize)
+	context.TotalNumberOfRequests += 1
 	getBatchDuration := hrtime.Since(getBatchStartTime)
 	err = context.GetBatchLatencies.RecordValue(getBatchDuration.Milliseconds())
 	if err != nil {

--- a/examples/get-set-batch-perf-test/utils/perf-test-options.go
+++ b/examples/get-set-batch-perf-test/utils/perf-test-options.go
@@ -8,22 +8,24 @@ import (
 )
 
 type PerfTestContext struct {
-	StartTime          time.Duration
-	TotalItemSizeBytes int64
-	AsyncGetLatencies  *hdrhistogram.Histogram
-	AsyncSetLatencies  *hdrhistogram.Histogram
-	SetBatchLatencies  *hdrhistogram.Histogram
-	GetBatchLatencies  *hdrhistogram.Histogram
+	StartTime             time.Duration
+	TotalItemSizeBytes    int64
+	TotalNumberOfRequests int64
+	AsyncGetLatencies     *hdrhistogram.Histogram
+	AsyncSetLatencies     *hdrhistogram.Histogram
+	SetBatchLatencies     *hdrhistogram.Histogram
+	GetBatchLatencies     *hdrhistogram.Histogram
 }
 
 func InitiatePerfTestContext() *PerfTestContext {
 	return &PerfTestContext{
-		StartTime:          hrtime.Now(),
-		TotalItemSizeBytes: 0,
-		AsyncGetLatencies:  hdrhistogram.New(1, 1000, 1),
-		AsyncSetLatencies:  hdrhistogram.New(1, 1000, 1),
-		SetBatchLatencies:  hdrhistogram.New(1, 1000, 1),
-		GetBatchLatencies:  hdrhistogram.New(1, 1000, 1),
+		StartTime:             hrtime.Now(),
+		TotalItemSizeBytes:    0,
+		TotalNumberOfRequests: 0,
+		AsyncGetLatencies:     hdrhistogram.New(1, 10000000000, 3),
+		AsyncSetLatencies:     hdrhistogram.New(1, 10000000000, 3),
+		SetBatchLatencies:     hdrhistogram.New(1, 10000000000, 3),
+		GetBatchLatencies:     hdrhistogram.New(1, 10000000000, 3),
 	}
 }
 

--- a/examples/loadgen/main.go
+++ b/examples/loadgen/main.go
@@ -129,7 +129,7 @@ func worker(
 			return
 		default:
 			i++
-			//elapsed = 0
+			elapsed = 0
 			cacheKey := fmt.Sprintf("worker%doperation%d", id, i)
 			setStart := hrtime.Now()
 			_, err := client.Set(ctx, &momento.SetRequest{
@@ -310,12 +310,12 @@ func main() {
 	opts := loadGeneratorOptions{
 		logLevel:              momento_default_logger.DEBUG,
 		showStatsInterval:     time.Second * 5,
-		cacheItemPayloadBytes: 10,
+		cacheItemPayloadBytes: 100,
 		// Note: You are likely to see degraded performance if you increase this above 50
 		// and observe elevated client-side latencies.
-		numberOfConcurrentRequests: 100,
-		maxRequestsPerSecond:       18000,
-		howLongToRun:               time.Minute * 5,
+		numberOfConcurrentRequests: 50,
+		maxRequestsPerSecond:       100,
+		howLongToRun:               time.Minute,
 	}
 
 	loadGenerator := newLoadGenerator(config.LaptopLatest(), opts)


### PR DESCRIPTION
# PR Description:
This commit updates the loadgen and perf test on get/set examples:

## Loadgen:
- Update the construction of histogram
- Remove the bottleneck that made the get/set channels clogged up due to restriction on the length of channels

## Get/Set Perf Test:
- Add worker delay logic to slow down the requests
- Print TPS after every run
