### PR TITLE
fix: make sure to clean up caches and stores that can be leaked in tests

### DIFF
--- a/momento/cache_client_test.go
+++ b/momento/cache_client_test.go
@@ -19,6 +19,8 @@ var _ = Describe("cache-client", func() {
 
 	BeforeEach(func() {
 		sharedContext = NewSharedContext()
+
+		DeferCleanup(func() { sharedContext.Close() })
 	})
 
 	It(`errors on an invalid TTL`, func() {

--- a/momento/storage_client_test.go
+++ b/momento/storage_client_test.go
@@ -14,11 +14,13 @@ import (
 )
 
 var _ = Describe("storage-client misc", func() {
-	var sharedContext = NewSharedContext()
+	var sharedContext SharedContext
 
 	BeforeEach(func() {
 		sharedContext = NewSharedContext()
 		sharedContext.CreateDefaultStores()
+
+		DeferCleanup(func() { sharedContext.Close() })
 	})
 
 	It("errors on invalid timeout", func() {


### PR DESCRIPTION
`"storage-client misc"` appeared to be leaking two stores with each run and we might've also been leaking caches this whole time 😱