### PR TITLE
chore: switch from TEST_AUTH_TOKEN to MOMENTO_API_KEY when running tests

### DIFF
--- a/.github/workflows/manual_release.yml
+++ b/.github/workflows/manual_release.yml
@@ -29,7 +29,7 @@ jobs:
       contents: read
       pull-requests: read
     env:
-      TEST_AUTH_TOKEN: ${{ secrets.ALPHA_TEST_AUTH_TOKEN }}
+      MOMENTO_API_KEY: ${{ secrets.ALPHA_TEST_AUTH_TOKEN }}
     steps:
       - name: Setup repo
         uses: actions/checkout@v3

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -44,7 +44,7 @@ jobs:
       contents: read
       pull-requests: read
     env:
-      TEST_AUTH_TOKEN: ${{ secrets.ALPHA_TEST_AUTH_TOKEN }}
+      MOMENTO_API_KEY: ${{ secrets.ALPHA_TEST_AUTH_TOKEN }}
     steps:
       - name: Setup repo
         uses: actions/checkout@v3

--- a/.github/workflows/on-push-to-main.yml
+++ b/.github/workflows/on-push-to-main.yml
@@ -40,7 +40,7 @@ jobs:
       contents: read
       pull-requests: read
     env:
-      TEST_AUTH_TOKEN: ${{ secrets.ALPHA_TEST_AUTH_TOKEN }}
+      MOMENTO_API_KEY: ${{ secrets.ALPHA_TEST_AUTH_TOKEN }}
     steps:
       - name: Setup repo
         uses: actions/checkout@v3

--- a/CONTRIBUTING.template.md
+++ b/CONTRIBUTING.template.md
@@ -45,7 +45,7 @@ Running `make precommit` will run all formatters, linters, and the tests. Run th
 
 We use [Ginkgo](https://onsi.github.io/ginkgo/) and [Gomega](https://onsi.github.io/gomega/) to write our tests.
 
-Integration tests require an auth token for testing. Set the env var `TEST_AUTH_TOKEN` to provide it, you can get this from your `~/.momento/credentials` file.
+Integration tests require an auth token for testing. Set the env var `MOMENTO_API_KEY` to provide it, you can get this from your `~/.momento/credentials` file.
 
 Then run `make test`.
 

--- a/batchutils/batch_operations_test.go
+++ b/batchutils/batch_operations_test.go
@@ -28,7 +28,7 @@ var _ = Describe("Batch operations", func() {
 	BeforeEach(func() {
 		ctx = context.Background()
 		cacheName = fmt.Sprintf("golang-%s", uuid.NewString())
-		credentialProvider, err := auth.FromEnvironmentVariable("TEST_AUTH_TOKEN")
+		credentialProvider, err := auth.FromEnvironmentVariable("MOMENTO_API_KEY")
 		if err != nil {
 			panic(err)
 		}

--- a/batchutils/batch_set_test.go
+++ b/batchutils/batch_set_test.go
@@ -27,7 +27,7 @@ var _ = Describe("Batch set operations", func() {
 	BeforeEach(func() {
 		ctx = context.Background()
 		cacheName = fmt.Sprintf("golang-%s", uuid.NewString())
-		credentialProvider, err := auth.FromEnvironmentVariable("TEST_AUTH_TOKEN")
+		credentialProvider, err := auth.FromEnvironmentVariable("MOMENTO_API_KEY")
 		if err != nil {
 			panic(err)
 		}

--- a/momento/test_helpers/shared_context.go
+++ b/momento/test_helpers/shared_context.go
@@ -43,7 +43,7 @@ func NewSharedContext() SharedContext {
 	shared := SharedContext{}
 
 	shared.Ctx = context.Background()
-	credentialProvider, err := auth.NewEnvMomentoTokenProvider("TEST_AUTH_TOKEN")
+	credentialProvider, err := auth.NewEnvMomentoTokenProvider("MOMENTO_API_KEY")
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
Unlike the other SDKs, this one still expected an env var named `TEST_AUTH_TOKEN` to `MOMENTO_API_KEY` so this officially switches it over.

Will be more consistent with the other SDKs and will also fix an issue with deploying the golang sdk canary.