### PR TITLE
chore: add example for ShardedTopicClient

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -10,10 +10,10 @@
 
 Each example is a main.go file in its own directory.
 
-To run an example, provide your Momento Auth Token as the MOMENTO_API_KEY environment variable and `go run` the example's main.go. For example, to run the get/set/delete example...
+To run an example, provide your Momento Auth Token as the MOMENTO_API_KEY environment variable and `go run <directory>/*.go` for the specific exmaple directory. For example, to run the get/set/delete example...
 
 ```
-MOMENTO_API_KEY=<YOUR_TOKEN> go run scalar-example/main.go
+MOMENTO_API_KEY=<YOUR_TOKEN> go run scalar-example/*.go
 ```
 
 ## Using SDK in your project

--- a/examples/go.mod
+++ b/examples/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/HdrHistogram/hdrhistogram-go v1.1.2
 	github.com/google/uuid v1.6.0
 	github.com/loov/hrtime v1.0.3
-	github.com/momentohq/client-sdk-go v1.20.0
+	github.com/momentohq/client-sdk-go v1.21.1
 
 	// logrus is not required to use momento, but it is used in the logging-example
 	github.com/sirupsen/logrus v1.9.0

--- a/examples/go.sum
+++ b/examples/go.sum
@@ -47,6 +47,10 @@ github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWE
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/momentohq/client-sdk-go v1.20.0 h1:FrW+8EkTPlTYKJPbB36in+jjQd222dpiUaUWCXCuL6k=
 github.com/momentohq/client-sdk-go v1.20.0/go.mod h1:NB+kwQzksj9AJabAjS+GgcT5H8sUTg+3U93HlRSVh8c=
+github.com/momentohq/client-sdk-go v1.21.0 h1:R4dKw+gJ5MdZFFvlHrGTfQPvJ6J9ga2l4/HzwWzsk+4=
+github.com/momentohq/client-sdk-go v1.21.0/go.mod h1:NB+kwQzksj9AJabAjS+GgcT5H8sUTg+3U93HlRSVh8c=
+github.com/momentohq/client-sdk-go v1.21.1 h1:JmfdQrKL2p1j5FZhQYwQ7002ifeSD+UzTqeY7/Pg4E8=
+github.com/momentohq/client-sdk-go v1.21.1/go.mod h1:NB+kwQzksj9AJabAjS+GgcT5H8sUTg+3U93HlRSVh8c=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/onsi/ginkgo/v2 v2.8.1 h1:xFTEVwOFa1D/Ty24Ws1npBWkDYEV9BqZrsDxVrVkrrU=
 github.com/onsi/gomega v1.26.0 h1:03cDLK28U6hWvCAns6NeydX3zIm4SF3ci69ulidS32Q=

