### PR TITLE
chore: slow down the tests a bit to be mindful of service limits

### DIFF
--- a/momento/control_test.go
+++ b/momento/control_test.go
@@ -3,6 +3,7 @@ package momento_test
 import (
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2"
@@ -14,6 +15,10 @@ import (
 )
 
 var _ = Describe("control-ops", func() {
+	BeforeEach(func() {
+		time.Sleep(100 * time.Millisecond)
+	})
+
 	Describe("cache-client happy-path", func() {
 		It("creates, lists, and deletes caches", func() {
 			cacheNames := []string{uuid.NewString(), uuid.NewString()}

--- a/momento/dictionary_test.go
+++ b/momento/dictionary_test.go
@@ -18,6 +18,7 @@ var _ = Describe("cache-client dictionary-methods", func() {
 
 	BeforeEach(func() {
 		dictionaryName = uuid.NewString()
+		time.Sleep(100 * time.Millisecond)
 	})
 
 	DescribeTable("try using invalid cache and dictionary names",

--- a/momento/leaderboard_test.go
+++ b/momento/leaderboard_test.go
@@ -2,6 +2,7 @@ package momento_test
 
 import (
 	"fmt"
+	"time"
 
 	. "github.com/momentohq/client-sdk-go/momento"
 	. "github.com/momentohq/client-sdk-go/responses"
@@ -61,6 +62,7 @@ var _ = Describe("leaderboard-client", func() {
 	Describe("Leaderboard", func() {
 		var testLeaderboard Leaderboard
 		BeforeEach(func() {
+			time.Sleep(100 * time.Millisecond)
 			testLeaderboard = createLeaderboard()
 			DeferCleanup(func() { deleteLeaderboard(testLeaderboard) })
 		})

--- a/momento/list_test.go
+++ b/momento/list_test.go
@@ -3,6 +3,7 @@ package momento_test
 import (
 	"fmt"
 	"sort"
+	"time"
 
 	"github.com/google/uuid"
 	. "github.com/momentohq/client-sdk-go/momento"
@@ -69,6 +70,7 @@ var _ = Describe("cache-client list-methods", func() {
 
 	BeforeEach(func() {
 		listName = uuid.NewString()
+		time.Sleep(100 * time.Millisecond)
 	})
 
 	DescribeTable("try using invalid cache and list names",

--- a/momento/scalar_test.go
+++ b/momento/scalar_test.go
@@ -14,6 +14,10 @@ import (
 )
 
 var _ = Describe("cache-client scalar-methods", func() {
+	BeforeEach(func() {
+		time.Sleep(100 * time.Millisecond)
+	})
+
 	DescribeTable("Gets, Sets, and Deletes",
 		func(clientType string, key Key, value Value, expectedString string, expectedBytes []byte) {
 			client, cacheName := sharedContext.GetClientPrereqsForType(clientType)

--- a/momento/set_test.go
+++ b/momento/set_test.go
@@ -27,6 +27,7 @@ var _ = Describe("cache-client set-methods", func() {
 
 	BeforeEach(func() {
 		setName = uuid.NewString()
+		time.Sleep(100 * time.Millisecond)
 	})
 
 	DescribeTable("errors when the cache is missing",

--- a/momento/sorted_set_test.go
+++ b/momento/sorted_set_test.go
@@ -19,6 +19,7 @@ var _ = Describe("cache-client sortedset-methods", func() {
 
 	BeforeEach(func() {
 		sortedSetName = uuid.NewString()
+		time.Sleep(100 * time.Millisecond)
 	})
 
 	// A convenience for adding elements to a sorted set.


### PR DESCRIPTION
Adds 100ms of delay before each test in the control, dictionary, leaderboard, list, scalar, set, and sorted set tests Describe blocks to slow down the tests a bit.

Currently, the tests are running a bit too fast and hitting limits when they're run as canaries so hitting throttling errors. These failures unnecessarily alert oncall and increasing canary limits further would not be a good use of resources.

With the 100ms addition, the local test runtime moves from ~3min to ~5min.

Can make the delay longer or more targeted to specific tests if needed.