### PR TITLE
chore: clean up and try to speed up tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ GOFILES_NOT_NODE = $(shell find . -type f -name '*.go' -not -path "./examples/aw
 .PHONY: install-devtools
 install-devtools:
 	go install golang.org/x/tools/cmd/goimports@latest
-	go install honnef.co/go/tools/cmd/staticcheck@latest
+	go install honnef.co/go/tools/cmd/staticcheck@v0.4.7
 	go install github.com/onsi/ginkgo/v2/ginkgo@v2.8.1
 
 .PHONY: format

--- a/momento/auth_client_test.go
+++ b/momento/auth_client_test.go
@@ -135,22 +135,11 @@ func newTopicClient(ctx SharedContext, provider auth.CredentialProvider) TopicCl
 	return tc
 }
 
-var _ = Describe("auth auth-client", func() {
-	var sharedContext SharedContext
-
-	BeforeEach(func() {
-		sharedContext = NewSharedContext()
-		sharedContext.CreateDefaultCaches()
-
-		DeferCleanup(func() {
-			sharedContext.Close()
-		})
-	})
-
+var _ = Describe("auth auth-client methods", func() {
 	Describe("Generate disposable tokens", func() {
 		Describe("CacheKeyReadOnly tokens", func() {
 			It(`Generates disposable token CacheKeyReadOnly AllCaches, and validates its permissions`, func() {
-				key := String(uuid.NewString())
+				key := NewStringKey()
 				resp := generateDisposableTokenSuccess(sharedContext, CacheKeyReadOnly(AllCaches{}, key))
 				credProvider := credProviderFromDisposableToken(resp)
 
@@ -176,7 +165,7 @@ var _ = Describe("auth auth-client", func() {
 			})
 
 			It(`Generates disposable token CacheKeyReadOnly for a specific cache, and validates its permissions`, func() {
-				key := String(uuid.NewString())
+				key := NewStringKey()
 				resp := generateDisposableTokenSuccess(sharedContext, CacheKeyReadOnly(CacheName{Name: sharedContext.CacheName}, key))
 				credProvider := credProviderFromDisposableToken(resp)
 
@@ -204,7 +193,7 @@ var _ = Describe("auth auth-client", func() {
 
 		Describe("CacheKeyWriteOnly tokens", func() {
 			It(`Generates disposable token CacheKeyWriteOnly for a specific cache, and validates its permissions`, func() {
-				key := String(uuid.NewString())
+				key := NewStringKey()
 				scope := CacheKeyWriteOnly(CacheName{Name: sharedContext.CacheName}, key)
 				resp := generateDisposableTokenSuccess(sharedContext, scope)
 				credProvider := credProviderFromDisposableToken(resp)
@@ -233,7 +222,7 @@ var _ = Describe("auth auth-client", func() {
 			})
 
 			It(`Generates disposable token CacheKeyWriteOnly for all caches, and validates its permissions`, func() {
-				key := String(uuid.NewString())
+				key := NewStringKey()
 				scope := CacheKeyWriteOnly(AllCaches{}, key)
 				resp := generateDisposableTokenSuccess(sharedContext, scope)
 				credProvider := credProviderFromDisposableToken(resp)
@@ -266,7 +255,7 @@ var _ = Describe("auth auth-client", func() {
 
 		Describe("CacheKeyReadWrite tokens", func() {
 			It(`Generates disposable token CacheKeyReadWrite for all caches, and validates its permissions`, func() {
-				key := String(uuid.NewString())
+				key := NewStringKey()
 				scope := CacheKeyReadWrite(AllCaches{}, key)
 				resp := generateDisposableTokenSuccess(sharedContext, scope)
 				credProvider := credProviderFromDisposableToken(resp)
@@ -299,7 +288,7 @@ var _ = Describe("auth auth-client", func() {
 			})
 
 			It(`Generates disposable token CacheKeyReadWrite for a specific cache, and validates its permissions`, func() {
-				key := String(uuid.NewString())
+				key := NewStringKey()
 				scope := CacheKeyReadWrite(CacheName{Name: sharedContext.CacheName}, key)
 				resp := generateDisposableTokenSuccess(sharedContext, scope)
 				credProvider := credProviderFromDisposableToken(resp)
@@ -334,7 +323,7 @@ var _ = Describe("auth auth-client", func() {
 
 		Describe("CacheKeyPrefixReadWrite tokens", func() {
 			It(`Generates disposable token CacheKeyPrefixReadWrite for a specific cache, and validates its permissions`, func() {
-				key := String(uuid.NewString())
+				key := NewStringKey()
 				scope := CacheKeyPrefixReadWrite(CacheName{Name: sharedContext.CacheName}, key)
 				resp := generateDisposableTokenSuccess(sharedContext, scope)
 				credProvider := credProviderFromDisposableToken(resp)
@@ -367,7 +356,7 @@ var _ = Describe("auth auth-client", func() {
 			})
 
 			It(`Generates disposable token CacheKeyPrefixReadWrite for all caches, and validates its permissions`, func() {
-				key := String(uuid.NewString())
+				key := NewStringKey()
 				scope := CacheKeyPrefixReadWrite(AllCaches{}, key)
 				resp := generateDisposableTokenSuccess(sharedContext, scope)
 				credProvider := credProviderFromDisposableToken(resp)
@@ -402,7 +391,7 @@ var _ = Describe("auth auth-client", func() {
 
 		Describe("CacheKeyPrefixReadOnly tokens", func() {
 			It(`Generates disposable token CacheKeyPrefixReadOnly for a specific cache, and validates its permissions`, func() {
-				key := String(uuid.NewString())
+				key := NewStringKey()
 				scope := CacheKeyPrefixReadOnly(CacheName{Name: sharedContext.CacheName}, key)
 				resp := generateDisposableTokenSuccess(sharedContext, scope)
 				credProvider := credProviderFromDisposableToken(resp)
@@ -435,7 +424,7 @@ var _ = Describe("auth auth-client", func() {
 			})
 
 			It(`Generates disposable token CacheKeyPrefixReadOnly for all caches, and validates its permissions`, func() {
-				key := String(uuid.NewString())
+				key := NewStringKey()
 				scope := CacheKeyPrefixReadOnly(AllCaches{}, key)
 				resp := generateDisposableTokenSuccess(sharedContext, scope)
 				credProvider := credProviderFromDisposableToken(resp)
@@ -470,7 +459,7 @@ var _ = Describe("auth auth-client", func() {
 
 		Describe("CacheKeyPrefixWriteOnly tokens", func() {
 			It(`Generates disposable token CacheKeyPrefixWriteOnly for a specific cache, and validates its permissions`, func() {
-				key := String(uuid.NewString())
+				key := NewStringKey()
 				scope := CacheKeyPrefixWriteOnly(CacheName{Name: sharedContext.CacheName}, key)
 				resp := generateDisposableTokenSuccess(sharedContext, scope)
 				credProvider := credProviderFromDisposableToken(resp)
@@ -505,7 +494,7 @@ var _ = Describe("auth auth-client", func() {
 			})
 
 			It(`Generates disposable token CacheKeyPrefixWriteOnly for all caches, and validates its permissions`, func() {
-				key := String(uuid.NewString())
+				key := NewStringKey()
 				scope := CacheKeyPrefixWriteOnly(AllCaches{}, key)
 				resp := generateDisposableTokenSuccess(sharedContext, scope)
 				credProvider := credProviderFromDisposableToken(resp)
@@ -1416,9 +1405,10 @@ var _ = Describe("auth auth-client", func() {
 				Expect(err.(MomentoError).Code()).To(Equal(momentoerrors.PermissionError))
 
 				// Can set values in an existing cache
+				key := NewStringKey()
 				setResp, err := cacheClient.Set(sharedContext.Ctx, &SetRequest{
 					CacheName: authTestCache1,
-					Key:       String("key"),
+					Key:       key,
 					Value:     String("value"),
 				})
 				Expect(err).To(BeNil())
@@ -1427,7 +1417,7 @@ var _ = Describe("auth auth-client", func() {
 				// Can get values in an existing cache
 				getResp, err := cacheClient.Get(sharedContext.Ctx, &GetRequest{
 					CacheName: authTestCache1,
-					Key:       String("key"),
+					Key:       key,
 				})
 				Expect(err).To(BeNil())
 				Expect(getResp).To(BeAssignableToTypeOf(&responses.GetHit{}))
@@ -1654,9 +1644,10 @@ var _ = Describe("auth auth-client", func() {
 				defer topicClient.Close()
 
 				// 1. Cache get/set on authTestCache1 should succeed
+				key := NewStringKey()
 				setResp, err := cacheClient.Set(sharedContext.Ctx, &SetRequest{
 					CacheName: authTestCache1,
-					Key:       String("key"),
+					Key:       key,
 					Value:     String("value"),
 				})
 				Expect(err).To(BeNil())
@@ -1664,7 +1655,7 @@ var _ = Describe("auth auth-client", func() {
 
 				getResp, err := cacheClient.Get(sharedContext.Ctx, &GetRequest{
 					CacheName: authTestCache1,
-					Key:       String("key"),
+					Key:       key,
 				})
 				Expect(err).To(BeNil())
 				Expect(getResp).To(BeAssignableToTypeOf(&responses.GetHit{}))
@@ -1672,7 +1663,7 @@ var _ = Describe("auth auth-client", func() {
 				// 2. Cache get/set on authTestCache2 should fail
 				_, err = cacheClient.Set(sharedContext.Ctx, &SetRequest{
 					CacheName: authTestCache2,
-					Key:       String("key"),
+					Key:       key,
 					Value:     String("value"),
 				})
 				Expect(err).To(HaveOccurred())
@@ -1680,7 +1671,7 @@ var _ = Describe("auth auth-client", func() {
 
 				_, err = cacheClient.Get(sharedContext.Ctx, &GetRequest{
 					CacheName: authTestCache2,
-					Key:       String("key"),
+					Key:       key,
 				})
 				Expect(err).To(HaveOccurred())
 				Expect(err.(MomentoError).Code()).To(Equal(momentoerrors.PermissionError))

--- a/momento/auth_client_test.go
+++ b/momento/auth_client_test.go
@@ -135,7 +135,7 @@ func newTopicClient(ctx SharedContext, provider auth.CredentialProvider) TopicCl
 	return tc
 }
 
-var _ = Describe("auth auth-client methods", func() {
+var _ = Describe("auth auth-client", func() {
 	Describe("Generate disposable tokens", func() {
 		Describe("CacheKeyReadOnly tokens", func() {
 			It(`Generates disposable token CacheKeyReadOnly AllCaches, and validates its permissions`, func() {

--- a/momento/cache_client_test.go
+++ b/momento/cache_client_test.go
@@ -13,7 +13,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("cache-client creation", func() {
+var _ = Describe("cache-client", func() {
 	It(`errors on an invalid TTL`, func() {
 		zeroDefaultTtl := 0 * time.Second
 		client, err := NewCacheClient(sharedContext.Configuration, sharedContext.CredentialProvider, zeroDefaultTtl)

--- a/momento/cache_client_test.go
+++ b/momento/cache_client_test.go
@@ -8,24 +8,15 @@ import (
 
 	"github.com/momentohq/client-sdk-go/config"
 	. "github.com/momentohq/client-sdk-go/momento"
-	. "github.com/momentohq/client-sdk-go/momento/test_helpers"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("cache-client", func() {
-	var sharedContext SharedContext
-
-	BeforeEach(func() {
-		sharedContext = NewSharedContext()
-
-		DeferCleanup(func() { sharedContext.Close() })
-	})
-
+var _ = Describe("cache-client creation", func() {
 	It(`errors on an invalid TTL`, func() {
-		sharedContext.DefaultTtl = 0 * time.Second
-		client, err := NewCacheClient(sharedContext.Configuration, sharedContext.CredentialProvider, sharedContext.DefaultTtl)
+		zeroDefaultTtl := 0 * time.Second
+		client, err := NewCacheClient(sharedContext.Configuration, sharedContext.CredentialProvider, zeroDefaultTtl)
 
 		Expect(client).To(BeNil())
 		Expect(err).NotTo(BeNil())
@@ -37,9 +28,9 @@ var _ = Describe("cache-client", func() {
 
 	It(`errors on invalid timeout`, func() {
 		badRequestTimeout := 0 * time.Second
-		sharedContext.Configuration = config.LaptopLatest().WithClientTimeout(badRequestTimeout)
+		badRequestTimeoutConfig := config.LaptopLatest().WithClientTimeout(badRequestTimeout)
 		Expect(
-			NewCacheClient(sharedContext.Configuration, sharedContext.CredentialProvider, sharedContext.DefaultTtl),
+			NewCacheClient(badRequestTimeoutConfig, sharedContext.CredentialProvider, sharedContext.DefaultTtl),
 		).Error().To(HaveMomentoErrorCode(InvalidArgumentError))
 	})
 

--- a/momento/control_test.go
+++ b/momento/control_test.go
@@ -8,18 +8,11 @@ import (
 	. "github.com/onsi/gomega"
 
 	. "github.com/momentohq/client-sdk-go/momento"
-	. "github.com/momentohq/client-sdk-go/momento/test_helpers"
+	helpers "github.com/momentohq/client-sdk-go/momento/test_helpers"
 	. "github.com/momentohq/client-sdk-go/responses"
 )
 
 var _ = Describe("control-ops", func() {
-	var sharedContext SharedContext
-
-	BeforeEach(func() {
-		sharedContext = NewSharedContext()
-		DeferCleanup(func() { sharedContext.Close() })
-	})
-
 	Describe("cache-client happy-path", func() {
 		It("creates, lists, and deletes caches", func() {
 			cacheNames := []string{uuid.NewString(), uuid.NewString()}
@@ -75,7 +68,7 @@ var _ = Describe("control-ops", func() {
 		It("creates and deletes using a default cache", func() {
 			Expect(
 				sharedContext.ClientWithDefaultCacheName.CreateCache(sharedContext.Ctx, &CreateCacheRequest{}),
-			).To(BeAssignableToTypeOf(&CreateCacheSuccess{}))
+			).Error().NotTo(HaveOccurred())
 			Expect(
 				sharedContext.ClientWithDefaultCacheName.DeleteCache(sharedContext.Ctx, &DeleteCacheRequest{}),
 			).To(BeAssignableToTypeOf(&DeleteCacheSuccess{}))
@@ -171,17 +164,17 @@ var _ = Describe("control-ops", func() {
 				sharedContext.ClientWithDefaultCacheName.CreateCache(
 					sharedContext.Ctx, &CreateCacheRequest{CacheName: sharedContext.CacheName},
 				),
-			).To(BeAssignableToTypeOf(&CreateCacheSuccess{}))
+			).Error().NotTo(HaveOccurred())
 			Expect(
 				sharedContext.ClientWithDefaultCacheName.Get(
-					sharedContext.Ctx, &GetRequest{Key: String("hi")},
+					sharedContext.Ctx, &GetRequest{Key: helpers.NewStringKey()},
 				),
 			).Error().To(HaveMomentoErrorCode(CacheNotFoundError))
 			Expect(
 				sharedContext.ClientWithDefaultCacheName.Get(
 					sharedContext.Ctx, &GetRequest{
 						CacheName: sharedContext.CacheName,
-						Key:       String("hi"),
+						Key:       helpers.NewStringKey(),
 					},
 				),
 			).To(BeAssignableToTypeOf(&GetMiss{}))

--- a/momento/leaderboard_test.go
+++ b/momento/leaderboard_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	. "github.com/momentohq/client-sdk-go/momento"
-	. "github.com/momentohq/client-sdk-go/momento/test_helpers"
 	. "github.com/momentohq/client-sdk-go/responses"
 
 	"github.com/google/uuid"
@@ -13,15 +12,6 @@ import (
 )
 
 var _ = Describe("leaderboard-client", func() {
-	var sharedContext SharedContext
-
-	BeforeEach(func() {
-		sharedContext = NewSharedContext()
-		sharedContext.CreateDefaultCaches()
-
-		DeferCleanup(func() { sharedContext.Close() })
-	})
-
 	// Convenience method for creating temporary leaderboard
 	createLeaderboard := func() Leaderboard {
 		leaderboard, err := sharedContext.LeaderboardClient.Leaderboard(sharedContext.Ctx, &LeaderboardRequest{

--- a/momento/list_test.go
+++ b/momento/list_test.go
@@ -65,16 +65,6 @@ func populateList(sharedContext SharedContext, listName string, numItems int) []
 }
 
 var _ = Describe("cache-client list-methods", func() {
-	// var sharedContext SharedContext
-
-	// BeforeEach(func() {
-	// 	sharedContext = NewSharedContext()
-	// 	sharedContext.CreateDefaultCaches()
-	// 	DeferCleanup(func() {
-	// 		sharedContext.Close()
-	// 	})
-	// })
-
 	var listName string
 
 	BeforeEach(func() {

--- a/momento/list_test.go
+++ b/momento/list_test.go
@@ -46,18 +46,18 @@ func getValueAndExpectedValueListsRange(start int, end int) ([]Value, []string) 
 	return values, expected
 }
 
-func populateList(sharedContext SharedContext, numItems int) []string {
+func populateList(sharedContext SharedContext, listName string, numItems int) []string {
 	values, expected := getValueAndExpectedValueLists(numItems)
 	Expect(
 		sharedContext.Client.ListConcatenateFront(sharedContext.Ctx, &ListConcatenateFrontRequest{
 			CacheName: sharedContext.CacheName,
-			ListName:  sharedContext.CollectionName,
+			ListName:  listName,
 			Values:    values,
 		}),
 	).To(BeAssignableToTypeOf(&ListConcatenateFrontSuccess{}))
 	Expect(
 		sharedContext.ClientWithDefaultCacheName.ListConcatenateFront(sharedContext.Ctx, &ListConcatenateFrontRequest{
-			ListName: sharedContext.CollectionName,
+			ListName: listName,
 			Values:   values,
 		}),
 	).To(BeAssignableToTypeOf(&ListConcatenateFrontSuccess{}))
@@ -65,14 +65,20 @@ func populateList(sharedContext SharedContext, numItems int) []string {
 }
 
 var _ = Describe("cache-client list-methods", func() {
-	var sharedContext SharedContext
+	// var sharedContext SharedContext
+
+	// BeforeEach(func() {
+	// 	sharedContext = NewSharedContext()
+	// 	sharedContext.CreateDefaultCaches()
+	// 	DeferCleanup(func() {
+	// 		sharedContext.Close()
+	// 	})
+	// })
+
+	var listName string
 
 	BeforeEach(func() {
-		sharedContext = NewSharedContext()
-		sharedContext.CreateDefaultCaches()
-		DeferCleanup(func() {
-			sharedContext.Close()
-		})
+		listName = uuid.NewString()
 	})
 
 	DescribeTable("try using invalid cache and list names",
@@ -147,19 +153,19 @@ var _ = Describe("cache-client list-methods", func() {
 			).Error().To(HaveMomentoErrorCode(expectedErrorCode))
 		},
 		Entry("nonexistent cache name", DefaultClient, uuid.NewString(), uuid.NewString(), CacheNotFoundError),
-		Entry("empty cache name", DefaultClient, "", sharedContext.CollectionName, InvalidArgumentError),
+		Entry("empty cache name", DefaultClient, "", listName, InvalidArgumentError),
 		Entry("empty list name", DefaultClient, sharedContext.CacheName, "", InvalidArgumentError),
 		Entry("nonexistent cache name", WithDefaultCache, uuid.NewString(), uuid.NewString(), CacheNotFoundError),
-		Entry("empty cache name", WithDefaultCache, "", sharedContext.CollectionName, InvalidArgumentError),
+		Entry("empty cache name", WithDefaultCache, "", listName, InvalidArgumentError),
 		Entry("empty list name", WithDefaultCache, sharedContext.CacheName, "", InvalidArgumentError),
 	)
 
 	It("returns the correct list length", func() {
 		numItems := 33
-		populateList(sharedContext, numItems)
+		populateList(sharedContext, listName, numItems)
 		lengthResp, err := sharedContext.Client.ListLength(sharedContext.Ctx, &ListLengthRequest{
 			CacheName: sharedContext.CacheName,
-			ListName:  sharedContext.CollectionName,
+			ListName:  listName,
 		})
 		Expect(err).To(BeNil())
 		switch result := lengthResp.(type) {
@@ -184,14 +190,14 @@ var _ = Describe("cache-client list-methods", func() {
 						Expect(
 							client.ListPushFront(sharedContext.Ctx, &ListPushFrontRequest{
 								CacheName: cacheName,
-								ListName:  sharedContext.CollectionName,
+								ListName:  listName,
 								Value:     value,
 							}),
 						).To(BeAssignableToTypeOf(&ListPushFrontSuccess{}))
 					}
 					fetchResp, err := client.ListFetch(sharedContext.Ctx, &ListFetchRequest{
 						CacheName: cacheName,
-						ListName:  sharedContext.CollectionName,
+						ListName:  listName,
 					})
 					Expect(err).To(BeNil())
 					Expect(fetchResp).To(BeAssignableToTypeOf(&ListFetchHit{}))
@@ -210,18 +216,18 @@ var _ = Describe("cache-client list-methods", func() {
 					client, cacheName := sharedContext.GetClientPrereqsForType(clientType)
 					numItems := 10
 					truncateTo := 5
-					populateList(sharedContext, numItems)
+					populateList(sharedContext, listName, numItems)
 					Expect(
 						client.ListPushFront(sharedContext.Ctx, &ListPushFrontRequest{
 							CacheName:          cacheName,
-							ListName:           sharedContext.CollectionName,
+							ListName:           listName,
 							Value:              String("andherlittledogtoo"),
 							TruncateBackToSize: uint32(truncateTo),
 						}),
 					).Error().To(BeNil())
 					fetchResp, err := client.ListFetch(sharedContext.Ctx, &ListFetchRequest{
 						CacheName: cacheName,
-						ListName:  sharedContext.CollectionName,
+						ListName:  listName,
 					})
 					Expect(err).To(BeNil())
 					Expect(fetchResp).To(HaveListLength(truncateTo))
@@ -234,7 +240,7 @@ var _ = Describe("cache-client list-methods", func() {
 				Expect(
 					sharedContext.Client.ListPushBack(sharedContext.Ctx, &ListPushBackRequest{
 						CacheName: sharedContext.CacheName,
-						ListName:  sharedContext.CollectionName,
+						ListName:  listName,
 						Value:     nil,
 					}),
 				).Error().To(HaveMomentoErrorCode(InvalidArgumentError))
@@ -244,14 +250,14 @@ var _ = Describe("cache-client list-methods", func() {
 				Expect(
 					sharedContext.Client.ListPushBack(sharedContext.Ctx, &ListPushBackRequest{
 						CacheName: sharedContext.CacheName,
-						ListName:  sharedContext.CollectionName,
+						ListName:  listName,
 						Value:     String(""),
 					}),
 				).To(BeAssignableToTypeOf(&ListPushBackSuccess{}))
 
 				fetchResp, err := sharedContext.Client.ListFetch(sharedContext.Ctx, &ListFetchRequest{
 					CacheName: sharedContext.CacheName,
-					ListName:  sharedContext.CollectionName,
+					ListName:  listName,
 				})
 				Expect(err).To(BeNil())
 				Expect(fetchResp).To(HaveListLength(1))
@@ -269,7 +275,7 @@ var _ = Describe("cache-client list-methods", func() {
 						Expect(
 							client.ListPushBack(sharedContext.Ctx, &ListPushBackRequest{
 								CacheName: cacheName,
-								ListName:  sharedContext.CollectionName,
+								ListName:  listName,
 								Value:     value,
 							}),
 						).To(BeAssignableToTypeOf(&ListPushBackSuccess{}))
@@ -277,7 +283,7 @@ var _ = Describe("cache-client list-methods", func() {
 
 					fetchResp, err := client.ListFetch(sharedContext.Ctx, &ListFetchRequest{
 						CacheName: cacheName,
-						ListName:  sharedContext.CollectionName,
+						ListName:  listName,
 					})
 					Expect(err).To(BeNil())
 					Expect(fetchResp).To(HaveListLength(numItems))
@@ -295,18 +301,18 @@ var _ = Describe("cache-client list-methods", func() {
 					client, cacheName := sharedContext.GetClientPrereqsForType(clientType)
 					numItems := 10
 					truncateTo := 5
-					populateList(sharedContext, numItems)
+					populateList(sharedContext, listName, numItems)
 					Expect(
 						client.ListPushBack(sharedContext.Ctx, &ListPushBackRequest{
 							CacheName:           cacheName,
-							ListName:            sharedContext.CollectionName,
+							ListName:            listName,
 							Value:               String("andherlittledogtoo"),
 							TruncateFrontToSize: uint32(truncateTo),
 						}),
 					).Error().To(BeNil())
 					fetchResp, err := client.ListFetch(sharedContext.Ctx, &ListFetchRequest{
 						CacheName: cacheName,
-						ListName:  sharedContext.CollectionName,
+						ListName:  listName,
 					})
 					Expect(err).To(BeNil())
 					Expect(fetchResp).To(HaveListLength(truncateTo))
@@ -319,7 +325,7 @@ var _ = Describe("cache-client list-methods", func() {
 				Expect(
 					sharedContext.Client.ListPushBack(sharedContext.Ctx, &ListPushBackRequest{
 						CacheName: sharedContext.CacheName,
-						ListName:  sharedContext.CollectionName,
+						ListName:  listName,
 						Value:     nil,
 					}),
 				).Error().To(HaveMomentoErrorCode(InvalidArgumentError))
@@ -329,14 +335,14 @@ var _ = Describe("cache-client list-methods", func() {
 				Expect(
 					sharedContext.Client.ListPushBack(sharedContext.Ctx, &ListPushBackRequest{
 						CacheName: sharedContext.CacheName,
-						ListName:  sharedContext.CollectionName,
+						ListName:  listName,
 						Value:     String(""),
 					}),
 				).To(BeAssignableToTypeOf(&ListPushBackSuccess{}))
 
 				fetchResp, err := sharedContext.Client.ListFetch(sharedContext.Ctx, &ListFetchRequest{
 					CacheName: sharedContext.CacheName,
-					ListName:  sharedContext.CollectionName,
+					ListName:  listName,
 				})
 				Expect(err).To(BeNil())
 				Expect(fetchResp).To(HaveListLength(1))
@@ -353,13 +359,13 @@ var _ = Describe("cache-client list-methods", func() {
 				func(clientType string) {
 					client, cacheName := sharedContext.GetClientPrereqsForType(clientType)
 					numItems := 10
-					expected := populateList(sharedContext, numItems)
+					expected := populateList(sharedContext, listName, numItems)
 
 					numConcatItems := 5
 					concatValues, concatExpected := getValueAndExpectedValueLists(numConcatItems)
 					concatResp, err := client.ListConcatenateFront(sharedContext.Ctx, &ListConcatenateFrontRequest{
 						CacheName: cacheName,
-						ListName:  sharedContext.CollectionName,
+						ListName:  listName,
 						Values:    concatValues,
 					})
 					Expect(err).To(BeNil())
@@ -367,7 +373,7 @@ var _ = Describe("cache-client list-methods", func() {
 
 					fetchResp, err := client.ListFetch(sharedContext.Ctx, &ListFetchRequest{
 						CacheName: cacheName,
-						ListName:  sharedContext.CollectionName,
+						ListName:  listName,
 					})
 					Expect(err).To(BeNil())
 					Expect(fetchResp).To(BeAssignableToTypeOf(&ListFetchHit{}))
@@ -385,11 +391,11 @@ var _ = Describe("cache-client list-methods", func() {
 			DescribeTable("truncates the list properly",
 				func(clientType string) {
 					client, cacheName := sharedContext.GetClientPrereqsForType(clientType)
-					populateList(sharedContext, 5)
+					populateList(sharedContext, listName, 5)
 					concatValues := []Value{String("100"), String("101"), String("102")}
 					concatResp, err := client.ListConcatenateFront(sharedContext.Ctx, &ListConcatenateFrontRequest{
 						CacheName:          cacheName,
-						ListName:           sharedContext.CollectionName,
+						ListName:           listName,
 						Values:             concatValues,
 						TruncateBackToSize: 3,
 					})
@@ -398,7 +404,7 @@ var _ = Describe("cache-client list-methods", func() {
 
 					fetchResp, err := client.ListFetch(sharedContext.Ctx, &ListFetchRequest{
 						CacheName: cacheName,
-						ListName:  sharedContext.CollectionName,
+						ListName:  listName,
 					})
 					Expect(err).To(BeNil())
 					Expect(fetchResp).To(BeAssignableToTypeOf(&ListFetchHit{}))
@@ -413,12 +419,12 @@ var _ = Describe("cache-client list-methods", func() {
 			)
 
 			It("returns an invalid argument for a nil value", func() {
-				populateList(sharedContext, 5)
+				populateList(sharedContext, listName, 5)
 				concatValues := []Value{nil, String("aRealValue"), nil}
 				Expect(
 					sharedContext.Client.ListConcatenateFront(sharedContext.Ctx, &ListConcatenateFrontRequest{
 						CacheName:          sharedContext.CacheName,
-						ListName:           sharedContext.CollectionName,
+						ListName:           listName,
 						Values:             concatValues,
 						TruncateBackToSize: 3,
 					}),
@@ -429,14 +435,14 @@ var _ = Describe("cache-client list-methods", func() {
 				Expect(
 					sharedContext.Client.ListConcatenateFront(sharedContext.Ctx, &ListConcatenateFrontRequest{
 						CacheName: sharedContext.CacheName,
-						ListName:  sharedContext.CollectionName,
+						ListName:  listName,
 						Values:    []Value{String("")},
 					}),
 				).To(BeAssignableToTypeOf(&ListConcatenateFrontSuccess{}))
 
 				fetchResp, err := sharedContext.Client.ListFetch(sharedContext.Ctx, &ListFetchRequest{
 					CacheName: sharedContext.CacheName,
-					ListName:  sharedContext.CollectionName,
+					ListName:  listName,
 				})
 				Expect(err).To(BeNil())
 				Expect(fetchResp).To(HaveListLength(1))
@@ -449,13 +455,13 @@ var _ = Describe("cache-client list-methods", func() {
 				func(clientType string) {
 					client, cacheName := sharedContext.GetClientPrereqsForType(clientType)
 					numItems := 10
-					expected := populateList(sharedContext, numItems)
+					expected := populateList(sharedContext, listName, numItems)
 
 					numConcatItems := 5
 					concatValues, concatExpected := getValueAndExpectedValueLists(numConcatItems)
 					concatResp, err := client.ListConcatenateBack(sharedContext.Ctx, &ListConcatenateBackRequest{
 						CacheName: cacheName,
-						ListName:  sharedContext.CollectionName,
+						ListName:  listName,
 						Values:    concatValues,
 					})
 					Expect(err).To(BeNil())
@@ -463,7 +469,7 @@ var _ = Describe("cache-client list-methods", func() {
 
 					fetchResp, err := client.ListFetch(sharedContext.Ctx, &ListFetchRequest{
 						CacheName: cacheName,
-						ListName:  sharedContext.CollectionName,
+						ListName:  listName,
 					})
 					Expect(err).To(BeNil())
 					Expect(fetchResp).To(BeAssignableToTypeOf(&ListFetchHit{}))
@@ -481,11 +487,11 @@ var _ = Describe("cache-client list-methods", func() {
 			DescribeTable("truncates the list properly",
 				func(clientType string) {
 					client, cacheName := sharedContext.GetClientPrereqsForType(clientType)
-					populateList(sharedContext, 5)
+					populateList(sharedContext, listName, 5)
 					concatValues := []Value{String("100"), String("101"), String("102")}
 					concatResp, err := client.ListConcatenateBack(sharedContext.Ctx, &ListConcatenateBackRequest{
 						CacheName:           cacheName,
-						ListName:            sharedContext.CollectionName,
+						ListName:            listName,
 						Values:              concatValues,
 						TruncateFrontToSize: 3,
 					})
@@ -494,7 +500,7 @@ var _ = Describe("cache-client list-methods", func() {
 
 					fetchResp, err := client.ListFetch(sharedContext.Ctx, &ListFetchRequest{
 						CacheName: cacheName,
-						ListName:  sharedContext.CollectionName,
+						ListName:  listName,
 					})
 					Expect(err).To(BeNil())
 					Expect(fetchResp).To(BeAssignableToTypeOf(&ListFetchHit{}))
@@ -509,12 +515,12 @@ var _ = Describe("cache-client list-methods", func() {
 			)
 
 			It("returns an invalid argument for a nil value", func() {
-				populateList(sharedContext, 5)
+				populateList(sharedContext, listName, 5)
 				concatValues := []Value{nil, String("aRealValue"), nil}
 				Expect(
 					sharedContext.Client.ListConcatenateBack(sharedContext.Ctx, &ListConcatenateBackRequest{
 						CacheName:           sharedContext.CacheName,
-						ListName:            sharedContext.CollectionName,
+						ListName:            listName,
 						Values:              concatValues,
 						TruncateFrontToSize: 3,
 					}),
@@ -525,14 +531,14 @@ var _ = Describe("cache-client list-methods", func() {
 				Expect(
 					sharedContext.Client.ListConcatenateBack(sharedContext.Ctx, &ListConcatenateBackRequest{
 						CacheName: sharedContext.CacheName,
-						ListName:  sharedContext.CollectionName,
+						ListName:  listName,
 						Values:    []Value{String("")},
 					}),
 				).To(BeAssignableToTypeOf(&ListConcatenateBackSuccess{}))
 
 				fetchResp, err := sharedContext.Client.ListFetch(sharedContext.Ctx, &ListFetchRequest{
 					CacheName: sharedContext.CacheName,
-					ListName:  sharedContext.CollectionName,
+					ListName:  listName,
 				})
 				Expect(err).To(BeNil())
 				Expect(fetchResp).To(HaveListLength(1))
@@ -548,11 +554,11 @@ var _ = Describe("cache-client list-methods", func() {
 				func(clientType string) {
 					client, cacheName := sharedContext.GetClientPrereqsForType(clientType)
 					numItems := 5
-					expected := populateList(sharedContext, numItems)
+					expected := populateList(sharedContext, listName, numItems)
 
 					popResp, err := client.ListPopFront(sharedContext.Ctx, &ListPopFrontRequest{
 						CacheName: cacheName,
-						ListName:  sharedContext.CollectionName,
+						ListName:  listName,
 					})
 					Expect(err).To(BeNil())
 					switch result := popResp.(type) {
@@ -564,7 +570,7 @@ var _ = Describe("cache-client list-methods", func() {
 
 					fetchResp, err := client.ListFetch(sharedContext.Ctx, &ListFetchRequest{
 						CacheName: cacheName,
-						ListName:  sharedContext.CollectionName,
+						ListName:  listName,
 					})
 					Expect(err).To(BeNil())
 					Expect(fetchResp).To(HaveListLength(numItems - 1))
@@ -575,18 +581,18 @@ var _ = Describe("cache-client list-methods", func() {
 
 			It("returns a miss after popping the last item", func() {
 				numItems := 3
-				populateList(sharedContext, numItems)
+				populateList(sharedContext, listName, numItems)
 				for i := 0; i < 3; i++ {
 					Expect(
 						sharedContext.Client.ListPopFront(sharedContext.Ctx, &ListPopFrontRequest{
 							CacheName: sharedContext.CacheName,
-							ListName:  sharedContext.CollectionName,
+							ListName:  listName,
 						}),
 					).To(BeAssignableToTypeOf(&ListPopFrontHit{}))
 				}
 				popResp, err := sharedContext.Client.ListPopFront(sharedContext.Ctx, &ListPopFrontRequest{
 					CacheName: sharedContext.CacheName,
-					ListName:  sharedContext.CollectionName,
+					ListName:  listName,
 				})
 				Expect(err).To(BeNil())
 				Expect(popResp).To(BeAssignableToTypeOf(&ListPopFrontMiss{}))
@@ -600,11 +606,11 @@ var _ = Describe("cache-client list-methods", func() {
 				func(clientType string) {
 					client, cacheName := sharedContext.GetClientPrereqsForType(clientType)
 					numItems := 5
-					expected := populateList(sharedContext, numItems)
+					expected := populateList(sharedContext, listName, numItems)
 
 					popResp, err := client.ListPopBack(sharedContext.Ctx, &ListPopBackRequest{
 						CacheName: cacheName,
-						ListName:  sharedContext.CollectionName,
+						ListName:  listName,
 					})
 					Expect(err).To(BeNil())
 					switch result := popResp.(type) {
@@ -616,7 +622,7 @@ var _ = Describe("cache-client list-methods", func() {
 
 					fetchResp, err := client.ListFetch(sharedContext.Ctx, &ListFetchRequest{
 						CacheName: cacheName,
-						ListName:  sharedContext.CollectionName,
+						ListName:  listName,
 					})
 					Expect(err).To(BeNil())
 					Expect(fetchResp).To(HaveListLength(numItems - 1))
@@ -627,18 +633,18 @@ var _ = Describe("cache-client list-methods", func() {
 
 			It("returns a miss after popping the last item", func() {
 				numItems := 3
-				populateList(sharedContext, numItems)
+				populateList(sharedContext, listName, numItems)
 				for i := 0; i < 3; i++ {
 					Expect(
 						sharedContext.Client.ListPopBack(sharedContext.Ctx, &ListPopBackRequest{
 							CacheName: sharedContext.CacheName,
-							ListName:  sharedContext.CollectionName,
+							ListName:  listName,
 						}),
 					).To(BeAssignableToTypeOf(&ListPopBackHit{}))
 				}
 				popResp, err := sharedContext.Client.ListPopBack(sharedContext.Ctx, &ListPopBackRequest{
 					CacheName: sharedContext.CacheName,
-					ListName:  sharedContext.CollectionName,
+					ListName:  listName,
 				})
 				Expect(err).To(BeNil())
 				Expect(popResp).To(BeAssignableToTypeOf(&ListPopBackMiss{}))
@@ -656,18 +662,18 @@ var _ = Describe("cache-client list-methods", func() {
 				func(clientType string) {
 					client, cacheName := sharedContext.GetClientPrereqsForType(clientType)
 					numItems := 5
-					expected := populateList(sharedContext, numItems)
+					expected := populateList(sharedContext, listName, numItems)
 					Expect(
 						client.ListRemoveValue(sharedContext.Ctx, &ListRemoveValueRequest{
 							CacheName: cacheName,
-							ListName:  sharedContext.CollectionName,
+							ListName:  listName,
 							Value:     String(expected[0]),
 						}),
 					).Error().To(BeNil())
 
 					fetchResp, err := client.ListFetch(sharedContext.Ctx, &ListFetchRequest{
 						CacheName: cacheName,
-						ListName:  sharedContext.CollectionName,
+						ListName:  listName,
 					})
 					Expect(err).To(BeNil())
 					switch result := fetchResp.(type) {
@@ -685,7 +691,7 @@ var _ = Describe("cache-client list-methods", func() {
 				Expect(
 					sharedContext.Client.ListRemoveValue(sharedContext.Ctx, &ListRemoveValueRequest{
 						CacheName: sharedContext.CacheName,
-						ListName:  sharedContext.CollectionName,
+						ListName:  listName,
 						Value:     nil,
 					}),
 				).Error().To(HaveMomentoErrorCode(InvalidArgumentError))
@@ -697,7 +703,7 @@ var _ = Describe("cache-client list-methods", func() {
 						sharedContext.Ctx,
 						&ListConcatenateFrontRequest{
 							CacheName: sharedContext.CacheName,
-							ListName:  sharedContext.CollectionName,
+							ListName:  listName,
 							Values:    []Value{String("one"), String(""), String("three")},
 						},
 					),
@@ -706,14 +712,14 @@ var _ = Describe("cache-client list-methods", func() {
 				Expect(
 					sharedContext.Client.ListRemoveValue(sharedContext.Ctx, &ListRemoveValueRequest{
 						CacheName: sharedContext.CacheName,
-						ListName:  sharedContext.CollectionName,
+						ListName:  listName,
 						Value:     String(""),
 					}),
 				).To(BeAssignableToTypeOf(&ListRemoveValueSuccess{}))
 
 				fetchResp, err := sharedContext.Client.ListFetch(sharedContext.Ctx, &ListFetchRequest{
 					CacheName: sharedContext.CacheName,
-					ListName:  sharedContext.CollectionName,
+					ListName:  listName,
 				})
 				Expect(err).To(BeNil())
 				switch result := fetchResp.(type) {
@@ -731,12 +737,12 @@ var _ = Describe("cache-client list-methods", func() {
 				func(clientType string) {
 					client, cacheName := sharedContext.GetClientPrereqsForType(clientType)
 					numItems := 5
-					populateList(sharedContext, numItems)
+					populateList(sharedContext, listName, numItems)
 					toAdd := []Value{String("#4"), String("#4"), String("#4"), String("#0")}
 					Expect(
 						client.ListConcatenateBack(sharedContext.Ctx, &ListConcatenateBackRequest{
 							CacheName: cacheName,
-							ListName:  sharedContext.CollectionName,
+							ListName:  listName,
 							Values:    toAdd,
 						}),
 					).To(BeAssignableToTypeOf(&ListConcatenateBackSuccess{}))
@@ -744,14 +750,14 @@ var _ = Describe("cache-client list-methods", func() {
 					Expect(
 						client.ListRemoveValue(sharedContext.Ctx, &ListRemoveValueRequest{
 							CacheName: cacheName,
-							ListName:  sharedContext.CollectionName,
+							ListName:  listName,
 							Value:     String("#4"),
 						}),
 					).To(BeAssignableToTypeOf(&ListRemoveValueSuccess{}))
 
 					fetchResp, err := client.ListFetch(sharedContext.Ctx, &ListFetchRequest{
 						CacheName: cacheName,
-						ListName:  sharedContext.CollectionName,
+						ListName:  listName,
 					})
 					Expect(err).To(BeNil())
 					switch result := fetchResp.(type) {
@@ -769,7 +775,7 @@ var _ = Describe("cache-client list-methods", func() {
 				Expect(
 					sharedContext.Client.ListRemoveValue(sharedContext.Ctx, &ListRemoveValueRequest{
 						CacheName: sharedContext.CacheName,
-						ListName:  sharedContext.CollectionName,
+						ListName:  listName,
 						Value:     nil,
 					}),
 				).Error().To(HaveMomentoErrorCode(InvalidArgumentError))
@@ -783,18 +789,18 @@ var _ = Describe("cache-client list-methods", func() {
 				func(clientType string) {
 					client, cacheName := sharedContext.GetClientPrereqsForType(clientType)
 					numItems := 5
-					populateList(sharedContext, numItems)
+					populateList(sharedContext, listName, numItems)
 					Expect(
 						client.ListRemoveValue(sharedContext.Ctx, &ListRemoveValueRequest{
 							CacheName: cacheName,
-							ListName:  sharedContext.CollectionName,
+							ListName:  listName,
 							Value:     String("iamnotinthelist"),
 						}),
 					).To(BeAssignableToTypeOf(&ListRemoveValueSuccess{}))
 
 					fetchResp, err := client.ListFetch(sharedContext.Ctx, &ListFetchRequest{
 						CacheName: cacheName,
-						ListName:  sharedContext.CollectionName,
+						ListName:  listName,
 					})
 					Expect(err).To(BeNil())
 					Expect(fetchResp).To(HaveListLength(numItems))
@@ -835,14 +841,14 @@ var _ = Describe("cache-client list-methods", func() {
 						Expect(
 							client.ListPushFront(sharedContext.Ctx, &ListPushFrontRequest{
 								CacheName: cacheName,
-								ListName:  sharedContext.CollectionName,
+								ListName:  listName,
 								Value:     value,
 							}),
 						).To(BeAssignableToTypeOf(&ListPushFrontSuccess{}))
 					}
 					fetchResp, err := client.ListFetch(sharedContext.Ctx, &ListFetchRequest{
 						CacheName: cacheName,
-						ListName:  sharedContext.CollectionName,
+						ListName:  listName,
 					})
 					Expect(err).To(BeNil())
 					Expect(fetchResp).To(BeAssignableToTypeOf(&ListFetchHit{}))
@@ -868,7 +874,7 @@ var _ = Describe("cache-client list-methods", func() {
 						Expect(
 							client.ListPushBack(sharedContext.Ctx, &ListPushBackRequest{
 								CacheName: cacheName,
-								ListName:  sharedContext.CollectionName,
+								ListName:  listName,
 								Value:     value,
 							}),
 						).To(BeAssignableToTypeOf(&ListPushBackSuccess{}))
@@ -877,7 +883,7 @@ var _ = Describe("cache-client list-methods", func() {
 					endIndex := int32(0)
 					fetchResp, err := client.ListFetch(sharedContext.Ctx, &ListFetchRequest{
 						CacheName: cacheName,
-						ListName:  sharedContext.CollectionName,
+						ListName:  listName,
 						EndIndex:  &endIndex,
 					})
 
@@ -901,7 +907,7 @@ var _ = Describe("cache-client list-methods", func() {
 						Expect(
 							client.ListPushBack(sharedContext.Ctx, &ListPushBackRequest{
 								CacheName: cacheName,
-								ListName:  sharedContext.CollectionName,
+								ListName:  listName,
 								Value:     value,
 							}),
 						).To(BeAssignableToTypeOf(&ListPushBackSuccess{}))
@@ -910,7 +916,7 @@ var _ = Describe("cache-client list-methods", func() {
 					startIndex := int32(1)
 					fetchResp, err := client.ListFetch(sharedContext.Ctx, &ListFetchRequest{
 						CacheName:  cacheName,
-						ListName:   sharedContext.CollectionName,
+						ListName:   listName,
 						StartIndex: &startIndex,
 					})
 
@@ -939,7 +945,7 @@ var _ = Describe("cache-client list-methods", func() {
 						Expect(
 							client.ListPushBack(sharedContext.Ctx, &ListPushBackRequest{
 								CacheName: cacheName,
-								ListName:  sharedContext.CollectionName,
+								ListName:  listName,
 								Value:     value,
 							}),
 						).To(BeAssignableToTypeOf(&ListPushBackSuccess{}))
@@ -948,7 +954,7 @@ var _ = Describe("cache-client list-methods", func() {
 					endIndex := int32(3)
 					fetchResp, err := client.ListFetch(sharedContext.Ctx, &ListFetchRequest{
 						CacheName: cacheName,
-						ListName:  sharedContext.CollectionName,
+						ListName:  listName,
 						EndIndex:  &endIndex,
 					})
 
@@ -977,7 +983,7 @@ var _ = Describe("cache-client list-methods", func() {
 						Expect(
 							client.ListPushBack(sharedContext.Ctx, &ListPushBackRequest{
 								CacheName: cacheName,
-								ListName:  sharedContext.CollectionName,
+								ListName:  listName,
 								Value:     value,
 							}),
 						).To(BeAssignableToTypeOf(&ListPushBackSuccess{}))
@@ -987,7 +993,7 @@ var _ = Describe("cache-client list-methods", func() {
 					endIndex := int32(3)
 					fetchResp, err := client.ListFetch(sharedContext.Ctx, &ListFetchRequest{
 						CacheName:  cacheName,
-						ListName:   sharedContext.CollectionName,
+						ListName:   listName,
 						StartIndex: &startIndex,
 						EndIndex:   &endIndex,
 					})
@@ -1018,7 +1024,7 @@ var _ = Describe("cache-client list-methods", func() {
 						Expect(
 							client.ListPushBack(sharedContext.Ctx, &ListPushBackRequest{
 								CacheName: cacheName,
-								ListName:  sharedContext.CollectionName,
+								ListName:  listName,
 								Value:     value,
 							}),
 						).To(BeAssignableToTypeOf(&ListPushBackSuccess{}))
@@ -1027,7 +1033,7 @@ var _ = Describe("cache-client list-methods", func() {
 					startIndex := int32(-2)
 					fetchResp, err := client.ListFetch(sharedContext.Ctx, &ListFetchRequest{
 						CacheName:  cacheName,
-						ListName:   sharedContext.CollectionName,
+						ListName:   listName,
 						StartIndex: &startIndex,
 					})
 

--- a/momento/momento_suite_test.go
+++ b/momento/momento_suite_test.go
@@ -5,16 +5,29 @@ import (
 	"testing"
 
 	"github.com/momentohq/client-sdk-go/momento"
+	helpers "github.com/momentohq/client-sdk-go/momento/test_helpers"
 	"github.com/momentohq/client-sdk-go/responses"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/types"
 )
 
+var sharedContext helpers.SharedContext
+
 func TestMomento(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Momento Suite")
 }
+
+var _ = BeforeSuite(func() {
+	sharedContext = helpers.NewSharedContext()
+	sharedContext.CreateDefaultCaches()
+	sharedContext.CreateDefaultStores()
+})
+
+var _ = AfterSuite(func() {
+	sharedContext.Close()
+})
 
 func HaveMomentoErrorCode(code string) types.GomegaMatcher {
 	return WithTransform(

--- a/momento/permission_scope_test.go
+++ b/momento/permission_scope_test.go
@@ -6,21 +6,9 @@ import (
 
 	"github.com/momentohq/client-sdk-go/internal"
 	. "github.com/momentohq/client-sdk-go/momento"
-	. "github.com/momentohq/client-sdk-go/momento/test_helpers"
 )
 
-var _ = Describe("auth auth-client", func() {
-	var sharedContext SharedContext
-
-	BeforeEach(func() {
-		sharedContext = NewSharedContext()
-		sharedContext.CreateDefaultCaches()
-
-		DeferCleanup(func() {
-			sharedContext.Close()
-		})
-	})
-
+var _ = Describe("auth auth-client permission-scope", func() {
 	Describe("PermissionScope", func() {
 		It("should support assignment from PredefinedScope and AllDataReadWrite", func() {
 			var scope PermissionScope

--- a/momento/permission_scope_test.go
+++ b/momento/permission_scope_test.go
@@ -8,7 +8,7 @@ import (
 	. "github.com/momentohq/client-sdk-go/momento"
 )
 
-var _ = Describe("auth auth-client permission-scope", func() {
+var _ = Describe("auth auth-client", func() {
 	Describe("PermissionScope", func() {
 		It("should support assignment from PredefinedScope and AllDataReadWrite", func() {
 			var scope PermissionScope

--- a/momento/ping_test.go
+++ b/momento/ping_test.go
@@ -1,23 +1,12 @@
 package momento_test
 
 import (
-	. "github.com/momentohq/client-sdk-go/momento/test_helpers"
 	. "github.com/momentohq/client-sdk-go/responses"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("ping-client", func() {
-	var sharedContext SharedContext
-
-	BeforeEach(func() {
-		sharedContext = NewSharedContext()
-		sharedContext.CreateDefaultCaches()
-		DeferCleanup(func() {
-			sharedContext.Close()
-		})
-	})
-
 	It("receives successful ping responses", func() {
 		for i := 0; i < 25; i++ {
 			Expect(

--- a/momento/scalar_test.go
+++ b/momento/scalar_test.go
@@ -14,13 +14,13 @@ import (
 )
 
 var _ = Describe("cache-client scalar-methods", func() {
-	var sharedContext SharedContext
-	BeforeEach(func() {
-		sharedContext = NewSharedContext()
-		sharedContext.CreateDefaultCaches()
+	// var sharedContext SharedContext
+	// BeforeEach(func() {
+	// 	sharedContext = NewSharedContext()
+	// 	sharedContext.CreateDefaultCaches()
 
-		DeferCleanup(func() { sharedContext.Close() })
-	})
+	// 	DeferCleanup(func() { sharedContext.Close() })
+	// })
 
 	DescribeTable("Gets, Sets, and Deletes",
 		func(clientType string, key Key, value Value, expectedString string, expectedBytes []byte) {
@@ -61,16 +61,16 @@ var _ = Describe("cache-client scalar-methods", func() {
 				}),
 			).To(BeAssignableToTypeOf(&GetMiss{}))
 		},
-		Entry("when the key and value are strings", DefaultClient, String("key"), String("value"), "value", []byte("value")),
-		Entry("when the key and value are bytes", DefaultClient, Bytes([]byte{1, 2, 3}), Bytes("string"), "string", []byte("string")),
-		Entry("when the value is empty", DefaultClient, String("key"), String(""), "", []byte("")),
-		Entry("when the value is blank", DefaultClient, String("key"), String("  "), "  ", []byte("  ")),
-		Entry("with default cache name when the key and value are strings", WithDefaultCache, String("key"), String("value"), "value", []byte("value")),
-		Entry("with default cache name when the key and value are bytes", WithDefaultCache, Bytes([]byte{1, 2, 3}), Bytes("string"), "string", []byte("string")),
-		Entry("with default cache name when the value is empty", WithDefaultCache, String("key"), String(""), "", []byte("")),
-		Entry("with default cache name when the value is blank", WithDefaultCache, String("key"), String("  "), "  ", []byte("  ")),
-		Entry("using a consistent read concern client", WithConsistentReadConcern, String("key"), String("value"), "value", []byte("value")),
-		Entry("using a balanced read concern client", DefaultClient, Bytes([]byte{1, 2, 3}), Bytes("string"), "string", []byte("string")),
+		Entry("when the key and value are strings", DefaultClient, NewStringKey(), String("value"), "value", []byte("value")),
+		Entry("when the key and value are bytes", DefaultClient, NewByteKey(), Bytes("string"), "string", []byte("string")),
+		Entry("when the value is empty", DefaultClient, NewStringKey(), String(""), "", []byte("")),
+		Entry("when the value is blank", DefaultClient, NewStringKey(), String("  "), "  ", []byte("  ")),
+		Entry("with default cache name when the key and value are strings", WithDefaultCache, NewStringKey(), String("value"), "value", []byte("value")),
+		Entry("with default cache name when the key and value are bytes", WithDefaultCache, NewByteKey(), Bytes("string"), "string", []byte("string")),
+		Entry("with default cache name when the value is empty", WithDefaultCache, NewStringKey(), String(""), "", []byte("")),
+		Entry("with default cache name when the value is blank", WithDefaultCache, NewStringKey(), String("  "), "  ", []byte("  ")),
+		Entry("using a consistent read concern client", WithConsistentReadConcern, NewStringKey(), String("value"), "value", []byte("value")),
+		Entry("using a balanced read concern client", DefaultClient, NewByteKey(), Bytes("string"), "string", []byte("string")),
 	)
 
 	DescribeTable("Set if not exists",
@@ -141,14 +141,14 @@ var _ = Describe("cache-client scalar-methods", func() {
 				}),
 			).To(BeAssignableToTypeOf(&GetMiss{}))
 		},
-		Entry("when the key and value are strings", DefaultClient, String("key"), String("value"), "value", []byte("value")),
-		Entry("when the key and value are bytes", DefaultClient, Bytes([]byte{1, 2, 3}), Bytes("string"), "string", []byte("string")),
-		Entry("when the value is empty", DefaultClient, String("key"), String(""), "", []byte("")),
-		Entry("when the value is blank", DefaultClient, String("key"), String("  "), "  ", []byte("  ")),
-		Entry("with default cache name when the key and value are strings", WithDefaultCache, String("key"), String("value"), "value", []byte("value")),
-		Entry("with default cache name when the key and value are bytes", WithDefaultCache, Bytes([]byte{1, 2, 3}), Bytes("string"), "string", []byte("string")),
-		Entry("with default cache name when the value is empty", WithDefaultCache, String("key"), String(""), "", []byte("")),
-		Entry("with default cache name when the value is blank", WithDefaultCache, String("key"), String("  "), "  ", []byte("  ")),
+		Entry("when the key and value are strings", DefaultClient, NewStringKey(), String("value"), "value", []byte("value")),
+		Entry("when the key and value are bytes", DefaultClient, NewByteKey(), Bytes("string"), "string", []byte("string")),
+		Entry("when the value is empty", DefaultClient, NewStringKey(), String(""), "", []byte("")),
+		Entry("when the value is blank", DefaultClient, NewStringKey(), String("  "), "  ", []byte("  ")),
+		Entry("with default cache name when the key and value are strings", WithDefaultCache, NewStringKey(), String("value"), "value", []byte("value")),
+		Entry("with default cache name when the key and value are bytes", WithDefaultCache, NewByteKey(), Bytes("string"), "string", []byte("string")),
+		Entry("with default cache name when the value is empty", WithDefaultCache, NewStringKey(), String(""), "", []byte("")),
+		Entry("with default cache name when the value is blank", WithDefaultCache, NewStringKey(), String("  "), "  ", []byte("  ")),
 	)
 
 	DescribeTable("Set if present",
@@ -197,14 +197,14 @@ var _ = Describe("cache-client scalar-methods", func() {
 				Fail("Unexpected type from Get")
 			}
 		},
-		Entry("when the key and value are strings", DefaultClient, String("key"), String("value"), "value", []byte("value")),
-		Entry("when the key and value are bytes", DefaultClient, Bytes([]byte{1, 2, 3}), Bytes("string"), "string", []byte("string")),
-		Entry("when the value is empty", DefaultClient, String("key"), String(""), "", []byte("")),
-		Entry("when the value is blank", DefaultClient, String("key"), String("  "), "  ", []byte("  ")),
-		Entry("with default cache name when the key and value are strings", WithDefaultCache, String("key"), String("value"), "value", []byte("value")),
-		Entry("with default cache name when the key and value are bytes", WithDefaultCache, Bytes([]byte{1, 2, 3}), Bytes("string"), "string", []byte("string")),
-		Entry("with default cache name when the value is empty", WithDefaultCache, String("key"), String(""), "", []byte("")),
-		Entry("with default cache name when the value is blank", WithDefaultCache, String("key"), String("  "), "  ", []byte("  ")),
+		Entry("when the key and value are strings", DefaultClient, NewStringKey(), String("value"), "value", []byte("value")),
+		Entry("when the key and value are bytes", DefaultClient, NewByteKey(), Bytes("string"), "string", []byte("string")),
+		Entry("when the value is empty", DefaultClient, NewStringKey(), String(""), "", []byte("")),
+		Entry("when the value is blank", DefaultClient, NewStringKey(), String("  "), "  ", []byte("  ")),
+		Entry("with default cache name when the key and value are strings", WithDefaultCache, NewStringKey(), String("value"), "value", []byte("value")),
+		Entry("with default cache name when the key and value are bytes", WithDefaultCache, NewByteKey(), Bytes("string"), "string", []byte("string")),
+		Entry("with default cache name when the value is empty", WithDefaultCache, NewStringKey(), String(""), "", []byte("")),
+		Entry("with default cache name when the value is blank", WithDefaultCache, NewStringKey(), String("  "), "  ", []byte("  ")),
 	)
 
 	DescribeTable("Set if absent",
@@ -261,14 +261,14 @@ var _ = Describe("cache-client scalar-methods", func() {
 				Fail("Unexpected type from Get")
 			}
 		},
-		Entry("when the key and value are strings", DefaultClient, String("key"), String("value"), "value", []byte("value")),
-		Entry("when the key and value are bytes", DefaultClient, Bytes([]byte{1, 2, 3}), Bytes("string"), "string", []byte("string")),
-		Entry("when the value is empty", DefaultClient, String("key"), String(""), "", []byte("")),
-		Entry("when the value is blank", DefaultClient, String("key"), String("  "), "  ", []byte("  ")),
-		Entry("with default cache name when the key and value are strings", WithDefaultCache, String("key"), String("value"), "value", []byte("value")),
-		Entry("with default cache name when the key and value are bytes", WithDefaultCache, Bytes([]byte{1, 2, 3}), Bytes("string"), "string", []byte("string")),
-		Entry("with default cache name when the value is empty", WithDefaultCache, String("key"), String(""), "", []byte("")),
-		Entry("with default cache name when the value is blank", WithDefaultCache, String("key"), String("  "), "  ", []byte("  ")),
+		Entry("when the key and value are strings", DefaultClient, NewStringKey(), String("value"), "value", []byte("value")),
+		Entry("when the key and value are bytes", DefaultClient, NewByteKey(), Bytes("string"), "string", []byte("string")),
+		Entry("when the value is empty", DefaultClient, NewStringKey(), String(""), "", []byte("")),
+		Entry("when the value is blank", DefaultClient, NewStringKey(), String("  "), "  ", []byte("  ")),
+		Entry("with default cache name when the key and value are strings", WithDefaultCache, NewStringKey(), String("value"), "value", []byte("value")),
+		Entry("with default cache name when the key and value are bytes", WithDefaultCache, NewByteKey(), Bytes("string"), "string", []byte("string")),
+		Entry("with default cache name when the value is empty", WithDefaultCache, NewStringKey(), String(""), "", []byte("")),
+		Entry("with default cache name when the value is blank", WithDefaultCache, NewStringKey(), String("  "), "  ", []byte("  ")),
 	)
 
 	DescribeTable("Set if present and not equal",
@@ -340,14 +340,14 @@ var _ = Describe("cache-client scalar-methods", func() {
 			})
 			Expect(err).To(HaveMomentoErrorCode(InvalidArgumentError))
 		},
-		Entry("when the key and value are strings", DefaultClient, String("key"), String("value"), "value", []byte("value")),
-		Entry("when the key and value are bytes", DefaultClient, Bytes([]byte{1, 2, 3}), Bytes("string"), "string", []byte("string")),
-		Entry("when the value is empty", DefaultClient, String("key"), String(""), "", []byte("")),
-		Entry("when the value is blank", DefaultClient, String("key"), String("  "), "  ", []byte("  ")),
-		Entry("with default cache name when the key and value are strings", WithDefaultCache, String("key"), String("value"), "value", []byte("value")),
-		Entry("with default cache name when the key and value are bytes", WithDefaultCache, Bytes([]byte{1, 2, 3}), Bytes("string"), "string", []byte("string")),
-		Entry("with default cache name when the value is empty", WithDefaultCache, String("key"), String(""), "", []byte("")),
-		Entry("with default cache name when the value is blank", WithDefaultCache, String("key"), String("  "), "  ", []byte("  ")),
+		Entry("when the key and value are strings", DefaultClient, NewStringKey(), String("value"), "value", []byte("value")),
+		Entry("when the key and value are bytes", DefaultClient, NewByteKey(), Bytes("string"), "string", []byte("string")),
+		Entry("when the value is empty", DefaultClient, NewStringKey(), String(""), "", []byte("")),
+		Entry("when the value is blank", DefaultClient, NewStringKey(), String("  "), "  ", []byte("  ")),
+		Entry("with default cache name when the key and value are strings", WithDefaultCache, NewStringKey(), String("value"), "value", []byte("value")),
+		Entry("with default cache name when the key and value are bytes", WithDefaultCache, NewByteKey(), Bytes("string"), "string", []byte("string")),
+		Entry("with default cache name when the value is empty", WithDefaultCache, NewStringKey(), String(""), "", []byte("")),
+		Entry("with default cache name when the value is blank", WithDefaultCache, NewStringKey(), String("  "), "  ", []byte("  ")),
 	)
 
 	DescribeTable("Set if equal",
@@ -420,14 +420,14 @@ var _ = Describe("cache-client scalar-methods", func() {
 			Expect(err).To(HaveMomentoErrorCode(InvalidArgumentError))
 
 		},
-		Entry("when the key and value are strings", DefaultClient, String("key"), String("value"), "value", []byte("value")),
-		Entry("when the key and value are bytes", DefaultClient, Bytes([]byte{1, 2, 3}), Bytes("string"), "string", []byte("string")),
-		Entry("when the value is empty", DefaultClient, String("key"), String(""), "", []byte("")),
-		Entry("when the value is blank", DefaultClient, String("key"), String("  "), "  ", []byte("  ")),
-		Entry("with default cache name when the key and value are strings", WithDefaultCache, String("key"), String("value"), "value", []byte("value")),
-		Entry("with default cache name when the key and value are bytes", WithDefaultCache, Bytes([]byte{1, 2, 3}), Bytes("string"), "string", []byte("string")),
-		Entry("with default cache name when the value is empty", WithDefaultCache, String("key"), String(""), "", []byte("")),
-		Entry("with default cache name when the value is blank", WithDefaultCache, String("key"), String("  "), "  ", []byte("  ")),
+		Entry("when the key and value are strings", DefaultClient, NewStringKey(), String("value"), "value", []byte("value")),
+		Entry("when the key and value are bytes", DefaultClient, NewByteKey(), Bytes("string"), "string", []byte("string")),
+		Entry("when the value is empty", DefaultClient, NewStringKey(), String(""), "", []byte("")),
+		Entry("when the value is blank", DefaultClient, NewStringKey(), String("  "), "  ", []byte("  ")),
+		Entry("with default cache name when the key and value are strings", WithDefaultCache, NewStringKey(), String("value"), "value", []byte("value")),
+		Entry("with default cache name when the key and value are bytes", WithDefaultCache, NewByteKey(), Bytes("string"), "string", []byte("string")),
+		Entry("with default cache name when the value is empty", WithDefaultCache, NewStringKey(), String(""), "", []byte("")),
+		Entry("with default cache name when the value is blank", WithDefaultCache, NewStringKey(), String("  "), "  ", []byte("  ")),
 	)
 
 	DescribeTable("Set if absent or equal",
@@ -504,14 +504,14 @@ var _ = Describe("cache-client scalar-methods", func() {
 			Expect(err).To(HaveMomentoErrorCode(InvalidArgumentError))
 
 		},
-		Entry("when the key and value are strings", DefaultClient, String("key"), String("value"), "value", []byte("value")),
-		Entry("when the key and value are bytes", DefaultClient, Bytes([]byte{1, 2, 3}), Bytes("string"), "string", []byte("string")),
-		Entry("when the value is empty", DefaultClient, String("key"), String(""), "", []byte("")),
-		Entry("when the value is blank", DefaultClient, String("key"), String("  "), "  ", []byte("  ")),
-		Entry("with default cache name when the key and value are strings", WithDefaultCache, String("key"), String("value"), "value", []byte("value")),
-		Entry("with default cache name when the key and value are bytes", WithDefaultCache, Bytes([]byte{1, 2, 3}), Bytes("string"), "string", []byte("string")),
-		Entry("with default cache name when the value is empty", WithDefaultCache, String("key"), String(""), "", []byte("")),
-		Entry("with default cache name when the value is blank", WithDefaultCache, String("key"), String("  "), "  ", []byte("  ")),
+		Entry("when the key and value are strings", DefaultClient, NewStringKey(), String("value"), "value", []byte("value")),
+		Entry("when the key and value are bytes", DefaultClient, NewByteKey(), Bytes("string"), "string", []byte("string")),
+		Entry("when the value is empty", DefaultClient, NewStringKey(), String(""), "", []byte("")),
+		Entry("when the value is blank", DefaultClient, NewStringKey(), String("  "), "  ", []byte("  ")),
+		Entry("with default cache name when the key and value are strings", WithDefaultCache, NewStringKey(), String("value"), "value", []byte("value")),
+		Entry("with default cache name when the key and value are bytes", WithDefaultCache, NewByteKey(), Bytes("string"), "string", []byte("string")),
+		Entry("with default cache name when the value is empty", WithDefaultCache, NewStringKey(), String(""), "", []byte("")),
+		Entry("with default cache name when the value is blank", WithDefaultCache, NewStringKey(), String("  "), "  ", []byte("  ")),
 	)
 
 	DescribeTable("Set if not equal",
@@ -588,21 +588,21 @@ var _ = Describe("cache-client scalar-methods", func() {
 			Expect(err).To(HaveMomentoErrorCode(InvalidArgumentError))
 
 		},
-		Entry("when the key and value are strings", DefaultClient, String("key"), String("value"), "value", []byte("value")),
-		Entry("when the key and value are bytes", DefaultClient, Bytes([]byte{1, 2, 3}), Bytes("string"), "string", []byte("string")),
-		Entry("when the value is empty", DefaultClient, String("key"), String(""), "", []byte("")),
-		Entry("when the value is blank", DefaultClient, String("key"), String("  "), "  ", []byte("  ")),
-		Entry("with default cache name when the key and value are strings", WithDefaultCache, String("key"), String("value"), "value", []byte("value")),
-		Entry("with default cache name when the key and value are bytes", WithDefaultCache, Bytes([]byte{1, 2, 3}), Bytes("string"), "string", []byte("string")),
-		Entry("with default cache name when the value is empty", WithDefaultCache, String("key"), String(""), "", []byte("")),
-		Entry("with default cache name when the value is blank", WithDefaultCache, String("key"), String("  "), "  ", []byte("  ")),
+		Entry("when the key and value are strings", DefaultClient, NewStringKey(), String("value"), "value", []byte("value")),
+		Entry("when the key and value are bytes", DefaultClient, NewByteKey(), Bytes("string"), "string", []byte("string")),
+		Entry("when the value is empty", DefaultClient, NewStringKey(), String(""), "", []byte("")),
+		Entry("when the value is blank", DefaultClient, NewStringKey(), String("  "), "  ", []byte("  ")),
+		Entry("with default cache name when the key and value are strings", WithDefaultCache, NewStringKey(), String("value"), "value", []byte("value")),
+		Entry("with default cache name when the key and value are bytes", WithDefaultCache, NewByteKey(), Bytes("string"), "string", []byte("string")),
+		Entry("with default cache name when the value is empty", WithDefaultCache, NewStringKey(), String(""), "", []byte("")),
+		Entry("with default cache name when the value is blank", WithDefaultCache, NewStringKey(), String("  "), "  ", []byte("  ")),
 	)
 
 	DescribeTable("errors when the cache is missing",
 		func(clientType string) {
 			client, _ := sharedContext.GetClientPrereqsForType(clientType)
 			cacheName := uuid.NewString()
-			key := String("key")
+			key := NewStringKey()
 			value := String("value")
 
 			getResp, err := client.Get(sharedContext.Ctx, &GetRequest{
@@ -663,7 +663,7 @@ var _ = Describe("cache-client scalar-methods", func() {
 			Expect(
 				client.Get(sharedContext.Ctx, &GetRequest{
 					CacheName: cacheName,
-					Key:       String(uuid.NewString()),
+					Key:       NewStringKey(),
 				}),
 			).To(BeAssignableToTypeOf(&GetMiss{}))
 		},
@@ -696,16 +696,16 @@ var _ = Describe("cache-client scalar-methods", func() {
 			Expect(deleteResp).To(BeNil())
 			Expect(err).To(HaveMomentoErrorCode(InvalidArgumentError))
 		},
-		Entry("With default client and an empty cache name", DefaultClient, "", String("key"), String("value")),
-		Entry("With default client and  an bank cache name", DefaultClient, "   ", String("key"), String("value")),
+		Entry("With default client and an empty cache name", DefaultClient, "", NewStringKey(), String("value")),
+		Entry("With default client and  an bank cache name", DefaultClient, "   ", NewStringKey(), String("value")),
 		Entry("With default client and  an empty key", DefaultClient, uuid.NewString(), String(""), String("value")),
-		Entry("With client with default cache and an bank cache name", WithDefaultCache, "   ", String("key"), String("value")),
+		Entry("With client with default cache and an bank cache name", WithDefaultCache, "   ", NewStringKey(), String("value")),
 		Entry("With client with default cache and an empty key", WithDefaultCache, uuid.NewString(), String(""), String("value")),
 	)
 
 	Describe("Set", func() {
 		It("Uses the default TTL", func() {
-			key := String("key")
+			key := NewStringKey()
 			value := String("value")
 
 			Expect(
@@ -736,7 +736,7 @@ var _ = Describe("cache-client scalar-methods", func() {
 		})
 
 		It("Overrides the default TTL", func() {
-			key := String("key")
+			key := NewStringKey()
 			value := String("value")
 
 			Expect(
@@ -777,7 +777,7 @@ var _ = Describe("cache-client scalar-methods", func() {
 		})
 
 		It("Overrides the default TTL without unit and invalid", func() {
-			key := String("key")
+			key := NewStringKey()
 			value := String("value")
 
 			resp, err := sharedContext.Client.Set(sharedContext.Ctx, &SetRequest{
@@ -799,7 +799,7 @@ var _ = Describe("cache-client scalar-methods", func() {
 		})
 
 		It("returns an error for a nil value", func() {
-			key := String("key")
+			key := NewStringKey()
 			Expect(
 				sharedContext.Client.Set(sharedContext.Ctx, &SetRequest{
 					CacheName: sharedContext.CacheName,
@@ -859,7 +859,7 @@ var _ = Describe("cache-client scalar-methods", func() {
 		DescribeTable("Overwrites Ttl",
 			func(clientType string) {
 				client, cacheName := sharedContext.GetClientPrereqsForType(clientType)
-				key := String("key")
+				key := NewStringKey()
 				value := String("value")
 
 				Expect(
@@ -894,7 +894,7 @@ var _ = Describe("cache-client scalar-methods", func() {
 		DescribeTable("Increases Ttl",
 			func(clientType string) {
 				client, cacheName := sharedContext.GetClientPrereqsForType(clientType)
-				key := String("key")
+				key := NewStringKey()
 				value := String("value")
 
 				Expect(
@@ -931,7 +931,7 @@ var _ = Describe("cache-client scalar-methods", func() {
 			func(clientType string) {
 				client, cacheName := sharedContext.GetClientPrereqsForType(clientType)
 
-				key := String("key")
+				key := NewStringKey()
 				value := String("value")
 
 				Expect(
@@ -964,7 +964,7 @@ var _ = Describe("cache-client scalar-methods", func() {
 		)
 
 		It("Returns InvalidArgumentError with negative or zero Ttl value for UpdateTtl", func() {
-			key := String("key")
+			key := NewStringKey()
 			value := String("value")
 
 			Expect(
@@ -993,7 +993,7 @@ var _ = Describe("cache-client scalar-methods", func() {
 		})
 
 		It("Returns InvalidArgumentError with negative or zero Ttl value for IncreaseTtl", func() {
-			key := String("key")
+			key := NewStringKey()
 			value := String("value")
 
 			Expect(
@@ -1022,7 +1022,7 @@ var _ = Describe("cache-client scalar-methods", func() {
 		})
 
 		It("Returns InvalidArgumentError with negative or zero Ttl value for DecreaseTtl", func() {
-			key := String("key")
+			key := NewStringKey()
 			value := String("value")
 
 			Expect(
@@ -1135,7 +1135,7 @@ var _ = Describe("cache-client scalar-methods", func() {
 		})
 
 		It("Increments from 0 to expected amount with bytes field", func() {
-			field := Bytes([]byte{1, 2, 3})
+			field := NewByteKey()
 
 			resp, err := sharedContext.Client.Increment(sharedContext.Ctx, &IncrementRequest{
 				CacheName: sharedContext.CacheName,

--- a/momento/scalar_test.go
+++ b/momento/scalar_test.go
@@ -14,14 +14,6 @@ import (
 )
 
 var _ = Describe("cache-client scalar-methods", func() {
-	// var sharedContext SharedContext
-	// BeforeEach(func() {
-	// 	sharedContext = NewSharedContext()
-	// 	sharedContext.CreateDefaultCaches()
-
-	// 	DeferCleanup(func() { sharedContext.Close() })
-	// })
-
 	DescribeTable("Gets, Sets, and Deletes",
 		func(clientType string, key Key, value Value, expectedString string, expectedBytes []byte) {
 			client, cacheName := sharedContext.GetClientPrereqsForType(clientType)

--- a/momento/set_test.go
+++ b/momento/set_test.go
@@ -23,14 +23,20 @@ func getElements(numElements int) []Value {
 }
 
 var _ = Describe("cache-client set-methods", func() {
-	var sharedContext SharedContext
+	// var sharedContext SharedContext
+
+	// BeforeEach(func() {
+	// 	sharedContext = NewSharedContext()
+	// 	sharedContext.CreateDefaultCaches()
+	// 	DeferCleanup(func() {
+	// 		sharedContext.Close()
+	// 	})
+	// })
+
+	var setName string
 
 	BeforeEach(func() {
-		sharedContext = NewSharedContext()
-		sharedContext.CreateDefaultCaches()
-		DeferCleanup(func() {
-			sharedContext.Close()
-		})
+		setName = uuid.NewString()
 	})
 
 	DescribeTable("errors when the cache is missing",
@@ -163,14 +169,14 @@ var _ = Describe("cache-client set-methods", func() {
 				Expect(
 					client.SetAddElement(sharedContext.Ctx, &SetAddElementRequest{
 						CacheName: cacheName,
-						SetName:   sharedContext.CollectionName,
+						SetName:   setName,
 						Element:   element,
 					}),
 				).To(BeAssignableToTypeOf(&SetAddElementSuccess{}))
 
 				fetchResp, err := client.SetFetch(sharedContext.Ctx, &SetFetchRequest{
 					CacheName: cacheName,
-					SetName:   sharedContext.CollectionName,
+					SetName:   setName,
 				})
 				Expect(err).To(BeNil())
 				switch result := fetchResp.(type) {
@@ -195,13 +201,13 @@ var _ = Describe("cache-client set-methods", func() {
 				Expect(
 					client.SetAddElements(sharedContext.Ctx, &SetAddElementsRequest{
 						CacheName: cacheName,
-						SetName:   sharedContext.CollectionName,
+						SetName:   setName,
 						Elements:  elements,
 					}),
 				).To(BeAssignableToTypeOf(&SetAddElementsSuccess{}))
 				fetchResp, err := client.SetFetch(sharedContext.Ctx, &SetFetchRequest{
 					CacheName: cacheName,
-					SetName:   sharedContext.CollectionName,
+					SetName:   setName,
 				})
 				Expect(err).To(BeNil())
 				switch result := fetchResp.(type) {
@@ -274,7 +280,7 @@ var _ = Describe("cache-client set-methods", func() {
 			Expect(
 				sharedContext.Client.SetAddElement(sharedContext.Ctx, &SetAddElementRequest{
 					CacheName: sharedContext.CacheName,
-					SetName:   sharedContext.CollectionName,
+					SetName:   setName,
 					Element:   nil,
 				}),
 			).Error().To(HaveMomentoErrorCode(InvalidArgumentError))
@@ -282,7 +288,7 @@ var _ = Describe("cache-client set-methods", func() {
 			Expect(
 				sharedContext.Client.SetAddElements(sharedContext.Ctx, &SetAddElementsRequest{
 					CacheName: sharedContext.CacheName,
-					SetName:   sharedContext.CollectionName,
+					SetName:   setName,
 					Elements:  nil,
 				}),
 			).Error().To(HaveMomentoErrorCode(InvalidArgumentError))
@@ -290,7 +296,7 @@ var _ = Describe("cache-client set-methods", func() {
 			Expect(
 				sharedContext.Client.SetAddElements(sharedContext.Ctx, &SetAddElementsRequest{
 					CacheName: sharedContext.CacheName,
-					SetName:   sharedContext.CollectionName,
+					SetName:   setName,
 					Elements:  []Value{nil, String("aValue"), nil},
 				}),
 			).Error().To(HaveMomentoErrorCode(InvalidArgumentError))
@@ -305,13 +311,13 @@ var _ = Describe("cache-client set-methods", func() {
 			Expect(
 				sharedContext.Client.SetAddElements(sharedContext.Ctx, &SetAddElementsRequest{
 					CacheName: sharedContext.CacheName,
-					SetName:   sharedContext.CollectionName,
+					SetName:   setName,
 					Elements:  elements,
 				}),
 			).Error().To(BeNil())
 			Expect(
 				sharedContext.ClientWithDefaultCacheName.SetAddElements(sharedContext.Ctx, &SetAddElementsRequest{
-					SetName:  sharedContext.CollectionName,
+					SetName:  setName,
 					Elements: elements,
 				}),
 			).Error().To(BeNil())
@@ -323,14 +329,14 @@ var _ = Describe("cache-client set-methods", func() {
 				Expect(
 					client.SetRemoveElement(sharedContext.Ctx, &SetRemoveElementRequest{
 						CacheName: cacheName,
-						SetName:   sharedContext.CollectionName,
+						SetName:   setName,
 						Element:   toRemove,
 					}),
 				).Error().To(BeNil())
 
 				fetchResp, err := client.SetFetch(sharedContext.Ctx, &SetFetchRequest{
 					CacheName: cacheName,
-					SetName:   sharedContext.CollectionName,
+					SetName:   setName,
 				})
 				Expect(err).To(BeNil())
 				Expect(fetchResp).To(HaveSetLength(expectedLength))
@@ -355,14 +361,14 @@ var _ = Describe("cache-client set-methods", func() {
 				Expect(
 					client.SetRemoveElements(sharedContext.Ctx, &SetRemoveElementsRequest{
 						CacheName: cacheName,
-						SetName:   sharedContext.CollectionName,
+						SetName:   setName,
 						Elements:  toRemove,
 					}),
 				).Error().To(BeNil())
 
 				fetchResp, err := client.SetFetch(sharedContext.Ctx, &SetFetchRequest{
 					CacheName: cacheName,
-					SetName:   sharedContext.CollectionName,
+					SetName:   setName,
 				})
 				Expect(err).To(BeNil())
 				Expect(fetchResp).To(HaveSetLength(expectedLength))
@@ -385,7 +391,7 @@ var _ = Describe("cache-client set-methods", func() {
 			Expect(
 				sharedContext.Client.SetRemoveElement(sharedContext.Ctx, &SetRemoveElementRequest{
 					CacheName: sharedContext.CacheName,
-					SetName:   sharedContext.CollectionName,
+					SetName:   setName,
 					Element:   nil,
 				}),
 			).Error().To(HaveMomentoErrorCode(InvalidArgumentError))
@@ -393,7 +399,7 @@ var _ = Describe("cache-client set-methods", func() {
 			Expect(
 				sharedContext.Client.SetRemoveElements(sharedContext.Ctx, &SetRemoveElementsRequest{
 					CacheName: sharedContext.CacheName,
-					SetName:   sharedContext.CollectionName,
+					SetName:   setName,
 					Elements:  nil,
 				}),
 			).Error().To(HaveMomentoErrorCode(InvalidArgumentError))
@@ -401,7 +407,7 @@ var _ = Describe("cache-client set-methods", func() {
 			Expect(
 				sharedContext.Client.SetRemoveElements(sharedContext.Ctx, &SetRemoveElementsRequest{
 					CacheName: sharedContext.CacheName,
-					SetName:   sharedContext.CollectionName,
+					SetName:   setName,
 					Elements:  []Value{nil, String("aValue"), nil},
 				}),
 			).Error().To(HaveMomentoErrorCode(InvalidArgumentError))
@@ -415,13 +421,13 @@ var _ = Describe("cache-client set-methods", func() {
 
 		_, err := sharedContext.Client.SetAddElements(sharedContext.Ctx, &SetAddElementsRequest{
 			CacheName: sharedContext.CacheName,
-			SetName:   sharedContext.CollectionName,
+			SetName:   setName,
 			Elements:  elements,
 		})
 		Expect(err).To(BeNil())
 		resp, err := sharedContext.Client.SetLength(sharedContext.Ctx, &SetLengthRequest{
 			CacheName: sharedContext.CacheName,
-			SetName:   sharedContext.CollectionName,
+			SetName:   setName,
 		})
 		Expect(err).To(BeNil())
 		switch result := resp.(type) {
@@ -445,13 +451,13 @@ var _ = Describe("cache-client set-methods", func() {
 			Expect(
 				sharedContext.Client.SetAddElements(sharedContext.Ctx, &SetAddElementsRequest{
 					CacheName: sharedContext.CacheName,
-					SetName:   sharedContext.CollectionName,
+					SetName:   setName,
 					Elements:  elements,
 				}),
 			).Error().To(BeNil())
 			Expect(
 				sharedContext.ClientWithDefaultCacheName.SetAddElements(sharedContext.Ctx, &SetAddElementsRequest{
-					SetName:  sharedContext.CollectionName,
+					SetName:  setName,
 					Elements: elements,
 				}),
 			).Error().To(BeNil())
@@ -462,7 +468,7 @@ var _ = Describe("cache-client set-methods", func() {
 				client, cacheName := sharedContext.GetClientPrereqsForType(clientType)
 				containsResp, err := client.SetContainsElements(sharedContext.Ctx, &SetContainsElementsRequest{
 					CacheName: cacheName,
-					SetName:   sharedContext.CollectionName,
+					SetName:   setName,
 					Elements:  toCheck,
 				})
 				Expect(err).To(BeNil())
@@ -498,14 +504,14 @@ var _ = Describe("cache-client set-methods", func() {
 				Expect(
 					sharedContext.Client.SetAddElement(sharedContext.Ctx, &SetAddElementRequest{
 						CacheName: sharedContext.CacheName,
-						SetName:   sharedContext.CollectionName,
+						SetName:   setName,
 						Element:   String("hello"),
 					}),
 				).Error().To(BeNil())
 
 				fetchResp, err := sharedContext.Client.SetFetch(sharedContext.Ctx, &SetFetchRequest{
 					CacheName: sharedContext.CacheName,
-					SetName:   sharedContext.CollectionName,
+					SetName:   setName,
 				})
 				Expect(err).To(BeNil())
 				Expect(fetchResp).To(HaveSetLength(1))
@@ -514,7 +520,7 @@ var _ = Describe("cache-client set-methods", func() {
 
 				fetchResp, err = sharedContext.Client.SetFetch(sharedContext.Ctx, &SetFetchRequest{
 					CacheName: sharedContext.CacheName,
-					SetName:   sharedContext.CollectionName,
+					SetName:   setName,
 				})
 				Expect(err).To(BeNil())
 				Expect(fetchResp).To(BeAssignableToTypeOf(&SetFetchMiss{}))
@@ -531,7 +537,7 @@ var _ = Describe("cache-client set-methods", func() {
 				Expect(
 					sharedContext.Client.SetAddElement(sharedContext.Ctx, &SetAddElementRequest{
 						CacheName: sharedContext.CacheName,
-						SetName:   sharedContext.CollectionName,
+						SetName:   setName,
 						Element:   String("goodbye"),
 					}),
 				).To(BeAssignableToTypeOf(&SetAddElementSuccess{}))
@@ -541,7 +547,7 @@ var _ = Describe("cache-client set-methods", func() {
 				Expect(
 					sharedContext.Client.SetAddElement(sharedContext.Ctx, &SetAddElementRequest{
 						CacheName: sharedContext.CacheName,
-						SetName:   sharedContext.CollectionName,
+						SetName:   setName,
 						Element:   String("hello"),
 						Ttl: &utils.CollectionTtl{
 							Ttl:        sharedContext.DefaultTtl + time.Second*60,
@@ -552,7 +558,7 @@ var _ = Describe("cache-client set-methods", func() {
 
 				fetchResp, err := sharedContext.Client.SetFetch(sharedContext.Ctx, &SetFetchRequest{
 					CacheName: sharedContext.CacheName,
-					SetName:   sharedContext.CollectionName,
+					SetName:   setName,
 				})
 				Expect(err).To(BeNil())
 				Expect(fetchResp).To(HaveSetLength(2))
@@ -561,7 +567,7 @@ var _ = Describe("cache-client set-methods", func() {
 
 				fetchResp, err = sharedContext.Client.SetFetch(sharedContext.Ctx, &SetFetchRequest{
 					CacheName: sharedContext.CacheName,
-					SetName:   sharedContext.CollectionName,
+					SetName:   setName,
 				})
 				Expect(err).To(BeNil())
 				Expect(fetchResp).To(BeAssignableToTypeOf(&SetFetchHit{}))
@@ -571,7 +577,7 @@ var _ = Describe("cache-client set-methods", func() {
 				Expect(
 					sharedContext.Client.SetAddElement(sharedContext.Ctx, &SetAddElementRequest{
 						CacheName: sharedContext.CacheName,
-						SetName:   sharedContext.CollectionName,
+						SetName:   setName,
 						Element:   String("hello"),
 						Ttl: &utils.CollectionTtl{
 							Ttl:        sharedContext.DefaultTtl + 1*time.Second,
@@ -583,7 +589,7 @@ var _ = Describe("cache-client set-methods", func() {
 				Expect(
 					sharedContext.Client.SetFetch(sharedContext.Ctx, &SetFetchRequest{
 						CacheName: sharedContext.CacheName,
-						SetName:   sharedContext.CollectionName,
+						SetName:   setName,
 					}),
 				).To(HaveSetLength(2))
 
@@ -592,7 +598,7 @@ var _ = Describe("cache-client set-methods", func() {
 				Expect(
 					sharedContext.Client.SetFetch(sharedContext.Ctx, &SetFetchRequest{
 						CacheName: sharedContext.CacheName,
-						SetName:   sharedContext.CollectionName,
+						SetName:   setName,
 					}),
 				).To(BeAssignableToTypeOf(&SetFetchMiss{}))
 			})
@@ -601,7 +607,7 @@ var _ = Describe("cache-client set-methods", func() {
 				Expect(
 					sharedContext.Client.SetAddElement(sharedContext.Ctx, &SetAddElementRequest{
 						CacheName: sharedContext.CacheName,
-						SetName:   sharedContext.CollectionName,
+						SetName:   setName,
 						Element:   String("hello"),
 						Ttl: &utils.CollectionTtl{
 							Ttl:        time.Millisecond * 20,
@@ -612,7 +618,7 @@ var _ = Describe("cache-client set-methods", func() {
 
 				fetchResp, err := sharedContext.Client.SetFetch(sharedContext.Ctx, &SetFetchRequest{
 					CacheName: sharedContext.CacheName,
-					SetName:   sharedContext.CollectionName,
+					SetName:   setName,
 				})
 				Expect(err).To(BeNil())
 				Expect(fetchResp).To(HaveSetLength(2))
@@ -621,7 +627,7 @@ var _ = Describe("cache-client set-methods", func() {
 
 				fetchResp, err = sharedContext.Client.SetFetch(sharedContext.Ctx, &SetFetchRequest{
 					CacheName: sharedContext.CacheName,
-					SetName:   sharedContext.CollectionName,
+					SetName:   setName,
 				})
 				Expect(err).To(BeNil())
 				Expect(fetchResp).To(BeAssignableToTypeOf(&SetFetchHit{}))
@@ -631,7 +637,7 @@ var _ = Describe("cache-client set-methods", func() {
 				Expect(
 					sharedContext.Client.SetAddElement(sharedContext.Ctx, &SetAddElementRequest{
 						CacheName: sharedContext.CacheName,
-						SetName:   sharedContext.CollectionName,
+						SetName:   setName,
 						Element:   String("hello"),
 						Ttl: &utils.CollectionTtl{
 							Ttl:        time.Millisecond * 200,
@@ -645,7 +651,7 @@ var _ = Describe("cache-client set-methods", func() {
 				Expect(
 					sharedContext.Client.SetFetch(sharedContext.Ctx, &SetFetchRequest{
 						CacheName: sharedContext.CacheName,
-						SetName:   sharedContext.CollectionName,
+						SetName:   setName,
 					}),
 				).To(BeAssignableToTypeOf(&SetFetchMiss{}))
 			})
@@ -658,7 +664,7 @@ var _ = Describe("cache-client set-methods", func() {
 			Expect(
 				sharedContext.Client.SetAddElements(sharedContext.Ctx, &SetAddElementsRequest{
 					CacheName: sharedContext.CacheName,
-					SetName:   sharedContext.CollectionName,
+					SetName:   setName,
 					Elements:  elements,
 				}),
 			).Error().To(BeNil())
@@ -679,14 +685,14 @@ var _ = Describe("cache-client set-methods", func() {
 			// Pop one item from the set (1 is the default), 9 should remain
 			resp1, err1 := sharedContext.Client.SetPop(sharedContext.Ctx, &SetPopRequest{
 				CacheName: sharedContext.CacheName,
-				SetName:   sharedContext.CollectionName,
+				SetName:   setName,
 			})
 			Expect(err1).To(BeNil())
 			Expect(resp1).To(BeAssignableToTypeOf(&SetPopHit{}))
 			Expect(
 				sharedContext.Client.SetFetch(sharedContext.Ctx, &SetFetchRequest{
 					CacheName: sharedContext.CacheName,
-					SetName:   sharedContext.CollectionName,
+					SetName:   setName,
 				}),
 			).To(HaveSetLength(9))
 
@@ -694,7 +700,7 @@ var _ = Describe("cache-client set-methods", func() {
 			count = 4
 			resp2, err2 := sharedContext.Client.SetPop(sharedContext.Ctx, &SetPopRequest{
 				CacheName: sharedContext.CacheName,
-				SetName:   sharedContext.CollectionName,
+				SetName:   setName,
 				Count:     &count,
 			})
 			Expect(err2).To(BeNil())
@@ -702,7 +708,7 @@ var _ = Describe("cache-client set-methods", func() {
 			Expect(
 				sharedContext.Client.SetFetch(sharedContext.Ctx, &SetFetchRequest{
 					CacheName: sharedContext.CacheName,
-					SetName:   sharedContext.CollectionName,
+					SetName:   setName,
 				}),
 			).To(HaveSetLength(5))
 
@@ -710,7 +716,7 @@ var _ = Describe("cache-client set-methods", func() {
 			count = 5
 			resp3, err3 := sharedContext.Client.SetPop(sharedContext.Ctx, &SetPopRequest{
 				CacheName: sharedContext.CacheName,
-				SetName:   sharedContext.CollectionName,
+				SetName:   setName,
 				Count:     &count,
 			})
 			Expect(err3).To(BeNil())
@@ -718,14 +724,14 @@ var _ = Describe("cache-client set-methods", func() {
 			Expect(
 				sharedContext.Client.SetFetch(sharedContext.Ctx, &SetFetchRequest{
 					CacheName: sharedContext.CacheName,
-					SetName:   sharedContext.CollectionName,
+					SetName:   setName,
 				}),
 			).To(BeAssignableToTypeOf(&SetFetchMiss{}))
 
 			// Expect a miss when set is empty
 			resp4, err4 := sharedContext.Client.SetPop(sharedContext.Ctx, &SetPopRequest{
 				CacheName: sharedContext.CacheName,
-				SetName:   sharedContext.CollectionName,
+				SetName:   setName,
 			})
 			Expect(err4).To(BeNil())
 			Expect(resp4).To(BeAssignableToTypeOf(&SetPopMiss{}))

--- a/momento/set_test.go
+++ b/momento/set_test.go
@@ -23,16 +23,6 @@ func getElements(numElements int) []Value {
 }
 
 var _ = Describe("cache-client set-methods", func() {
-	// var sharedContext SharedContext
-
-	// BeforeEach(func() {
-	// 	sharedContext = NewSharedContext()
-	// 	sharedContext.CreateDefaultCaches()
-	// 	DeferCleanup(func() {
-	// 		sharedContext.Close()
-	// 	})
-	// })
-
 	var setName string
 
 	BeforeEach(func() {

--- a/momento/sorted_set_test.go
+++ b/momento/sorted_set_test.go
@@ -15,14 +15,6 @@ import (
 )
 
 var _ = Describe("cache-client sortedset-methods", func() {
-	// var sharedContext SharedContext
-	// BeforeEach(func() {
-	// 	sharedContext = NewSharedContext()
-	// 	sharedContext.CreateDefaultCaches()
-
-	// 	DeferCleanup(func() { sharedContext.Close() })
-	// })
-
 	var sortedSetName string
 
 	BeforeEach(func() {

--- a/momento/sorted_set_test.go
+++ b/momento/sorted_set_test.go
@@ -15,12 +15,18 @@ import (
 )
 
 var _ = Describe("cache-client sortedset-methods", func() {
-	var sharedContext SharedContext
-	BeforeEach(func() {
-		sharedContext = NewSharedContext()
-		sharedContext.CreateDefaultCaches()
+	// var sharedContext SharedContext
+	// BeforeEach(func() {
+	// 	sharedContext = NewSharedContext()
+	// 	sharedContext.CreateDefaultCaches()
 
-		DeferCleanup(func() { sharedContext.Close() })
+	// 	DeferCleanup(func() { sharedContext.Close() })
+	// })
+
+	var sortedSetName string
+
+	BeforeEach(func() {
+		sortedSetName = uuid.NewString()
 	})
 
 	// A convenience for adding elements to a sorted set.
@@ -30,7 +36,7 @@ var _ = Describe("cache-client sortedset-methods", func() {
 				sharedContext.Ctx,
 				&SortedSetPutElementsRequest{
 					CacheName: sharedContext.CacheName,
-					SetName:   sharedContext.CollectionName,
+					SetName:   sortedSetName,
 					Elements:  elements,
 				},
 			),
@@ -39,7 +45,7 @@ var _ = Describe("cache-client sortedset-methods", func() {
 			sharedContext.ClientWithDefaultCacheName.SortedSetPutElements(
 				sharedContext.Ctx,
 				&SortedSetPutElementsRequest{
-					SetName:  sharedContext.CollectionName,
+					SetName:  sortedSetName,
 					Elements: elements,
 				},
 			),
@@ -52,7 +58,7 @@ var _ = Describe("cache-client sortedset-methods", func() {
 			sharedContext.Ctx,
 			&SortedSetFetchByRankRequest{
 				CacheName: sharedContext.CacheName,
-				SetName:   sharedContext.CollectionName,
+				SetName:   sortedSetName,
 			},
 		)
 	}
@@ -134,13 +140,13 @@ var _ = Describe("cache-client sortedset-methods", func() {
 				}),
 			).Error().To(HaveMomentoErrorCode(expectedError))
 		},
-		Entry("Empty cache name with default client", DefaultClient, "", sharedContext.CollectionName, InvalidArgumentError),
-		Entry("Blank cache name with default client", DefaultClient, "  ", sharedContext.CollectionName, InvalidArgumentError),
+		Entry("Empty cache name with default client", DefaultClient, "", sortedSetName, InvalidArgumentError),
+		Entry("Blank cache name with default client", DefaultClient, "  ", sortedSetName, InvalidArgumentError),
 		Entry("Empty collection name with default client", DefaultClient, sharedContext.CacheName, "", InvalidArgumentError),
 		Entry("Blank collection name with default client", DefaultClient, sharedContext.CacheName, "  ", InvalidArgumentError),
 		Entry("Non-existent cache with default client", DefaultClient, uuid.NewString(), uuid.NewString(), CacheNotFoundError),
-		Entry("Empty cache name with client with default cache", WithDefaultCache, "", sharedContext.CollectionName, InvalidArgumentError),
-		Entry("Blank cache name with client with default cache", WithDefaultCache, "  ", sharedContext.CollectionName, InvalidArgumentError),
+		Entry("Empty cache name with client with default cache", WithDefaultCache, "", sortedSetName, InvalidArgumentError),
+		Entry("Blank cache name with client with default cache", WithDefaultCache, "  ", sortedSetName, InvalidArgumentError),
 		Entry("Empty collection name with client with default cache", WithDefaultCache, sharedContext.CacheName, "", InvalidArgumentError),
 		Entry("Blank collection name with client with default cache", WithDefaultCache, sharedContext.CacheName, "  ", InvalidArgumentError),
 		Entry("Non-existent cache with client with default cache", WithDefaultCache, uuid.NewString(), uuid.NewString(), CacheNotFoundError),
@@ -211,7 +217,7 @@ var _ = Describe("cache-client sortedset-methods", func() {
 			func(element SortedSetElement, ttl *utils.CollectionTtl) {
 				request := &SortedSetIncrementScoreRequest{
 					CacheName: sharedContext.CacheName,
-					SetName:   sharedContext.CollectionName,
+					SetName:   sortedSetName,
 					Value:     element.Value,
 					Amount:    element.Score,
 				}
@@ -228,7 +234,7 @@ var _ = Describe("cache-client sortedset-methods", func() {
 			func(element SortedSetElement, ttl *utils.CollectionTtl) {
 				request := &SortedSetPutElementRequest{
 					CacheName: sharedContext.CacheName,
-					SetName:   sharedContext.CollectionName,
+					SetName:   sortedSetName,
 					Value:     element.Value,
 					Score:     element.Score,
 				}
@@ -245,7 +251,7 @@ var _ = Describe("cache-client sortedset-methods", func() {
 			func(element SortedSetElement, ttl *utils.CollectionTtl) {
 				request := &SortedSetPutElementsRequest{
 					CacheName: sharedContext.CacheName,
-					SetName:   sharedContext.CollectionName,
+					SetName:   sortedSetName,
 					Elements:  []SortedSetElement{element},
 				}
 				if ttl != nil {
@@ -266,7 +272,7 @@ var _ = Describe("cache-client sortedset-methods", func() {
 					sharedContext.Ctx,
 					&SortedSetFetchByRankRequest{
 						CacheName: sharedContext.CacheName,
-						SetName:   sharedContext.CollectionName,
+						SetName:   sortedSetName,
 					},
 				),
 			).To(BeAssignableToTypeOf(&SortedSetFetchMiss{}))
@@ -294,7 +300,7 @@ var _ = Describe("cache-client sortedset-methods", func() {
 						sharedContext.Ctx,
 						&SortedSetFetchByRankRequest{
 							CacheName: cacheName,
-							SetName:   sharedContext.CollectionName,
+							SetName:   sortedSetName,
 						},
 					)
 					Expect(err).To(BeNil())
@@ -329,7 +335,7 @@ var _ = Describe("cache-client sortedset-methods", func() {
 						sharedContext.Ctx,
 						&SortedSetFetchByRankRequest{
 							CacheName: sharedContext.CacheName,
-							SetName:   sharedContext.CollectionName,
+							SetName:   sortedSetName,
 							Order:     DESCENDING,
 						},
 					),
@@ -353,7 +359,7 @@ var _ = Describe("cache-client sortedset-methods", func() {
 						sharedContext.Ctx,
 						&SortedSetFetchByRankRequest{
 							CacheName: sharedContext.CacheName,
-							SetName:   sharedContext.CollectionName,
+							SetName:   sortedSetName,
 							Order:     DESCENDING,
 							StartRank: &start,
 							EndRank:   &end,
@@ -375,7 +381,7 @@ var _ = Describe("cache-client sortedset-methods", func() {
 						sharedContext.Ctx,
 						&SortedSetFetchByRankRequest{
 							CacheName: sharedContext.CacheName,
-							SetName:   sharedContext.CollectionName,
+							SetName:   sortedSetName,
 							Order:     DESCENDING,
 							StartRank: &start,
 						},
@@ -396,7 +402,7 @@ var _ = Describe("cache-client sortedset-methods", func() {
 					sharedContext.Ctx,
 					&SortedSetFetchByRankRequest{
 						CacheName: sharedContext.CacheName,
-						SetName:   sharedContext.CollectionName,
+						SetName:   sortedSetName,
 						Order:     DESCENDING,
 						StartRank: &start,
 						EndRank:   &end,
@@ -417,7 +423,7 @@ var _ = Describe("cache-client sortedset-methods", func() {
 						sharedContext.Ctx,
 						&SortedSetFetchByRankRequest{
 							CacheName: sharedContext.CacheName,
-							SetName:   sharedContext.CollectionName,
+							SetName:   sortedSetName,
 							Order:     DESCENDING,
 							EndRank:   &end,
 						},
@@ -438,7 +444,7 @@ var _ = Describe("cache-client sortedset-methods", func() {
 							sharedContext.Ctx,
 							&SortedSetFetchByRankRequest{
 								CacheName: sharedContext.CacheName,
-								SetName:   sharedContext.CollectionName,
+								SetName:   sortedSetName,
 								StartRank: &start,
 								EndRank:   &end,
 							},
@@ -470,7 +476,7 @@ var _ = Describe("cache-client sortedset-methods", func() {
 		putElements(sortedSetElements)
 		lengthResp, err := sharedContext.Client.SortedSetLength(sharedContext.Ctx, &SortedSetLengthRequest{
 			CacheName: sharedContext.CacheName,
-			SetName:   sharedContext.CollectionName,
+			SetName:   sortedSetName,
 		})
 		Expect(err).To(BeNil())
 		switch result := lengthResp.(type) {
@@ -496,7 +502,7 @@ var _ = Describe("cache-client sortedset-methods", func() {
 					sharedContext.Ctx,
 					&SortedSetFetchByScoreRequest{
 						CacheName: sharedContext.CacheName,
-						SetName:   sharedContext.CollectionName,
+						SetName:   sortedSetName,
 					},
 				),
 			).To(BeAssignableToTypeOf(&SortedSetFetchMiss{}))
@@ -524,7 +530,7 @@ var _ = Describe("cache-client sortedset-methods", func() {
 						sharedContext.Ctx,
 						&SortedSetFetchByScoreRequest{
 							CacheName: cacheName,
-							SetName:   sharedContext.CollectionName,
+							SetName:   sortedSetName,
 						},
 					)
 					Expect(err).To(BeNil())
@@ -559,7 +565,7 @@ var _ = Describe("cache-client sortedset-methods", func() {
 						sharedContext.Ctx,
 						&SortedSetFetchByScoreRequest{
 							CacheName: sharedContext.CacheName,
-							SetName:   sharedContext.CollectionName,
+							SetName:   sortedSetName,
 							Order:     DESCENDING,
 						},
 					),
@@ -583,7 +589,7 @@ var _ = Describe("cache-client sortedset-methods", func() {
 						sharedContext.Ctx,
 						&SortedSetFetchByScoreRequest{
 							CacheName: sharedContext.CacheName,
-							SetName:   sharedContext.CollectionName,
+							SetName:   sortedSetName,
 							Order:     DESCENDING,
 							MinScore:  &minScore,
 							MaxScore:  &maxScore,
@@ -607,7 +613,7 @@ var _ = Describe("cache-client sortedset-methods", func() {
 						sharedContext.Ctx,
 						&SortedSetFetchByScoreRequest{
 							CacheName: sharedContext.CacheName,
-							SetName:   sharedContext.CollectionName,
+							SetName:   sortedSetName,
 							Order:     DESCENDING,
 							MinScore:  &minScore,
 							MaxScore:  &maxScore,
@@ -632,7 +638,7 @@ var _ = Describe("cache-client sortedset-methods", func() {
 					sharedContext.Ctx,
 					&SortedSetLengthByScoreRequest{
 						CacheName: sharedContext.CacheName,
-						SetName:   sharedContext.CollectionName,
+						SetName:   sortedSetName,
 					},
 				),
 			).To(BeAssignableToTypeOf(&SortedSetLengthByScoreMiss{}))
@@ -660,7 +666,7 @@ var _ = Describe("cache-client sortedset-methods", func() {
 						sharedContext.Ctx,
 						&SortedSetLengthByScoreRequest{
 							CacheName: cacheName,
-							SetName:   sharedContext.CollectionName,
+							SetName:   sortedSetName,
 						},
 					)
 					Expect(err).To(BeNil())
@@ -684,7 +690,7 @@ var _ = Describe("cache-client sortedset-methods", func() {
 					sharedContext.Ctx,
 					&SortedSetLengthByScoreRequest{
 						CacheName: sharedContext.CacheName,
-						SetName:   sharedContext.CollectionName,
+						SetName:   sortedSetName,
 						MinScore:  &minScore,
 						MaxScore:  &maxScore,
 					},
@@ -708,7 +714,7 @@ var _ = Describe("cache-client sortedset-methods", func() {
 					sharedContext.Ctx,
 					&SortedSetLengthByScoreRequest{
 						CacheName: sharedContext.CacheName,
-						SetName:   sharedContext.CollectionName,
+						SetName:   sortedSetName,
 						MinScore:  &minScore,
 						MaxScore:  &maxScore,
 					},
@@ -732,7 +738,7 @@ var _ = Describe("cache-client sortedset-methods", func() {
 					sharedContext.Ctx,
 					&SortedSetLengthByScoreRequest{
 						CacheName: sharedContext.CacheName,
-						SetName:   sharedContext.CollectionName,
+						SetName:   sortedSetName,
 						MinScore:  &minScore,
 						MaxScore:  &maxScore,
 					},
@@ -756,7 +762,7 @@ var _ = Describe("cache-client sortedset-methods", func() {
 					sharedContext.Ctx,
 					&SortedSetLengthByScoreRequest{
 						CacheName: sharedContext.CacheName,
-						SetName:   sharedContext.CollectionName,
+						SetName:   sortedSetName,
 						MinScore:  &minScore,
 						MaxScore:  &maxScore,
 					},
@@ -781,7 +787,7 @@ var _ = Describe("cache-client sortedset-methods", func() {
 					sharedContext.Ctx,
 					&SortedSetGetRankRequest{
 						CacheName: sharedContext.CacheName,
-						SetName:   sharedContext.CollectionName,
+						SetName:   sortedSetName,
 						Value:     String("foo"),
 					},
 				),
@@ -815,7 +821,7 @@ var _ = Describe("cache-client sortedset-methods", func() {
 					sharedContext.Ctx,
 					&SortedSetGetRankRequest{
 						CacheName: cacheName,
-						SetName:   sharedContext.CollectionName,
+						SetName:   sortedSetName,
 						Value:     String("first"),
 					},
 				)
@@ -833,7 +839,7 @@ var _ = Describe("cache-client sortedset-methods", func() {
 						sharedContext.Ctx,
 						&SortedSetGetRankRequest{
 							CacheName: cacheName,
-							SetName:   sharedContext.CollectionName,
+							SetName:   sortedSetName,
 							Value:     String("last"),
 						},
 					),
@@ -844,7 +850,7 @@ var _ = Describe("cache-client sortedset-methods", func() {
 						sharedContext.Ctx,
 						&SortedSetGetRankRequest{
 							CacheName: cacheName,
-							SetName:   sharedContext.CollectionName,
+							SetName:   sortedSetName,
 							Order:     DESCENDING,
 							Value:     String("last"),
 						},
@@ -861,7 +867,7 @@ var _ = Describe("cache-client sortedset-methods", func() {
 					sharedContext.Ctx,
 					&SortedSetGetRankRequest{
 						CacheName: sharedContext.CacheName,
-						SetName:   sharedContext.CollectionName,
+						SetName:   sortedSetName,
 						Value:     nil,
 					},
 				),
@@ -878,7 +884,7 @@ var _ = Describe("cache-client sortedset-methods", func() {
 					sharedContext.Ctx,
 					&SortedSetGetRankRequest{
 						CacheName: sharedContext.CacheName,
-						SetName:   sharedContext.CollectionName,
+						SetName:   sortedSetName,
 						Value:     String(""),
 					},
 				),
@@ -893,7 +899,7 @@ var _ = Describe("cache-client sortedset-methods", func() {
 					sharedContext.Ctx,
 					&SortedSetGetScoresRequest{
 						CacheName: sharedContext.CacheName,
-						SetName:   sharedContext.CollectionName,
+						SetName:   sortedSetName,
 						Values:    []Value{String("foo")},
 					},
 				),
@@ -927,7 +933,7 @@ var _ = Describe("cache-client sortedset-methods", func() {
 					sharedContext.Ctx,
 					&SortedSetGetScoresRequest{
 						CacheName: cacheName,
-						SetName:   sharedContext.CollectionName,
+						SetName:   sortedSetName,
 						Values: []Value{
 							String("first"), String("last"), String("dne"),
 						},
@@ -959,7 +965,7 @@ var _ = Describe("cache-client sortedset-methods", func() {
 					sharedContext.Ctx,
 					&SortedSetGetScoresRequest{
 						CacheName: sharedContext.CacheName,
-						SetName:   sharedContext.CollectionName,
+						SetName:   sortedSetName,
 						Values:    nil,
 					},
 				),
@@ -970,7 +976,7 @@ var _ = Describe("cache-client sortedset-methods", func() {
 					sharedContext.Ctx,
 					&SortedSetGetScoresRequest{
 						CacheName: sharedContext.CacheName,
-						SetName:   sharedContext.CollectionName,
+						SetName:   sortedSetName,
 						Values:    []Value{nil, String("aValue"), nil},
 					},
 				),
@@ -992,7 +998,7 @@ var _ = Describe("cache-client sortedset-methods", func() {
 				getResp, err := client.SortedSetGetScore(
 					sharedContext.Ctx, &SortedSetGetScoreRequest{
 						CacheName: cacheName,
-						SetName:   sharedContext.CollectionName,
+						SetName:   sortedSetName,
 						Value:     String("first"),
 					},
 				)
@@ -1017,7 +1023,7 @@ var _ = Describe("cache-client sortedset-methods", func() {
 			getResp, err := sharedContext.Client.SortedSetGetScore(
 				sharedContext.Ctx, &SortedSetGetScoreRequest{
 					CacheName: sharedContext.CacheName,
-					SetName:   sharedContext.CollectionName,
+					SetName:   sortedSetName,
 					Value:     String("idontexist"),
 				},
 			)
@@ -1041,7 +1047,7 @@ var _ = Describe("cache-client sortedset-methods", func() {
 			Expect(
 				sharedContext.Client.SortedSetPutElement(sharedContext.Ctx, &SortedSetPutElementRequest{
 					CacheName: sharedContext.CacheName,
-					SetName:   sharedContext.CollectionName,
+					SetName:   sortedSetName,
 					Value:     nil,
 					Score:     10,
 				}),
@@ -1056,7 +1062,7 @@ var _ = Describe("cache-client sortedset-methods", func() {
 					sharedContext.Ctx,
 					&SortedSetIncrementScoreRequest{
 						CacheName: sharedContext.CacheName,
-						SetName:   sharedContext.CollectionName,
+						SetName:   sortedSetName,
 						Value:     String("dne"),
 						Amount:    99,
 					},
@@ -1070,7 +1076,7 @@ var _ = Describe("cache-client sortedset-methods", func() {
 					sharedContext.Ctx,
 					&SortedSetIncrementScoreRequest{
 						CacheName: sharedContext.CacheName,
-						SetName:   sharedContext.CollectionName,
+						SetName:   sortedSetName,
 						Value:     String("dne"),
 						Amount:    0,
 					},
@@ -1084,7 +1090,7 @@ var _ = Describe("cache-client sortedset-methods", func() {
 					sharedContext.Ctx,
 					&SortedSetIncrementScoreRequest{
 						CacheName: sharedContext.CacheName,
-						SetName:   sharedContext.CollectionName,
+						SetName:   sortedSetName,
 						Value:     String("dne"),
 					},
 				),
@@ -1106,7 +1112,7 @@ var _ = Describe("cache-client sortedset-methods", func() {
 					sharedContext.Ctx,
 					&SortedSetIncrementScoreRequest{
 						CacheName: cacheName,
-						SetName:   sharedContext.CollectionName,
+						SetName:   sortedSetName,
 						Value:     String("middle"),
 						Amount:    42,
 					},
@@ -1125,7 +1131,7 @@ var _ = Describe("cache-client sortedset-methods", func() {
 						sharedContext.Ctx,
 						&SortedSetIncrementScoreRequest{
 							CacheName: cacheName,
-							SetName:   sharedContext.CollectionName,
+							SetName:   sortedSetName,
 							Value:     String("middle"),
 							Amount:    -42,
 						},
@@ -1142,7 +1148,7 @@ var _ = Describe("cache-client sortedset-methods", func() {
 					sharedContext.Ctx,
 					&SortedSetIncrementScoreRequest{
 						CacheName: sharedContext.CacheName,
-						SetName:   sharedContext.CollectionName,
+						SetName:   sortedSetName,
 						Value:     nil,
 						Amount:    42,
 					},
@@ -1159,7 +1165,7 @@ var _ = Describe("cache-client sortedset-methods", func() {
 				sharedContext.Ctx,
 				&SortedSetIncrementScoreRequest{
 					CacheName: sharedContext.CacheName,
-					SetName:   sharedContext.CollectionName,
+					SetName:   sortedSetName,
 					Value:     String(""),
 					Amount:    10,
 				},
@@ -1178,7 +1184,7 @@ var _ = Describe("cache-client sortedset-methods", func() {
 					sharedContext.Ctx,
 					&SortedSetPutElementRequest{
 						CacheName: cacheName,
-						SetName:   sharedContext.CollectionName,
+						SetName:   sortedSetName,
 						Value:     inputValue,
 						Score:     inputScore,
 					})
@@ -1189,7 +1195,7 @@ var _ = Describe("cache-client sortedset-methods", func() {
 					sharedContext.Ctx,
 					&SortedSetFetchByRankRequest{
 						CacheName: cacheName,
-						SetName:   sharedContext.CollectionName,
+						SetName:   sortedSetName,
 					},
 				)
 				Expect(fetchErr).To(BeNil())
@@ -1210,7 +1216,7 @@ var _ = Describe("cache-client sortedset-methods", func() {
 			putElements([]SortedSetElement{{Value: strValue, Score: 500}})
 			fetchResp, err := sharedContext.Client.SortedSetGetScore(sharedContext.Ctx, &SortedSetGetScoreRequest{
 				CacheName: sharedContext.CacheName,
-				SetName:   sharedContext.CollectionName,
+				SetName:   sortedSetName,
 				Value:     strValue,
 			})
 			Expect(err).To(BeNil())
@@ -1251,7 +1257,7 @@ var _ = Describe("cache-client sortedset-methods", func() {
 			Expect(
 				sharedContext.Client.SortedSetPutElement(sharedContext.Ctx, &SortedSetPutElementRequest{
 					CacheName: sharedContext.CacheName,
-					SetName:   sharedContext.CollectionName,
+					SetName:   sortedSetName,
 					Value:     nil,
 					Score:     0,
 				}),
@@ -1269,7 +1275,7 @@ var _ = Describe("cache-client sortedset-methods", func() {
 						sharedContext.Ctx,
 						&SortedSetPutElementsRequest{
 							CacheName: cacheName,
-							SetName:   sharedContext.CollectionName,
+							SetName:   sortedSetName,
 							Elements:  elems,
 						},
 					),
@@ -1277,7 +1283,7 @@ var _ = Describe("cache-client sortedset-methods", func() {
 
 				fetchResp, err := client.SortedSetFetchByRank(sharedContext.Ctx, &SortedSetFetchByRankRequest{
 					CacheName: cacheName,
-					SetName:   sharedContext.CollectionName,
+					SetName:   sortedSetName,
 					Order:     ASCENDING,
 				})
 				Expect(err).To(BeNil())
@@ -1318,7 +1324,7 @@ var _ = Describe("cache-client sortedset-methods", func() {
 		It("returns an error for nil elements", func() {
 			Expect(sharedContext.Client.SortedSetPutElements(sharedContext.Ctx, &SortedSetPutElementsRequest{
 				CacheName: sharedContext.CacheName,
-				SetName:   sharedContext.CollectionName,
+				SetName:   sortedSetName,
 				Elements:  nil,
 			})).Error().To(HaveMomentoErrorCode(InvalidArgumentError))
 		})
@@ -1326,7 +1332,7 @@ var _ = Describe("cache-client sortedset-methods", func() {
 		It("returns an error for nil values", func() {
 			Expect(sharedContext.Client.SortedSetPutElements(sharedContext.Ctx, &SortedSetPutElementsRequest{
 				CacheName: sharedContext.CacheName,
-				SetName:   sharedContext.CollectionName,
+				SetName:   sortedSetName,
 				Elements:  []SortedSetElement{{Value: String("hi"), Score: 10}, {Value: nil, Score: 500}},
 			})).Error().To(HaveMomentoErrorCode(InvalidArgumentError))
 		})
@@ -1342,7 +1348,7 @@ var _ = Describe("cache-client sortedset-methods", func() {
 						sharedContext.Ctx,
 						&SortedSetPutElementsRequest{
 							CacheName: cacheName,
-							SetName:   sharedContext.CollectionName,
+							SetName:   sortedSetName,
 							Elements:  elems,
 						},
 					),
@@ -1351,14 +1357,14 @@ var _ = Describe("cache-client sortedset-methods", func() {
 				Expect(
 					client.SortedSetRemoveElement(sharedContext.Ctx, &SortedSetRemoveElementRequest{
 						CacheName: cacheName,
-						SetName:   sharedContext.CollectionName,
+						SetName:   sortedSetName,
 						Value:     String("val1"),
 					}),
 				).To(BeAssignableToTypeOf(&SortedSetRemoveElementSuccess{}))
 
 				fetchResp, err := client.SortedSetFetchByRank(sharedContext.Ctx, &SortedSetFetchByRankRequest{
 					CacheName: cacheName,
-					SetName:   sharedContext.CollectionName,
+					SetName:   sortedSetName,
 					Order:     ASCENDING,
 				})
 				Expect(err).To(BeNil())
@@ -1380,7 +1386,7 @@ var _ = Describe("cache-client sortedset-methods", func() {
 			Expect(
 				sharedContext.Client.SortedSetRemoveElement(sharedContext.Ctx, &SortedSetRemoveElementRequest{
 					CacheName: sharedContext.CacheName,
-					SetName:   sharedContext.CollectionName,
+					SetName:   sortedSetName,
 					Value:     String("idontexist"),
 				}),
 			).To(BeAssignableToTypeOf(&SortedSetRemoveElementSuccess{}))
@@ -1390,7 +1396,7 @@ var _ = Describe("cache-client sortedset-methods", func() {
 			Expect(
 				sharedContext.Client.SortedSetRemoveElement(sharedContext.Ctx, &SortedSetRemoveElementRequest{
 					CacheName: sharedContext.CacheName,
-					SetName:   sharedContext.CollectionName,
+					SetName:   sortedSetName,
 					Value:     nil,
 				}),
 			).Error().To(HaveMomentoErrorCode(InvalidArgumentError))
@@ -1398,7 +1404,7 @@ var _ = Describe("cache-client sortedset-methods", func() {
 			Expect(
 				sharedContext.Client.SortedSetRemoveElement(sharedContext.Ctx, &SortedSetRemoveElementRequest{
 					CacheName: sharedContext.CacheName,
-					SetName:   sharedContext.CollectionName,
+					SetName:   sortedSetName,
 				}),
 			).Error().To(HaveMomentoErrorCode(InvalidArgumentError))
 		})
@@ -1411,7 +1417,7 @@ var _ = Describe("cache-client sortedset-methods", func() {
 					sharedContext.Ctx,
 					&SortedSetRemoveElementsRequest{
 						CacheName: sharedContext.CacheName,
-						SetName:   sharedContext.CollectionName,
+						SetName:   sortedSetName,
 						Values:    []Value{String("dne")},
 					},
 				),
@@ -1434,7 +1440,7 @@ var _ = Describe("cache-client sortedset-methods", func() {
 						sharedContext.Ctx,
 						&SortedSetRemoveElementsRequest{
 							CacheName: cacheName,
-							SetName:   sharedContext.CollectionName,
+							SetName:   sortedSetName,
 							Values: []Value{
 								String("first"), String("dne"),
 							},
@@ -1447,7 +1453,7 @@ var _ = Describe("cache-client sortedset-methods", func() {
 						sharedContext.Ctx,
 						&SortedSetFetchByRankRequest{
 							CacheName: cacheName,
-							SetName:   sharedContext.CollectionName,
+							SetName:   sortedSetName,
 						},
 					),
 				).To(HaveSortedSetElements(
@@ -1467,7 +1473,7 @@ var _ = Describe("cache-client sortedset-methods", func() {
 					sharedContext.Ctx,
 					&SortedSetRemoveElementsRequest{
 						CacheName: sharedContext.CacheName,
-						SetName:   sharedContext.CollectionName,
+						SetName:   sortedSetName,
 						Values:    nil,
 					},
 				),
@@ -1478,7 +1484,7 @@ var _ = Describe("cache-client sortedset-methods", func() {
 					sharedContext.Ctx,
 					&SortedSetRemoveElementsRequest{
 						CacheName: sharedContext.CacheName,
-						SetName:   sharedContext.CollectionName,
+						SetName:   sortedSetName,
 						Values:    []Value{nil, String("aValue"), nil},
 					},
 				),

--- a/momento/storage_client_test.go
+++ b/momento/storage_client_test.go
@@ -7,22 +7,12 @@ import (
 
 	"github.com/momentohq/client-sdk-go/config"
 	. "github.com/momentohq/client-sdk-go/momento"
-	. "github.com/momentohq/client-sdk-go/momento/test_helpers"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("storage-client misc", func() {
-	var sharedContext SharedContext
-
-	BeforeEach(func() {
-		sharedContext = NewSharedContext()
-		sharedContext.CreateDefaultStores()
-
-		DeferCleanup(func() { sharedContext.Close() })
-	})
-
 	It("errors on invalid timeout", func() {
 		badRequestTimeout := 0 * time.Second
 		sharedContext.StorageConfiguration = config.StorageLaptopLatest().WithClientTimeout(badRequestTimeout)

--- a/momento/storage_scalar_test.go
+++ b/momento/storage_scalar_test.go
@@ -8,18 +8,9 @@ import (
 	. "github.com/onsi/gomega"
 
 	. "github.com/momentohq/client-sdk-go/momento"
-	. "github.com/momentohq/client-sdk-go/momento/test_helpers"
 )
 
 var _ = Describe("storage-client scalar", func() {
-	var sharedContext SharedContext
-	BeforeEach(func() {
-		sharedContext = NewSharedContext()
-		sharedContext.CreateDefaultStores()
-
-		DeferCleanup(func() { sharedContext.Close() })
-	})
-
 	DescribeTable("Sets with correct StorageValueType",
 		func(key string, value storageTypes.Value) {
 			_, err := sharedContext.StorageClient.Put(sharedContext.Ctx, &StoragePutRequest{

--- a/momento/test_helpers/shared_context.go
+++ b/momento/test_helpers/shared_context.go
@@ -26,7 +26,6 @@ type SharedContext struct {
 	TopicClient                     momento.TopicClient
 	CacheName                       string
 	StoreName                       string
-	CollectionName                  string
 	Ctx                             context.Context
 	DefaultTtl                      time.Duration
 	Configuration                   config.Configuration
@@ -107,8 +106,6 @@ func NewSharedContext() SharedContext {
 
 	shared.CacheName = fmt.Sprintf("golang-%s", uuid.NewString())
 	shared.StoreName = fmt.Sprintf("golang-%s", uuid.NewString())
-
-	shared.CollectionName = uuid.NewString()
 
 	return shared
 }

--- a/momento/test_helpers/utils.go
+++ b/momento/test_helpers/utils.go
@@ -1,0 +1,14 @@
+package helpers
+
+import (
+	"github.com/google/uuid"
+	"github.com/momentohq/client-sdk-go/momento"
+)
+
+func NewStringKey() momento.String {
+	return momento.String(uuid.NewString())
+}
+
+func NewByteKey() momento.Bytes {
+	return momento.Bytes([]byte(uuid.NewString()))
+}

--- a/momento/topic_client_test.go
+++ b/momento/topic_client_test.go
@@ -11,19 +11,13 @@ import (
 	. "github.com/onsi/gomega"
 
 	. "github.com/momentohq/client-sdk-go/momento"
-	. "github.com/momentohq/client-sdk-go/momento/test_helpers"
 )
 
 var _ = Describe("topic-client", func() {
-	var sharedContext SharedContext
+	var topicName string
 
 	BeforeEach(func() {
-		sharedContext = NewSharedContext()
-		sharedContext.CreateDefaultCaches()
-
-		DeferCleanup(func() {
-			sharedContext.Close()
-		})
+		topicName = uuid.NewString()
 	})
 
 	DescribeTable("Validates the names",
@@ -44,8 +38,8 @@ var _ = Describe("topic-client", func() {
 				}),
 			).Error().To(HaveMomentoErrorCode(expectedError))
 		},
-		Entry("Empty cache name", "", sharedContext.CollectionName, InvalidArgumentError),
-		Entry("Blank cache name", "  ", sharedContext.CollectionName, InvalidArgumentError),
+		Entry("Empty cache name", "", topicName, InvalidArgumentError),
+		Entry("Blank cache name", "  ", topicName, InvalidArgumentError),
 		Entry("Empty collection name", sharedContext.CacheName, "", InvalidArgumentError),
 		Entry("Blank collection name", sharedContext.CacheName, "  ", InvalidArgumentError),
 		Entry("Non-existent cache", uuid.NewString(), uuid.NewString(), CacheNotFoundError),
@@ -59,7 +53,7 @@ var _ = Describe("topic-client", func() {
 
 		sub, err := sharedContext.TopicClient.Subscribe(sharedContext.Ctx, &TopicSubscribeRequest{
 			CacheName: sharedContext.CacheName,
-			TopicName: sharedContext.CollectionName,
+			TopicName: topicName,
 		})
 		if err != nil {
 			panic(err)
@@ -89,7 +83,7 @@ var _ = Describe("topic-client", func() {
 		for _, value := range publishedValues {
 			_, err := sharedContext.TopicClient.Publish(sharedContext.Ctx, &TopicPublishRequest{
 				CacheName: sharedContext.CacheName,
-				TopicName: sharedContext.CollectionName,
+				TopicName: topicName,
 				Value:     value,
 			})
 			if err != nil {
@@ -106,7 +100,7 @@ var _ = Describe("topic-client", func() {
 
 		sub, _ := sharedContext.TopicClient.Subscribe(sharedContext.Ctx, &TopicSubscribeRequest{
 			CacheName: sharedContext.CacheName,
-			TopicName: sharedContext.CollectionName,
+			TopicName: topicName,
 		})
 
 		// Create a new context with a timeout
@@ -141,7 +135,7 @@ var _ = Describe("topic-client", func() {
 		Expect(
 			sharedContext.TopicClient.Publish(sharedContext.Ctx, &TopicPublishRequest{
 				CacheName: sharedContext.CacheName,
-				TopicName: sharedContext.CollectionName,
+				TopicName: topicName,
 				Value:     nil,
 			}),
 		).Error().To(HaveMomentoErrorCode(InvalidArgumentError))
@@ -152,7 +146,7 @@ var _ = Describe("topic-client", func() {
 			Expect(
 				sharedContext.TopicClient.Subscribe(sharedContext.Ctx, &TopicSubscribeRequest{
 					CacheName: sharedContext.CacheName,
-					TopicName: sharedContext.CollectionName,
+					TopicName: topicName,
 				}),
 			).Error().NotTo(HaveOccurred())
 		})


### PR DESCRIPTION
Closes https://github.com/momentohq/dev-eco-issue-tracker/issues/958

Tests were consistently taking anywhere from 18-31 minutes in CI recently. This PR attempts to refactor the tests to speed them up. The tests pass in 3-4 minutes now!

Improvements:

- Uses [BeforeSuite and AfterSuite](https://onsi.github.io/ginkgo/#suite-setup-and-cleanup-beforesuite-and-aftersuite) instead of BeforeEach and AfterEach to initialize test resources (clients, caches, stores, etc). BeforeEach created resources before each "spec" (we have at least 500 specs whereas we have only 3 suites: auth, batchutils, and momento).
- Uses BeforeEach only to provide unique names for topics and collections.
- Adds new helper functions for creating unique string and byte keys.
- Control plane tests that use cache client with default cache name now use their own dedicated cache client to avoid polluting the shared context.