### PR TITLE
fix: don't log error message when subscription context cancelled

### DIFF
--- a/momento/topic_subscription.go
+++ b/momento/topic_subscription.go
@@ -47,8 +47,6 @@ func (s *topicSubscription) Item(ctx context.Context) (TopicValue, error) {
 
 		rawMsg := new(pb.XSubscriptionItem)
 		if err := s.grpcClient.RecvMsg(rawMsg); err != nil {
-			s.log.Error("stream disconnected, attempting to reconnect err:", fmt.Sprint(err))
-
 			select {
 			case <-ctx.Done():
 				{
@@ -63,6 +61,7 @@ func (s *topicSubscription) Item(ctx context.Context) (TopicValue, error) {
 			default:
 				{
 					// Attempt to reconnect
+					s.log.Error("stream disconnected YO, attempting to reconnect err:", fmt.Sprint(err))
 					s.attemptReconnect(ctx)
 				}
 			}


### PR DESCRIPTION
Prior to this commit, when a topic subscription was cancelled,
we would log an error message stating that we were going to attempt
to reconnect even when we aren't actually going to.

This commit moves the error log statement so that it only happens
if the contexts are not Done. This prevents users from seeing
errant error log messages when they are performing a clean shutdown.
