### PR TITLE
test: identify services under test w/labels and setup conditionally

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,27 +75,27 @@ test: install-ginkgo
 
 test-auth-service: install-ginkgo
 	@echo "Testing auth service..."
-	@ginkgo ${GINKGO_OPTS} --focus auth-client ${TEST_DIRS}
+	@ginkgo ${GINKGO_OPTS} --label-filter auth-service ${TEST_DIRS}
 
 
 test-cache-service: install-ginkgo
 	@echo "Testing cache service..."
-	@ginkgo ${GINKGO_OPTS} --focus "cache-client|batch-utils" ${TEST_DIRS}
+	@ginkgo ${GINKGO_OPTS} --label-filter cache-service ${TEST_DIRS}
 
 
 test-leaderboard-service: install-ginkgo
 	@echo "Testing leaderboard service..."
-	@ginkgo ${GINKGO_OPTS} --focus leaderboard-client ${TEST_DIRS}
+	@ginkgo ${GINKGO_OPTS} --label-filter leaderboard-service ${TEST_DIRS}
 
 
 test-storage-service: install-ginkgo
 	@echo "Testing storage service..."
-	@ginkgo ${GINKGO_OPTS} --focus storage-client ${TEST_DIRS}
+	@ginkgo ${GINKGO_OPTS} --label-filter storage-service ${TEST_DIRS}
 
 
 test-topics-service: install-ginkgo
 	@echo "Testing topics service..."
-	@ginkgo ${GINKGO_OPTS} --focus topic-client ${TEST_DIRS}
+	@ginkgo ${GINKGO_OPTS} --label-filter topics-service ${TEST_DIRS}
 
 
 vendor:

