### PR TITLE
chore: remove NextToken from ListCachesRequest

### DIFF
--- a/momento/list_caches.go
+++ b/momento/list_caches.go
@@ -1,6 +1,3 @@
 package momento
 
-type ListCachesRequest struct {
-	// Token to continue paginating through the list. It's used to handle large paginated lists.
-	NextToken string
-}
+type ListCachesRequest struct{}


### PR DESCRIPTION
This PR removes the NextToken from the ListCachesRequest. This parameter was never used; we decided early on to make the user experience simpler for users by avoiding the need to use a while loop to list the caches, and we removed this parameter from the other SDKs. It was unintentionally left in place in the go SDK, so removing it should help users avoid confusion about it and keep user code simple.

This is a technically backward incompatible change. We are coordinating with users to make sure it it safe for them to receive the change before merging it.