### PR TITLE
chore: run ci on ubuntu-24.04

### DIFF
--- a/.github/workflows/manual_release.yml
+++ b/.github/workflows/manual_release.yml
@@ -24,7 +24,7 @@ jobs:
         run: echo "release=${{ steps.semrel.outputs.version }}" >> $GITHUB_OUTPUT
   
   test:
-    runs-on: macos-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
       pull-requests: read

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -39,7 +39,7 @@ jobs:
           output_file: ./CONTRIBUTING.md
           dev_docs_slug: go
   test:
-    runs-on: macos-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
       pull-requests: read

--- a/.github/workflows/on-push-to-main.yml
+++ b/.github/workflows/on-push-to-main.yml
@@ -35,7 +35,7 @@ jobs:
           dev_docs_slug: go
 
   test:
-    runs-on: macos-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
       pull-requests: read


### PR DESCRIPTION
Previously we ran on macos to sidestep timeouts of uncertain origin on ubuntu-22.04 + GitHub's Azure runners. This has resolved on ubuntu-24.04