--- a/examples/topic-example/main.go
+++ b/examples/topic-example/main.go
@@ -39,6 +39,8 @@ func main() {
 
 	// Publish messages for the subscriber
 	publishMessages(topicClient, ctx)
+
+	sub.Close()
 }
 
 func pollForMessages(ctx context.Context, sub momento.TopicSubscription) {

--- a/examples/topic-sharded-example/README.md
+++ b/examples/topic-sharded-example/README.md
@@ -27,6 +27,8 @@ it will use goroutines to subscribe to all of these topics and emit messages fro
 Caveats:
 * If you have some topics that you don't wish to shard, and some that you do, you should create separate `TopicClient`
   and `ShardedTopicClient` instances accordingly.
+* For any topic that you do wish to shard, it's important that you use a `ShardedTopicClient` for both the `Publish` and
+  the `Subscribe` operations. Otherwise you may end up with messages being lost.
 * It's important to make sure you use the same value for `numShardsPerTopic` in all of the places where you are doing
   any `Publish` and `Subscribe` operations on the same topic. If you don't, you may end up with messages appearing to
   be lost due to the clients not using the same list of sharded topic names behind the scenes.
@@ -42,3 +44,7 @@ Caveats:
 ```
 MOMENTO_API_KEY=<YOUR_TOKEN> go run topic-sharded-example/*.go
 ```
+
+If you compare the code in this [main.go](./main.go) to the code in the basic topic example's [main.go](../topic-example/main.go),
+you'll note that they are almost identical. The only meaningful difference is the way the `TopicClient` is instantiated,
+in the `getShardedTopicClient` and `getTopicClient` functions respectively. 

--- a/examples/topic-sharded-example/README.md
+++ b/examples/topic-sharded-example/README.md
@@ -1,0 +1,44 @@
+# Sharded Topic Example
+
+If you have a Momento Topic for which you expect an extremely high volume of traffic (> 100k publishes per second),
+you will likely get better performance by sharding the traffic into multiple topics. This allows for better load distribution
+on Momento's servers.
+
+In this directory we provide an example of an alternate implementation of the Momento `TopicClient` interface that 
+will split your topic up into multiple shards while still retaining the same API.
+
+All you need to do is to update the line of code where you instantiate your `TopicClient` from this:
+
+```go
+topicClient, err := momento.NewTopicClient(config, credentialsProvider)
+```
+
+to this:
+
+```go
+numShardsPerTopic := 16
+topicClient, err := NewShardedTopicClient(config, credentialsProvider, numShardsPerTopic)
+```
+
+When you `Publish` to the `ShardedTopicClient`, it will treat the topic name that you specify as a prefix, and create
+multiple topics suffixed with `-0`, `-1`, etc. up to the number of shards you specify. When you create a subscription,
+it will use goroutines to subscribe to all of these topics and emit messages from all of them.
+
+Caveats:
+* If you have some topics that you don't wish to shard, and some that you do, you should create separate `TopicClient`
+  and `ShardedTopicClient` instances accordingly.
+* It's important to make sure you use the same value for `numShardsPerTopic` in all of the places where you are doing
+  any `Publish` and `Subscribe` operations on the same topic. If you don't, you may end up with messages appearing to
+  be lost due to the clients not using the same list of sharded topic names behind the scenes.
+
+## Requirements.
+
+- [Go](https://go.dev/dl/)
+- A Momento Auth Token; you can generate one using the [Momento CLI](https://github.com/momentohq/momento-cli).
+- Run `go mod vendor` to install dependencies.
+
+## Running the example
+
+```
+MOMENTO_API_KEY=<YOUR_TOKEN> go run topic-sharded-example/*.go
+```

--- a/examples/topic-sharded-example/main.go
+++ b/examples/topic-sharded-example/main.go
@@ -1,0 +1,132 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"github.com/momentohq/client-sdk-go/config/logger"
+	"github.com/momentohq/client-sdk-go/config/logger/momento_default_logger"
+	"math/rand"
+	"time"
+
+	"github.com/momentohq/client-sdk-go/auth"
+	"github.com/momentohq/client-sdk-go/config"
+	"github.com/momentohq/client-sdk-go/momento"
+)
+
+const (
+	cacheName = "test-cache"
+	topicName = "test-topic"
+)
+
+// You wouldn't need the cacheClient object, setupCache function, or associated code if you were connecting to an existing cache in Momento Serverless Cache.
+// For demonstration purposes, this example creates a cache for the new Topic to show the publish and subscribe functionality.
+func main() {
+	// Initialization
+	logLevel := momento_default_logger.INFO
+	// for more verbose logging, comment out the previous line and uncomment the line below
+	//logLevel := momento_default_logger.DEBUG
+	loggerFactory := momento_default_logger.NewDefaultMomentoLoggerFactory(logLevel)
+	log := loggerFactory.GetLogger("sharded-topic-example")
+
+	rand.Seed(time.Now().UnixNano())
+
+	topicClient := getTopicClient(loggerFactory)
+	cacheClient := getCacheClient()
+	ctx := context.Background()
+	setupCache(cacheClient, ctx)
+
+	// Instantiate subscriber
+	sub, err := topicClient.Subscribe(ctx, &momento.TopicSubscribeRequest{
+		CacheName: cacheName,
+		TopicName: topicName,
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	// Receive and print messages in a goroutine
+	go func() { pollForMessages(ctx, sub, log) }()
+	time.Sleep(time.Second)
+
+	// Publish messages for the subscriber
+	publishMessages(topicClient, ctx, log)
+
+	sub.Close()
+}
+
+func pollForMessages(ctx context.Context, sub momento.TopicSubscription, log logger.MomentoLogger) {
+	for {
+		item, err := sub.Item(ctx)
+		if err != nil {
+			if errors.Is(err, context.Canceled) {
+				log.Debug("context canceled, shutting down subscription poll loop")
+				return
+			}
+			panic(err)
+		}
+		switch msg := item.(type) {
+		case momento.String:
+			log.Info(fmt.Sprintf("received message as string: '%v'", msg))
+		case momento.Bytes:
+			log.Info(fmt.Sprintf("received message as bytes: '%v'", msg))
+		}
+	}
+}
+
+func getTopicClient(loggerFactory logger.MomentoLoggerFactory) momento.TopicClient {
+	credProvider, err := auth.NewEnvMomentoTokenProvider("MOMENTO_API_KEY")
+	if err != nil {
+		panic(err)
+	}
+	topicClient, err := NewShardedTopicClient(
+		config.TopicsDefaultWithLogger(loggerFactory),
+		credProvider,
+		16,
+	)
+	if err != nil {
+		panic(err)
+	}
+	return topicClient
+}
+
+func getCacheClient() momento.CacheClient {
+	credProvider, err := auth.NewEnvMomentoTokenProvider("MOMENTO_API_KEY")
+	if err != nil {
+		panic(err)
+	}
+	cacheClient, err := momento.NewCacheClientWithEagerConnectTimeout(
+		config.LaptopLatest(),
+		credProvider,
+		time.Second*60,
+		30*time.Second,
+	)
+	if err != nil {
+		panic(err)
+	}
+	return cacheClient
+}
+
+func setupCache(client momento.CacheClient, ctx context.Context) {
+	_, err := client.CreateCache(ctx, &momento.CreateCacheRequest{
+		CacheName: "test-cache",
+	})
+	if err != nil {
+		panic(err)
+	}
+}
+
+func publishMessages(client momento.TopicClient, ctx context.Context, log logger.MomentoLogger) {
+	for i := 0; i < 10; i++ {
+		log.Info(fmt.Sprintf("publishing message %d", i))
+		_, err := client.Publish(ctx, &momento.TopicPublishRequest{
+			CacheName: cacheName,
+			TopicName: topicName,
+			Value:     momento.String(fmt.Sprintf("hello %d", i)),
+		})
+		if err != nil {
+			panic(err)
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+}

--- a/examples/topic-sharded-example/main.go
+++ b/examples/topic-sharded-example/main.go
@@ -32,7 +32,8 @@ func main() {
 
 	rand.Seed(time.Now().UnixNano())
 
-	topicClient := getTopicClient(loggerFactory)
+	numShardsPerTopic := 16
+	topicClient := getShardedTopicClient(loggerFactory, numShardsPerTopic)
 	cacheClient := getCacheClient()
 	ctx := context.Background()
 	setupCache(cacheClient, ctx)
@@ -75,15 +76,18 @@ func pollForMessages(ctx context.Context, sub momento.TopicSubscription, log log
 	}
 }
 
-func getTopicClient(loggerFactory logger.MomentoLoggerFactory) momento.TopicClient {
+func getShardedTopicClient(loggerFactory logger.MomentoLoggerFactory, numShardsPerTopic int) momento.TopicClient {
 	credProvider, err := auth.NewEnvMomentoTokenProvider("MOMENTO_API_KEY")
 	if err != nil {
 		panic(err)
 	}
+	//
+	// NOTE: this the main difference between this program and the basic topic example in ../topic-example
+	//
 	topicClient, err := NewShardedTopicClient(
 		config.TopicsDefaultWithLogger(loggerFactory),
 		credProvider,
-		16,
+		numShardsPerTopic,
 	)
 	if err != nil {
 		panic(err)

--- a/examples/topic-sharded-example/main.go
+++ b/examples/topic-sharded-example/main.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/momentohq/client-sdk-go/config/logger"
-	"github.com/momentohq/client-sdk-go/config/logger/momento_default_logger"
 	"math/rand"
 	"time"
+
+	"github.com/momentohq/client-sdk-go/config/logger"
+	"github.com/momentohq/client-sdk-go/config/logger/momento_default_logger"
 
 	"github.com/momentohq/client-sdk-go/auth"
 	"github.com/momentohq/client-sdk-go/config"

--- a/examples/topic-sharded-example/sharded_topic_client.go
+++ b/examples/topic-sharded-example/sharded_topic_client.go
@@ -1,0 +1,192 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"github.com/momentohq/client-sdk-go/auth"
+	"github.com/momentohq/client-sdk-go/config"
+	"github.com/momentohq/client-sdk-go/config/logger"
+	"github.com/momentohq/client-sdk-go/momento"
+	"github.com/momentohq/client-sdk-go/responses"
+	"math/rand"
+	"sync"
+)
+
+type shardedTopicClient struct {
+	topicClient       momento.TopicClient
+	numShardsPerTopic int
+	log               logger.MomentoLogger
+}
+
+func NewShardedTopicClient(topicsConfiguration config.TopicsConfiguration, credentialProvider auth.CredentialProvider, numShardsPerTopic int) (momento.TopicClient, error) {
+	topicClient, err := momento.NewTopicClient(topicsConfiguration, credentialProvider)
+	if err != nil {
+		return nil, err
+	}
+	return shardedTopicClient{
+		topicClient:       topicClient,
+		numShardsPerTopic: numShardsPerTopic,
+		log:               topicsConfiguration.GetLoggerFactory().GetLogger("sharded-topic-client"),
+	}, nil
+}
+
+func (c shardedTopicClient) Subscribe(ctx context.Context, request *momento.TopicSubscribeRequest) (momento.TopicSubscription, error) {
+	subscriptions := make([]namedTopicSubscription, c.numShardsPerTopic)
+	for i := 0; i < c.numShardsPerTopic; i++ {
+		topicName := fmt.Sprintf("%s-%d", request.TopicName, i)
+		subscription, err := c.topicClient.Subscribe(ctx, &momento.TopicSubscribeRequest{
+			CacheName: request.CacheName,
+			TopicName: topicName,
+		})
+		if err != nil {
+			for j := 0; j < c.numShardsPerTopic; j++ {
+				if subscriptions[j].subscription != nil {
+					subscriptions[j].subscription.Close()
+				}
+			}
+			return nil, err
+		}
+		subscriptions[i] = namedTopicSubscription{
+			topicName:    topicName,
+			subscription: subscription,
+		}
+	}
+	return newShardedTopicSubscription(ctx, subscriptions, c.log), nil
+}
+
+func (c shardedTopicClient) Publish(ctx context.Context, request *momento.TopicPublishRequest) (responses.TopicPublishResponse, error) {
+	topicNamePrefix := request.TopicName
+	shardToPublishTo := rand.Intn(c.numShardsPerTopic)
+	topicName := fmt.Sprintf("%s-%d", topicNamePrefix, shardToPublishTo)
+	c.log.Debug("Publishing to topic %s", topicName)
+	shardRequest := momento.TopicPublishRequest{
+		CacheName: cacheName,
+		TopicName: topicName,
+		Value:     request.Value,
+	}
+	return c.topicClient.Publish(ctx, &shardRequest)
+}
+
+func (c shardedTopicClient) Close() {
+	c.topicClient.Close()
+}
+
+type namedTopicSubscription struct {
+	topicName    string
+	subscription momento.TopicSubscription
+}
+
+type shardedTopicItem struct {
+	value momento.TopicValue
+	err   error
+}
+
+type shardedTopicSubscription struct {
+	cancelContext        context.Context
+	cancelFunction       context.CancelFunc
+	receivedItemsChannel chan shardedTopicItem
+	subscriptions        []namedTopicSubscription
+	wg                   *sync.WaitGroup
+	log                  logger.MomentoLogger
+}
+
+func newShardedTopicSubscription(
+	ctx context.Context, subscriptions []namedTopicSubscription, log logger.MomentoLogger,
+) shardedTopicSubscription {
+	// We want the channel to support a bit of buffer in case we are reading things from the
+	// sharded subscriptions faster than the caller is consuming them. Arbitrarily choosing a value
+	// for now that should give us plenty of breathing room but not consume an excessive amount of memory.
+	itemsChannelSize := 1_000
+	receivedItemsChannel := make(chan shardedTopicItem, itemsChannelSize)
+
+	// try withCancel on context
+	cancelContext, cancelFunction := context.WithCancel(ctx)
+
+	var wg sync.WaitGroup
+
+	for i := 0; i < len(subscriptions); i++ {
+		subscription := subscriptions[i]
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			publishSubscriptionItemsToChannel(ctx, cancelContext, subscription, receivedItemsChannel, log)
+			log.Debug("Back from publishSubscriptionItemsToChannel for topic: %s", subscription.topicName)
+		}()
+	}
+
+	return shardedTopicSubscription{
+		cancelContext:        cancelContext,
+		cancelFunction:       cancelFunction,
+		receivedItemsChannel: receivedItemsChannel,
+		subscriptions:        subscriptions,
+		wg:                   &wg,
+		log:                  log,
+	}
+}
+
+func (s shardedTopicSubscription) Item(ctx context.Context) (momento.TopicValue, error) {
+
+	for {
+		// Its totally possible a client just calls `cancel` on the `context` immediately after subscribing to an
+		// item, so we should check that here.
+		select {
+		case <-ctx.Done():
+			{
+				s.log.Debug("Context is Done, sharded subscription exiting item loop")
+			}
+			return nil, ctx.Err()
+		case <-s.cancelContext.Done():
+			s.log.Debug("Context is Cancelled, sharded subscription exiting item loop")
+			return nil, s.cancelContext.Err()
+
+		default:
+			// Proceed as is
+		}
+
+		item := <-s.receivedItemsChannel
+		return item.value, item.err
+	}
+}
+
+func publishSubscriptionItemsToChannel(
+	ctx context.Context, cancelContext context.Context, sub namedTopicSubscription, topicValueChan chan shardedTopicItem, log logger.MomentoLogger) {
+	topicName := sub.topicName
+	log.Debug("Beginning publish coroutine for topic: %s", topicName)
+	for {
+		log.Debug("Next iteration of publish coroutine for topic: %s", topicName)
+		select {
+		case <-ctx.Done():
+			// Context has been canceled, return an error
+			{
+				log.Debug("Context is Done, stopping publish coroutine for topic: %s", topicName)
+				return
+			}
+		case <-cancelContext.Done():
+			{
+				log.Debug("Context has been cancelled, stopping publish coroutine for topic: %s", topicName)
+				return
+			}
+		default:
+			// Proceed as is
+		}
+
+		log.Debug("Waiting for next subscription item in coroutine for topic: %s", topicName)
+		item, err := sub.subscription.Item(ctx)
+		log.Debug("subscription.Item returned a value in coroutine for topic: %s", topicName)
+		topicValueChan <- shardedTopicItem{
+			value: item,
+			err:   err,
+		}
+	}
+}
+
+func (s shardedTopicSubscription) Close() {
+	for i := 0; i < len(s.subscriptions); i++ {
+		s.log.Debug("Closing subscription for topic: %s", s.subscriptions[i].topicName)
+		s.subscriptions[i].subscription.Close()
+	}
+	s.cancelFunction()
+	s.log.Debug("Waiting for sharded subscription goroutines to exit.")
+	s.wg.Wait()
+	s.log.Debug("All sharded subscription goroutines have exited; ShardedTopicSubscription.Close complete")
+}

--- a/examples/topic-sharded-example/sharded_topic_client.go
+++ b/examples/topic-sharded-example/sharded_topic_client.go
@@ -3,13 +3,14 @@ package main
 import (
 	"context"
 	"fmt"
+	"math/rand"
+	"sync"
+
 	"github.com/momentohq/client-sdk-go/auth"
 	"github.com/momentohq/client-sdk-go/config"
 	"github.com/momentohq/client-sdk-go/config/logger"
 	"github.com/momentohq/client-sdk-go/momento"
 	"github.com/momentohq/client-sdk-go/responses"
-	"math/rand"
-	"sync"
 )
 
 type shardedTopicClient struct {


### PR DESCRIPTION
This commit adds a new example in the examples dir; it contains
a drop-in-replacement for the TopicClient that will allow you
to specify a number of shards to split your topic into. Behind
the scenes it will create multiple topics and split up your
messages between them, which can help distribute load more
evenly and improve performance for extremely high-volume topics.
It conforms to the existing TopicClient interface, so it can
be consumed without any code changes beyond the constructor.
