### PR TITLE
refactor: organize makefile phony declarations and add echo statements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,40 +1,45 @@
+.PHONY: install-devtools format imports tidy vet staticcheck lint \
+	install-protos-devtools protos build precommit \
+	test \
+	vendor build-examples run-docs-examples
+
 GOFILES_NOT_NODE = $(shell find . -type f -name '*.go' -not -path "./examples/aws-lambda/infrastructure/*")
 
-.PHONY: install-devtools
+
 install-devtools:
 	go install golang.org/x/tools/cmd/goimports@latest
 	go install honnef.co/go/tools/cmd/staticcheck@v0.4.7
 	go install github.com/onsi/ginkgo/v2/ginkgo@v2.8.1
 
-.PHONY: format
+
 format:
 	gofmt -s -w ${GOFILES_NOT_NODE}
 
-.PHONY: imports
+
 imports:
 	goimports -l -w ${GOFILES_NOT_NODE}
 
-.PHONY: tidy
+
 tidy:
 	go mod tidy
 
-.PHONY: vet
+
 vet:
 	go vet ./...
 
-.PHONY: staticcheck
+
 staticcheck:
 	staticcheck ./...
 
-.PHONY: lint
+
 lint: format imports tidy vet staticcheck
 
-.PHONY: install-protos-devtools
+
 install-protos-devtools:
 	go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
 	go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest
 
-.PHONY: protos
+
 protos:
 	@echo "Run `make install-protos-devtools` if you're missing the Go grpc tools."
 	@echo "Did you copy momentohq/client_protos/proto/*.proto to internal/protos?"
@@ -42,25 +47,25 @@ protos:
 	rm -f internal/protos/httpcache.proto
 	protoc -I=internal/protos --go_out=internal/protos --go_opt=paths=source_relative --go-grpc_out=internal/protos --go-grpc_opt=paths=source_relative internal/protos/*.proto
 
-.PHONY: build
+
 build:
 	go build ./...
 
-.PHONY: precommit
+
 precommit: lint test
 
-.PHONY: test
+
 test:
 	ginkgo momento/ auth/ batchutils/
 
-.PHONY: vendor
+
 vendor:
 	go mod vendor
 
-.PHONY: build-examples
+
 build-examples:
 	cd examples && go build ./...
 
-.PHONY: run-docs-examples
+
 run-docs-examples:
 	cd examples && go run docs-examples/main.go

--- a/Makefile
+++ b/Makefile
@@ -7,28 +7,34 @@ GOFILES_NOT_NODE = $(shell find . -type f -name '*.go' -not -path "./examples/aw
 
 
 install-devtools:
+	@echo "Installing dev tools..."
 	go install golang.org/x/tools/cmd/goimports@latest
 	go install honnef.co/go/tools/cmd/staticcheck@v0.4.7
 	go install github.com/onsi/ginkgo/v2/ginkgo@v2.8.1
 
 
 format:
+	@echo "Formatting code..."
 	gofmt -s -w ${GOFILES_NOT_NODE}
 
 
 imports:
+	@echo "Running goimports..."
 	goimports -l -w ${GOFILES_NOT_NODE}
 
 
 tidy:
+	@echo "Running go mod tidy..."
 	go mod tidy
 
 
 vet:
+	@echo "Running go vet..."
 	go vet ./...
 
 
 staticcheck:
+	@echo "Running staticcheck..."
 	staticcheck ./...
 
 
@@ -36,11 +42,13 @@ lint: format imports tidy vet staticcheck
 
 
 install-protos-devtools:
+	@echo "Installing protos dev tools..."
 	go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
 	go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest
 
 
 protos:
+	@echo "Generating protos..."
 	@echo "Run `make install-protos-devtools` if you're missing the Go grpc tools."
 	@echo "Did you copy momentohq/client_protos/proto/*.proto to internal/protos?"
 	# this file is not needed and causes errors, so make sure it's not present
@@ -49,6 +57,7 @@ protos:
 
 
 build:
+	@echo "Building..."
 	go build ./...
 
 
@@ -56,16 +65,20 @@ precommit: lint test
 
 
 test:
+	@echo "Running tests..."
 	ginkgo momento/ auth/ batchutils/
 
 
 vendor:
+	@echo "Vendoring..."
 	go mod vendor
 
 
 build-examples:
+	@echo "Building examples..."
 	cd examples && go build ./...
 
 
 run-docs-examples:
+	@echo "Running docs examples..."
 	cd examples && go run docs-examples/main.go


### PR DESCRIPTION
We tidy up the Makefile per best practices: group PHONY declarations at the top and add echo statements for each target for clarity.