### PR TITLE
chore: try to make flaky tests less flaky

### DIFF
--- a/momento/scalar_test.go
+++ b/momento/scalar_test.go
@@ -1306,7 +1306,7 @@ var _ = Describe("cache-client scalar-methods", func() {
 
 	Describe("item get ttl", func() {
 		It("accurately reports the remaining TTL for a key", func() {
-			var ttl = time.Duration(time.Second * 60)
+			var ttl = time.Duration(time.Minute * 2)
 			_, err := sharedContext.Client.Set(sharedContext.Ctx, &SetRequest{
 				CacheName: sharedContext.CacheName,
 				Key:       String("hi"),

--- a/momento/topic_client_test.go
+++ b/momento/topic_client_test.go
@@ -103,9 +103,9 @@ var _ = Describe("topic-client", func() {
 			TopicName: topicName,
 		})
 
-		// Create a new context with a timeout
-		ctx, cancel := context.WithTimeout(context.Background(), time.Second*1)
-		defer cancel()
+		// immediately cancel the context
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
 
 		done := make(chan bool)
 
@@ -118,14 +118,12 @@ var _ = Describe("topic-client", func() {
 			close(done)
 		}()
 
-		// immediately cancel the context
-		cancel()
-
 		// Wait for either the Item function to return or the test to timeout
 		select {
 		case <-done:
 			// Test passed
-		case <-time.After(time.Second * 2):
+			Succeed()
+		case <-time.After(time.Second * 5):
 			Fail("Test timed out, likely due to infinite loop in Item function")
 		}
 


### PR DESCRIPTION
Saw several canary test failures from these two tests, likely flaky due to timing issues.

- Relaxed the timing requirement for the scalar test assert statement.
- Relaxed the timeout for the topics test and switched to using `WithCancel` instead of `WithTimeout` for greater clarity.

Checked that removing the context-checking part of `Item()` will make the test fail ([reference comment](https://github.com/momentohq/client-sdk-go/pull/351#discussion_r1313303122) from PR that added this test). I think the intent of this test was to check what happens when a `Item()` is called with a cancelled context (should return err) and I think that's still true after this revision.