### PR TITLE
fix: Allow subscription to complete when cancelled

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -23,7 +23,7 @@ on:
 jobs:
   analyze:
     name: Analyze
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   dependency-review:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: 'Checkout Repository'
         uses: actions/checkout@v3

--- a/.github/workflows/manual_release.yml
+++ b/.github/workflows/manual_release.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   release:
     needs: [test]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     outputs:
       version: ${{ steps.release.outputs.release }}
     steps:
@@ -71,7 +71,7 @@ jobs:
 
   publish_golang:
     needs: [test, release]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Setup repo
         uses: actions/checkout@v3

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   commitlint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Commitlint and Other Shared Build Steps
         uses: momentohq/standards-and-practices/github-actions/shared-build@gh-actions-v1
@@ -13,7 +13,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   readme:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/on-push-to-main.yml
+++ b/.github/workflows/on-push-to-main.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   readme:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Setup repo
         uses: actions/checkout@v3


### PR DESCRIPTION
If the context that was used to create a subscription is cancelled,
it becomes visible inside the subscription's `Item` function via
`cancelContext.Done()`. However, we were not checking for that
condition when the grpc client's `RecvMsg` function returned,
so after a cancel, we were reconnecting the stream. This made it
impossible to write a goroutine that called this Item function
and then cancel it successfully for a clean shutdown.

This commit adds in some extra logging and an additional case
statement to allow the subscription Item function to exit
when the cancelContext is done.
