### PR TITLE
fix: package api key and endpoint correctly in generate token/api key responses

### DIFF
--- a/momento/token_client.go
+++ b/momento/token_client.go
@@ -2,6 +2,8 @@ package momento
 
 import (
 	"context"
+	b64 "encoding/base64"
+	"encoding/json"
 
 	"github.com/momentohq/client-sdk-go/config"
 	"github.com/momentohq/client-sdk-go/internal/grpcmanagers"
@@ -273,8 +275,22 @@ func (client *tokenClient) GenerateDisposableToken(ctx context.Context, request 
 	if err != nil {
 		return nil, momentoerrors.ConvertSvcErr(err)
 	}
+
+	jsonObject := map[string]string{
+		"api_key":  resp.ApiKey,
+		"endpoint": resp.Endpoint,
+	}
+	jsonString, err := json.Marshal(jsonObject)
+	if err != nil {
+		return nil, NewMomentoError(
+			momentoerrors.ClientSdkError,
+			"Unable to map API key to necessary form",
+			err,
+		)
+	}
+	b64Encoded := b64.StdEncoding.EncodeToString([]byte(jsonString))
 	return &auth_responses.GenerateDisposableTokenSuccess{
-		ApiKey:     resp.ApiKey,
+		ApiKey:     b64Encoded,
 		Endpoint:   resp.Endpoint,
 		ValidUntil: resp.ValidUntil,
 	}, nil


### PR DESCRIPTION
Addition to https://github.com/momentohq/dev-eco-issue-tracker/issues/954

Found a bug in how GenerateApiKey and GenerateDisposableToken packages the responses ([JS sdk for reference](https://github.com/momentohq/client-sdk-javascript/blob/main/packages/core/src/messages/responses/generate-disposable-token.ts#L21-L23)).

This PR fixes the issue by ensuring "api_key" and "endpoint" are included in the b64-encoded object that's passed to the responses' ApiKey field.