### PR TITLE
chore: return nil response from storage get miss

### DIFF
--- a/examples/storage-example/main.go
+++ b/examples/storage-example/main.go
@@ -64,8 +64,8 @@ func main() {
 		panic(err)
 	}
 
-	// If the value was not found, the response's Value will be nil.
-	if getResp.Value() == nil {
+	// If the value was not found, the response will be nil.
+	if getResp == nil {
 		fmt.Println("Got nil")
 	}
 
@@ -80,8 +80,6 @@ func main() {
 		fmt.Printf("Got the float %f\n", t)
 	case storageTypes.Int:
 		fmt.Printf("Got the integer %d\n", t)
-	case nil:
-		fmt.Println("Got nil")
 	}
 
 	// If you know the type you're expecting, you can assert it directly:

--- a/momento/storage_client.go
+++ b/momento/storage_client.go
@@ -30,7 +30,7 @@ type PreviewStorageClient interface {
 	// ListStores lists all the stores.
 	ListStores(ctx context.Context, request *ListStoresRequest) (responses.ListStoresResponse, error)
 	// Get retrieves a value from a store.
-	Get(ctx context.Context, request *StorageGetRequest) (responses.StorageGetResponse, error)
+	Get(ctx context.Context, request *StorageGetRequest) (*responses.StorageGetResponse, error)
 	// Put sets a value in a store.
 	Put(ctx context.Context, request *StoragePutRequest) (responses.StoragePutResponse, error)
 	// Delete removes a value from a store.
@@ -171,13 +171,13 @@ func (c defaultPreviewStorageClient) Delete(ctx context.Context, request *Storag
 	return response, nil
 }
 
-func (c defaultPreviewStorageClient) Get(ctx context.Context, request *StorageGetRequest) (responses.StorageGetResponse, error) {
+func (c defaultPreviewStorageClient) Get(ctx context.Context, request *StorageGetRequest) (*responses.StorageGetResponse, error) {
 	if err := isStoreNameValid(request.StoreName); err != nil {
-		return *responses.NewStoreGetResponse_Nil(), err
+		return nil, err
 	}
 
 	if _, err := prepareName(request.Key, "Key"); err != nil {
-		return *responses.NewStoreGetResponse_Nil(), err
+		return nil, err
 	}
 
 	resp, err := c.getNextStorageDataClient().get(ctx, request)

--- a/momento/storage_data_client.go
+++ b/momento/storage_data_client.go
@@ -105,7 +105,7 @@ func (client *storageDataClient) put(ctx context.Context, request *StoragePutReq
 	return &responses.StoragePutSuccess{}, nil
 }
 
-func (client *storageDataClient) get(ctx context.Context, request *StorageGetRequest) (responses.StorageGetResponse, momentoerrors.MomentoSvcErr) {
+func (client *storageDataClient) get(ctx context.Context, request *StorageGetRequest) (*responses.StorageGetResponse, momentoerrors.MomentoSvcErr) {
 	ctx, cancel := context.WithTimeout(ctx, client.requestTimeout)
 	defer cancel()
 
@@ -125,22 +125,22 @@ func (client *storageDataClient) get(ctx context.Context, request *StorageGetReq
 		// Handle item not found error by returning a miss
 		myErr := momentoerrors.ConvertSvcErr(err, header, trailer)
 		if myErr.Code() == momentoerrors.ItemNotFoundError {
-			return *responses.NewStoreGetResponse_Nil(), nil
+			return nil, nil
 		}
-		return *responses.NewStoreGetResponse_Nil(), myErr
+		return nil, myErr
 	}
 
 	val := response.GetValue()
 	switch val.Value.(type) {
 	case *pb.XStoreValue_BytesValue:
-		return *responses.NewStoreGetResponse_Bytes(val.GetBytesValue()), nil
+		return responses.NewStoreGetResponse_Bytes(val.GetBytesValue()), nil
 	case *pb.XStoreValue_StringValue:
-		return *responses.NewStoreGetResponse_String(val.GetStringValue()), nil
+		return responses.NewStoreGetResponse_String(val.GetStringValue()), nil
 	case *pb.XStoreValue_DoubleValue:
-		return *responses.NewStoreGetResponse_Float(val.GetDoubleValue()), nil
+		return responses.NewStoreGetResponse_Float(val.GetDoubleValue()), nil
 	case *pb.XStoreValue_IntegerValue:
-		return *responses.NewStoreGetResponse_Integer(int(val.GetIntegerValue())), nil
+		return responses.NewStoreGetResponse_Integer(int(val.GetIntegerValue())), nil
 	default:
-		return *responses.NewStoreGetResponse_Nil(), momentoerrors.NewMomentoSvcErr(momentoerrors.UnknownServiceError, "Unknown store value type", nil)
+		return nil, momentoerrors.NewMomentoSvcErr(momentoerrors.UnknownServiceError, "Unknown store value type", nil)
 	}
 }


### PR DESCRIPTION
To allow the storage client Get response to be `nil` we had to convert the function's response type to a pointer. While this is inconsistent with the other response types, it does seem to work pretty naturally in the flow of the consumer code, which you can see in the storage-example in this PR. One disadvantage to implementing it this way is the possibility of a runtime panic if users try to access `getResponse.Value()` without first ensuring that `getResponse` isn't null.