--- a/batchutils/batch_operations_test.go
+++ b/batchutils/batch_operations_test.go
@@ -16,7 +16,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("batch-utils", func() {
+var _ = Describe("batch-utils", Label("cache-service"), func() {
 
 	var (
 		ctx       context.Context

--- a/batchutils/batch_set_test.go
+++ b/batchutils/batch_set_test.go
@@ -16,7 +16,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("batch-utils", func() {
+var _ = Describe("batch-utils", Label("cache-service"), func() {
 
 	var (
 		ctx       context.Context

--- a/momento/auth_client_test.go
+++ b/momento/auth_client_test.go
@@ -135,7 +135,7 @@ func newTopicClient(ctx SharedContext, provider auth.CredentialProvider) TopicCl
 	return tc
 }
 
-var _ = Describe("auth auth-client", func() {
+var _ = Describe("auth auth-client", Label(AUTH_SERVICE_LABEL), func() {
 	Describe("Generate disposable tokens", func() {
 		Describe("CacheKeyReadOnly tokens", func() {
 			It(`Generates disposable token CacheKeyReadOnly AllCaches, and validates its permissions`, func() {

--- a/momento/batch_set_get_test.go
+++ b/momento/batch_set_get_test.go
@@ -13,7 +13,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("cache-client get-batch set-batch", func() {
+var _ = Describe("cache-client get-batch set-batch", Label(CACHE_SERVICE_LABEL), func() {
 	var sharedContext SharedContext
 
 	BeforeEach(func() {

--- a/momento/cache_client_test.go
+++ b/momento/cache_client_test.go
@@ -13,7 +13,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("cache-client", func() {
+var _ = Describe("cache-client", Label(CACHE_SERVICE_LABEL), func() {
 	It(`errors on an invalid TTL`, func() {
 		zeroDefaultTtl := 0 * time.Second
 		client, err := NewCacheClient(sharedContext.Configuration, sharedContext.CredentialProvider, zeroDefaultTtl)

--- a/momento/control_test.go
+++ b/momento/control_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 var _ = Describe("control-ops", func() {
-	Describe("cache-client happy-path", func() {
+	Describe("cache-client happy-path", Label(CACHE_SERVICE_LABEL), func() {
 		It("creates, lists, and deletes caches", func() {
 			cacheNames := []string{uuid.NewString(), uuid.NewString()}
 			defer func() {
@@ -88,7 +88,7 @@ var _ = Describe("control-ops", func() {
 
 	})
 
-	Describe("storage-client happy-path", func() {
+	Describe("storage-client happy-path", Label(STORAGE_SERVICE_LABEL), func() {
 
 		It("creates, lists, and deletes stores", func() {
 			storeNames := []string{uuid.NewString(), uuid.NewString()}
@@ -162,7 +162,7 @@ var _ = Describe("control-ops", func() {
 		})
 	})
 
-	Describe("storage-client errors", func() {
+	Describe("storage-client errors", Label(STORAGE_SERVICE_LABEL), func() {
 		It("returns StoreNotFoundError when deleting a non-existent store", func() {
 			resp, err := sharedContext.StorageClient.DeleteStore(sharedContext.Ctx, &DeleteStoreRequest{StoreName: uuid.NewString()})
 			Expect(err).To(HaveMomentoErrorCode(StoreNotFoundError))
@@ -170,7 +170,7 @@ var _ = Describe("control-ops", func() {
 		})
 	})
 
-	Describe("cache-client default-cache-name", func() {
+	Describe("cache-client default-cache-name", Label(CACHE_SERVICE_LABEL), func() {
 		It("overrides default cache name", func() {
 			// Create a separate client with a default cache name to be used only in this test
 			// to avoid affecting the shared context when all tests run
@@ -210,7 +210,7 @@ var _ = Describe("control-ops", func() {
 		})
 	})
 
-	Describe("cache-client validate-cache-name", func() {
+	Describe("cache-client validate-cache-name", Label(CACHE_SERVICE_LABEL), func() {
 		It("CreateCache and DeleteCache errors on bad cache names", func() {
 			badCacheNames := []string{"", "   "}
 			for _, badCacheName := range badCacheNames {
@@ -230,7 +230,7 @@ var _ = Describe("control-ops", func() {
 		})
 	})
 
-	Describe("cache-client delete-cache", func() {
+	Describe("cache-client delete-cache", Label(CACHE_SERVICE_LABEL), func() {
 		It("succeeds even if the cache does not exist", func() {
 			Expect(
 				sharedContext.Client.DeleteCache(sharedContext.Ctx, &DeleteCacheRequest{CacheName: uuid.NewString()}),

--- a/momento/dictionary_test.go
+++ b/momento/dictionary_test.go
@@ -13,7 +13,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("cache-client dictionary-methods", func() {
+var _ = Describe("cache-client dictionary-methods", Label(CACHE_SERVICE_LABEL), func() {
 	var dictionaryName string
 
 	BeforeEach(func() {

--- a/momento/leaderboard_test.go
+++ b/momento/leaderboard_test.go
@@ -11,7 +11,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("leaderboard-client", func() {
+var _ = Describe("leaderboard-client", Label(LEADERBOARD_SERVICE_LABEL), func() {
 	// Convenience method for creating temporary leaderboard
 	createLeaderboard := func() Leaderboard {
 		leaderboard, err := sharedContext.LeaderboardClient.Leaderboard(sharedContext.Ctx, &LeaderboardRequest{

--- a/momento/list_test.go
+++ b/momento/list_test.go
@@ -64,7 +64,7 @@ func populateList(sharedContext SharedContext, listName string, numItems int) []
 	return expected
 }
 
-var _ = Describe("cache-client list-methods", func() {
+var _ = Describe("cache-client list-methods", Label(CACHE_SERVICE_LABEL), func() {
 	var listName string
 
 	BeforeEach(func() {

--- a/momento/permission_scope_test.go
+++ b/momento/permission_scope_test.go
@@ -8,7 +8,7 @@ import (
 	. "github.com/momentohq/client-sdk-go/momento"
 )
 
-var _ = Describe("auth auth-client", func() {
+var _ = Describe("auth auth-client", Label(AUTH_SERVICE_LABEL), func() {
 	Describe("PermissionScope", func() {
 		It("should support assignment from PredefinedScope and AllDataReadWrite", func() {
 			var scope PermissionScope

--- a/momento/scalar_test.go
+++ b/momento/scalar_test.go
@@ -13,7 +13,7 @@ import (
 	. "github.com/momentohq/client-sdk-go/responses"
 )
 
-var _ = Describe("cache-client scalar-methods", func() {
+var _ = Describe("cache-client scalar-methods", Label(CACHE_SERVICE_LABEL), func() {
 	DescribeTable("Gets, Sets, and Deletes",
 		func(clientType string, key Key, value Value, expectedString string, expectedBytes []byte) {
 			client, cacheName := sharedContext.GetClientPrereqsForType(clientType)

--- a/momento/set_test.go
+++ b/momento/set_test.go
@@ -22,7 +22,7 @@ func getElements(numElements int) []Value {
 	return elements
 }
 
-var _ = Describe("cache-client set-methods", func() {
+var _ = Describe("cache-client set-methods", Label(CACHE_SERVICE_LABEL), func() {
 	var setName string
 
 	BeforeEach(func() {

--- a/momento/sorted_set_test.go
+++ b/momento/sorted_set_test.go
@@ -14,7 +14,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("cache-client sortedset-methods", func() {
+var _ = Describe("cache-client sortedset-methods", Label(CACHE_SERVICE_LABEL), func() {
 	var sortedSetName string
 
 	BeforeEach(func() {

--- a/momento/storage_client_test.go
+++ b/momento/storage_client_test.go
@@ -12,7 +12,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("storage-client misc", func() {
+var _ = Describe("storage-client misc", Label(STORAGE_SERVICE_LABEL), func() {
 	It("errors on invalid timeout", func() {
 		badRequestTimeout := 0 * time.Second
 		sharedContext.StorageConfiguration = config.StorageLaptopLatest().WithClientTimeout(badRequestTimeout)

--- a/momento/storage_scalar_test.go
+++ b/momento/storage_scalar_test.go
@@ -10,7 +10,7 @@ import (
 	. "github.com/momentohq/client-sdk-go/momento"
 )
 
-var _ = Describe("storage-client scalar", func() {
+var _ = Describe("storage-client scalar", Label(STORAGE_SERVICE_LABEL), func() {
 	DescribeTable("Sets with correct StorageValueType",
 		func(key string, value storageTypes.Value) {
 			_, err := sharedContext.StorageClient.Put(sharedContext.Ctx, &StoragePutRequest{

--- a/momento/topic_client_test.go
+++ b/momento/topic_client_test.go
@@ -13,7 +13,7 @@ import (
 	. "github.com/momentohq/client-sdk-go/momento"
 )
 
-var _ = Describe("topic-client", func() {
+var _ = Describe("topic-client", Label(TOPICS_SERVICE_LABEL), func() {
 	var topicName string
 
 	BeforeEach(func() {


### PR DESCRIPTION
Modifies the tests to use labels to identify each service under
test. We then update the makefile to call ginkgo with a label filter,
and can then programmatically detect if (for example) the storage
service is under test. When the storage service is under test, we set
up the test resources. When the storage service is not under test, we
do not do that.

Previously we always stood up storage service test resources, which
caused errors in places where the storage service was not deployed
even if we weren't specifically testing the storage service.

Previously we used the ginkgo `focus` feature to match a regex on
the suite name. As far as I can tell, we cannot access the focus regex
programmatically, hence we use the labels instead. Because of this,
at some point we should consider renaming the test suite names as
they have been structured assuming we are using focus regex, eg

`Describe("auth auth-client", ...`