### PR TITLE
fix: use sync.Map to track first-time agent headers

### DIFF
--- a/internal/metadata.go
+++ b/internal/metadata.go
@@ -8,14 +8,6 @@ import (
 	"google.golang.org/grpc/metadata"
 )
 
-//	var FirstTimeHeadersSent = map[ClientType]bool{
-//		Cache:       false,
-//		Store:       false,
-//		Leaderboard: false,
-//		Topic:       false,
-//		Ping:        false,
-//		Auth:        false,
-//	}
 var FirstTimeHeadersSent sync.Map
 
 func init() {

--- a/internal/metadata.go
+++ b/internal/metadata.go
@@ -3,18 +3,30 @@ package internal
 import (
 	"context"
 	"runtime"
+	"sync"
 
 	"google.golang.org/grpc/metadata"
 )
 
-var FirstTimeHeadersSent = map[ClientType]bool{
-	Cache:       false,
-	Store:       false,
-	Leaderboard: false,
-	Topic:       false,
-	Ping:        false,
-	Auth:        false,
+//	var FirstTimeHeadersSent = map[ClientType]bool{
+//		Cache:       false,
+//		Store:       false,
+//		Leaderboard: false,
+//		Topic:       false,
+//		Ping:        false,
+//		Auth:        false,
+//	}
+var FirstTimeHeadersSent sync.Map
+
+func init() {
+	FirstTimeHeadersSent.Store(Cache, false)
+	FirstTimeHeadersSent.Store(Store, false)
+	FirstTimeHeadersSent.Store(Leaderboard, false)
+	FirstTimeHeadersSent.Store(Topic, false)
+	FirstTimeHeadersSent.Store(Ping, false)
+	FirstTimeHeadersSent.Store(Auth, false)
 }
+
 var Version = "1.26.1" // x-release-please-version
 
 type ClientType string
@@ -31,8 +43,10 @@ const (
 func CreateMetadata(ctx context.Context, clientType ClientType, extraPairs ...string) context.Context {
 	headers := extraPairs
 
-	if !FirstTimeHeadersSent[clientType] {
-		FirstTimeHeadersSent[clientType] = true
+	var ftHeadersSent, ok = FirstTimeHeadersSent.Load(clientType)
+
+	if !ok || !ftHeadersSent.(bool) {
+		FirstTimeHeadersSent.Store(clientType, true)
 		headers = append(headers, "runtime-version", "golang:"+runtime.Version())
 		headers = append(headers, "agent", "golang:"+string(clientType)+":"+Version)
 	}


### PR DESCRIPTION
Prior to this commit we were using a regular `map` object for
keeping track of whether the first-time headers have been
sent for a given client. These `map` objects are not safe for
concurrent access, and will cause the program to crash if there
is a concurrent read while a write is occurring.

This commit switches to a `sync.Map` which is safe for concurrent
access.
