### PR TITLE
feat: retry initial topic subscriptions on LimitExceeded

### DIFF
--- a/momento/topic_client.go
+++ b/momento/topic_client.go
@@ -4,6 +4,7 @@ package momento
 import (
 	"context"
 	"fmt"
+
 	"github.com/momentohq/client-sdk-go/internal/grpcmanagers"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -109,7 +110,7 @@ func (c defaultTopicClient) Subscribe(ctx context.Context, request *TopicSubscri
 	if err != nil {
 		return nil, err
 	}
-	
+
 	switch firstMsg.Kind.(type) {
 	case *pb.XSubscriptionItem_Heartbeat:
 		// The first message to a new subscription will always be a heartbeat.

--- a/momento/topic_client.go
+++ b/momento/topic_client.go
@@ -4,6 +4,7 @@ package momento
 import (
 	"context"
 	"fmt"
+
 	"github.com/momentohq/client-sdk-go/internal/grpcmanagers"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"

--- a/momento/topic_client.go
+++ b/momento/topic_client.go
@@ -4,7 +4,6 @@ package momento
 import (
 	"context"
 	"fmt"
-
 	"github.com/momentohq/client-sdk-go/internal/grpcmanagers"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -68,6 +67,10 @@ func (c defaultTopicClient) Subscribe(ctx context.Context, request *TopicSubscri
 	}
 
 	maxAttempts := c.numChannels
+	if maxAttempts == 0 {
+		maxAttempts = 1
+	}
+
 	failedAttempts := uint32(0)
 
 	var topicManager *grpcmanagers.TopicGrpcManager

--- a/momento/topic_client.go
+++ b/momento/topic_client.go
@@ -4,6 +4,10 @@ package momento
 import (
 	"context"
 	"fmt"
+	"github.com/momentohq/client-sdk-go/internal/grpcmanagers"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/momentohq/client-sdk-go/auth"
 	"github.com/momentohq/client-sdk-go/config"
@@ -24,14 +28,18 @@ type TopicClient interface {
 // defaultTopicClient represents all information needed for momento client to enable publish and subscribe operations.
 type defaultTopicClient struct {
 	credentialProvider auth.CredentialProvider
+	numChannels        uint32
 	pubSubClient       *pubSubClient
 	log                logger.MomentoLogger
 }
 
 // NewTopicClient returns a new TopicClient with provided configuration and credential provider arguments.
 func NewTopicClient(topicsConfiguration config.TopicsConfiguration, credentialProvider auth.CredentialProvider) (TopicClient, error) {
+	numChannels := topicsConfiguration.GetNumGrpcChannels()
+
 	client := &defaultTopicClient{
 		credentialProvider: credentialProvider,
+		numChannels:        numChannels,
 		log:                topicsConfiguration.GetLoggerFactory().GetLogger("topic-client"),
 	}
 
@@ -58,27 +66,57 @@ func (c defaultTopicClient) Subscribe(ctx context.Context, request *TopicSubscri
 		return nil, err
 	}
 
-	topicManager, clientStream, cancelContext, cancelFunction, err := c.pubSubClient.topicSubscribe(ctx, &TopicSubscribeRequest{
-		CacheName: request.CacheName,
-		TopicName: request.TopicName,
-	})
+	maxAttempts := c.numChannels
+	failedAttempts := uint32(0)
+
+	var topicManager *grpcmanagers.TopicGrpcManager
+	var clientStream grpc.ClientStream
+	var cancelContext context.Context
+	var cancelFunction context.CancelFunc
+	var err error
+
+	firstMsg := new(pb.XSubscriptionItem)
+
+	for failedAttempts < maxAttempts {
+		if failedAttempts > 0 {
+			c.log.Info(fmt.Sprintf("Retrying topic subscription due to subscription limit; retry attempt %d of %d", failedAttempts, maxAttempts-1))
+		}
+
+		topicManager, clientStream, cancelContext, cancelFunction, err = c.pubSubClient.topicSubscribe(ctx, &TopicSubscribeRequest{
+			CacheName: request.CacheName,
+			TopicName: request.TopicName,
+		})
+		if err != nil {
+			return nil, err
+		}
+
+		// Ping the stream to provide a nice error message if the cache does not exist.
+		err = clientStream.RecvMsg(firstMsg)
+		if err != nil {
+			rpcError, _ := status.FromError(err)
+			if rpcError != nil {
+				if rpcError.Code() == codes.ResourceExhausted {
+					c.log.Info("Topic subscription limit reached, checking to see if subscription is eligible for retry")
+					failedAttempts += 1
+					continue
+				}
+			}
+			return nil, momentoerrors.ConvertSvcErr(err)
+		}
+		break
+	}
+
 	if err != nil {
 		return nil, err
 	}
-
-	// Ping the stream to provide a nice error message if the cache does not exist.
-	rawMsg := new(pb.XSubscriptionItem)
-	err = clientStream.RecvMsg(rawMsg)
-	if err != nil {
-		return nil, momentoerrors.ConvertSvcErr(err)
-	}
-	switch rawMsg.Kind.(type) {
+	
+	switch firstMsg.Kind.(type) {
 	case *pb.XSubscriptionItem_Heartbeat:
 		// The first message to a new subscription will always be a heartbeat.
 	default:
 		return nil, momentoerrors.NewMomentoSvcErr(
 			momentoerrors.InternalServerError,
-			fmt.Sprintf("expected a heartbeat message, got: %T", rawMsg.Kind),
+			fmt.Sprintf("expected a heartbeat message, got: %T", firstMsg.Kind),
 			err,
 		)
 	}


### PR DESCRIPTION
This commit modifies the logic for the initial topic subscription
attempts so that if we get a LimitExceeded error, we will retry
the subscription if there are multiple grpc channels configured.
We try up to one time per channel, on the assumption that we
may get connected to another server where we are still beneath
our subscription limit.

Tested locally against an environment that had 2 servers, with
some code that tries to create 200 subscriptions (with a limit
of 100 per server), and 10 grpc channels. Observed that the first
150-160 usually connected on their first attempt. After that,
began to observe some intermittent retries, but almost always
ended up with 200 successful subscriptions.
