### PR TITLE
fix: use unique test keys

### DIFF
--- a/momento/auth_client_test.go
+++ b/momento/auth_client_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/momentohq/client-sdk-go/auth"
 	"github.com/momentohq/client-sdk-go/internal"
 	"github.com/momentohq/client-sdk-go/internal/momentoerrors"
@@ -65,28 +64,28 @@ func assertGetFailure(cc CacheClient, key Value, cacheName string) {
 }
 
 func assertSetSuccess(cc CacheClient, key Value, cacheName string) {
-	_, err := cc.Set(context.Background(), &SetRequest{Key: key, Value: String(uuid.NewString()), CacheName: cacheName})
+	_, err := cc.Set(context.Background(), &SetRequest{Key: key, Value: NewRandomMomentoString(), CacheName: cacheName})
 	if err != nil {
 		panic(err)
 	}
 }
 
 func assertSetFailure(cc CacheClient, key Value, cacheName string) {
-	_, err := cc.Set(context.Background(), &SetRequest{Key: key, Value: String(uuid.NewString()), CacheName: cacheName})
+	_, err := cc.Set(context.Background(), &SetRequest{Key: key, Value: NewRandomMomentoString(), CacheName: cacheName})
 	if err == nil {
 		panic("expected Set to fail but it succeeded")
 	}
 }
 
 func assertPublishSuccess(tc TopicClient, topicName string, cacheName string) {
-	_, err := tc.Publish(context.Background(), &TopicPublishRequest{TopicName: topicName, Value: String(uuid.NewString()), CacheName: cacheName})
+	_, err := tc.Publish(context.Background(), &TopicPublishRequest{TopicName: topicName, Value: NewRandomMomentoString(), CacheName: cacheName})
 	if err != nil {
 		panic(err)
 	}
 }
 
 func assertPublishFailure(tc TopicClient, topicName string, cacheName string) {
-	_, err := tc.Publish(context.Background(), &TopicPublishRequest{TopicName: topicName, Value: String(uuid.NewString()), CacheName: cacheName})
+	_, err := tc.Publish(context.Background(), &TopicPublishRequest{TopicName: topicName, Value: NewRandomMomentoString(), CacheName: cacheName})
 	if err == nil {
 		panic("expected publish to fail but it succeeded")
 	}
@@ -139,7 +138,7 @@ var _ = Describe("auth auth-client", Label(AUTH_SERVICE_LABEL), func() {
 	Describe("Generate disposable tokens", func() {
 		Describe("CacheKeyReadOnly tokens", func() {
 			It(`Generates disposable token CacheKeyReadOnly AllCaches, and validates its permissions`, func() {
-				key := NewStringKey()
+				key := NewRandomMomentoString()
 				resp := generateDisposableTokenSuccess(sharedContext, CacheKeyReadOnly(AllCaches{}, key))
 				credProvider := credProviderFromDisposableToken(resp)
 
@@ -160,12 +159,12 @@ var _ = Describe("auth auth-client", Label(AUTH_SERVICE_LABEL), func() {
 				// asserting topic permissions
 				tc := newTopicClient(sharedContext, credProvider)
 				defer tc.Close()
-				assertPublishFailure(tc, uuid.NewString(), sharedContext.CacheName)
-				assertSubscribeFailure(tc, uuid.NewString(), sharedContext.CacheName)
+				assertPublishFailure(tc, NewRandomString(), sharedContext.CacheName)
+				assertSubscribeFailure(tc, NewRandomString(), sharedContext.CacheName)
 			})
 
 			It(`Generates disposable token CacheKeyReadOnly for a specific cache, and validates its permissions`, func() {
-				key := NewStringKey()
+				key := NewRandomMomentoString()
 				resp := generateDisposableTokenSuccess(sharedContext, CacheKeyReadOnly(CacheName{Name: sharedContext.CacheName}, key))
 				credProvider := credProviderFromDisposableToken(resp)
 
@@ -186,14 +185,14 @@ var _ = Describe("auth auth-client", Label(AUTH_SERVICE_LABEL), func() {
 				// asserting topic permissions
 				tc := newTopicClient(sharedContext, credProvider)
 				defer tc.Close()
-				assertPublishFailure(tc, uuid.NewString(), sharedContext.CacheName)
-				assertSubscribeFailure(tc, uuid.NewString(), sharedContext.CacheName)
+				assertPublishFailure(tc, NewRandomString(), sharedContext.CacheName)
+				assertSubscribeFailure(tc, NewRandomString(), sharedContext.CacheName)
 			})
 		})
 
 		Describe("CacheKeyWriteOnly tokens", func() {
 			It(`Generates disposable token CacheKeyWriteOnly for a specific cache, and validates its permissions`, func() {
-				key := NewStringKey()
+				key := NewRandomMomentoString()
 				scope := CacheKeyWriteOnly(CacheName{Name: sharedContext.CacheName}, key)
 				resp := generateDisposableTokenSuccess(sharedContext, scope)
 				credProvider := credProviderFromDisposableToken(resp)
@@ -217,12 +216,12 @@ var _ = Describe("auth auth-client", Label(AUTH_SERVICE_LABEL), func() {
 				// asserting topic permissions
 				tc := newTopicClient(sharedContext, credProvider)
 				defer tc.Close()
-				assertPublishFailure(tc, uuid.NewString(), sharedContext.CacheName)
-				assertSubscribeFailure(tc, uuid.NewString(), sharedContext.CacheName)
+				assertPublishFailure(tc, NewRandomString(), sharedContext.CacheName)
+				assertSubscribeFailure(tc, NewRandomString(), sharedContext.CacheName)
 			})
 
 			It(`Generates disposable token CacheKeyWriteOnly for all caches, and validates its permissions`, func() {
-				key := NewStringKey()
+				key := NewRandomMomentoString()
 				scope := CacheKeyWriteOnly(AllCaches{}, key)
 				resp := generateDisposableTokenSuccess(sharedContext, scope)
 				credProvider := credProviderFromDisposableToken(resp)
@@ -248,14 +247,14 @@ var _ = Describe("auth auth-client", Label(AUTH_SERVICE_LABEL), func() {
 				// asserting topic permissions
 				tc := newTopicClient(sharedContext, credProvider)
 				defer tc.Close()
-				assertPublishFailure(tc, uuid.NewString(), sharedContext.CacheName)
-				assertSubscribeFailure(tc, uuid.NewString(), sharedContext.CacheName)
+				assertPublishFailure(tc, NewRandomString(), sharedContext.CacheName)
+				assertSubscribeFailure(tc, NewRandomString(), sharedContext.CacheName)
 			})
 		})
 
 		Describe("CacheKeyReadWrite tokens", func() {
 			It(`Generates disposable token CacheKeyReadWrite for all caches, and validates its permissions`, func() {
-				key := NewStringKey()
+				key := NewRandomMomentoString()
 				scope := CacheKeyReadWrite(AllCaches{}, key)
 				resp := generateDisposableTokenSuccess(sharedContext, scope)
 				credProvider := credProviderFromDisposableToken(resp)
@@ -283,12 +282,12 @@ var _ = Describe("auth auth-client", Label(AUTH_SERVICE_LABEL), func() {
 				// asserting topic permissions
 				tc := newTopicClient(sharedContext, credProvider)
 				defer tc.Close()
-				assertPublishFailure(tc, uuid.NewString(), sharedContext.CacheName)
-				assertSubscribeFailure(tc, uuid.NewString(), sharedContext.CacheName)
+				assertPublishFailure(tc, NewRandomString(), sharedContext.CacheName)
+				assertSubscribeFailure(tc, NewRandomString(), sharedContext.CacheName)
 			})
 
 			It(`Generates disposable token CacheKeyReadWrite for a specific cache, and validates its permissions`, func() {
-				key := NewStringKey()
+				key := NewRandomMomentoString()
 				scope := CacheKeyReadWrite(CacheName{Name: sharedContext.CacheName}, key)
 				resp := generateDisposableTokenSuccess(sharedContext, scope)
 				credProvider := credProviderFromDisposableToken(resp)
@@ -316,14 +315,14 @@ var _ = Describe("auth auth-client", Label(AUTH_SERVICE_LABEL), func() {
 				// asserting topic permissions
 				tc := newTopicClient(sharedContext, credProvider)
 				defer tc.Close()
-				assertPublishFailure(tc, uuid.NewString(), sharedContext.CacheName)
-				assertSubscribeFailure(tc, uuid.NewString(), sharedContext.CacheName)
+				assertPublishFailure(tc, NewRandomString(), sharedContext.CacheName)
+				assertSubscribeFailure(tc, NewRandomString(), sharedContext.CacheName)
 			})
 		})
 
 		Describe("CacheKeyPrefixReadWrite tokens", func() {
 			It(`Generates disposable token CacheKeyPrefixReadWrite for a specific cache, and validates its permissions`, func() {
-				key := NewStringKey()
+				key := NewRandomMomentoString()
 				scope := CacheKeyPrefixReadWrite(CacheName{Name: sharedContext.CacheName}, key)
 				resp := generateDisposableTokenSuccess(sharedContext, scope)
 				credProvider := credProviderFromDisposableToken(resp)
@@ -351,12 +350,12 @@ var _ = Describe("auth auth-client", Label(AUTH_SERVICE_LABEL), func() {
 				// asserting topic permissions
 				tc := newTopicClient(sharedContext, credProvider)
 				defer tc.Close()
-				assertPublishFailure(tc, uuid.NewString(), sharedContext.CacheName)
-				assertSubscribeFailure(tc, uuid.NewString(), sharedContext.CacheName)
+				assertPublishFailure(tc, NewRandomString(), sharedContext.CacheName)
+				assertSubscribeFailure(tc, NewRandomString(), sharedContext.CacheName)
 			})
 
 			It(`Generates disposable token CacheKeyPrefixReadWrite for all caches, and validates its permissions`, func() {
-				key := NewStringKey()
+				key := NewRandomMomentoString()
 				scope := CacheKeyPrefixReadWrite(AllCaches{}, key)
 				resp := generateDisposableTokenSuccess(sharedContext, scope)
 				credProvider := credProviderFromDisposableToken(resp)
@@ -384,14 +383,14 @@ var _ = Describe("auth auth-client", Label(AUTH_SERVICE_LABEL), func() {
 				// asserting topic permissions
 				tc := newTopicClient(sharedContext, credProvider)
 				defer tc.Close()
-				assertPublishFailure(tc, uuid.NewString(), sharedContext.CacheName)
-				assertSubscribeFailure(tc, uuid.NewString(), sharedContext.CacheName)
+				assertPublishFailure(tc, NewRandomString(), sharedContext.CacheName)
+				assertSubscribeFailure(tc, NewRandomString(), sharedContext.CacheName)
 			})
 		})
 
 		Describe("CacheKeyPrefixReadOnly tokens", func() {
 			It(`Generates disposable token CacheKeyPrefixReadOnly for a specific cache, and validates its permissions`, func() {
-				key := NewStringKey()
+				key := NewRandomMomentoString()
 				scope := CacheKeyPrefixReadOnly(CacheName{Name: sharedContext.CacheName}, key)
 				resp := generateDisposableTokenSuccess(sharedContext, scope)
 				credProvider := credProviderFromDisposableToken(resp)
@@ -419,12 +418,12 @@ var _ = Describe("auth auth-client", Label(AUTH_SERVICE_LABEL), func() {
 				// asserting topic permissions
 				tc := newTopicClient(sharedContext, credProvider)
 				defer tc.Close()
-				assertPublishFailure(tc, uuid.NewString(), sharedContext.CacheName)
-				assertSubscribeFailure(tc, uuid.NewString(), sharedContext.CacheName)
+				assertPublishFailure(tc, NewRandomString(), sharedContext.CacheName)
+				assertSubscribeFailure(tc, NewRandomString(), sharedContext.CacheName)
 			})
 
 			It(`Generates disposable token CacheKeyPrefixReadOnly for all caches, and validates its permissions`, func() {
-				key := NewStringKey()
+				key := NewRandomMomentoString()
 				scope := CacheKeyPrefixReadOnly(AllCaches{}, key)
 				resp := generateDisposableTokenSuccess(sharedContext, scope)
 				credProvider := credProviderFromDisposableToken(resp)
@@ -452,14 +451,14 @@ var _ = Describe("auth auth-client", Label(AUTH_SERVICE_LABEL), func() {
 				// asserting topic permissions
 				tc := newTopicClient(sharedContext, credProvider)
 				defer tc.Close()
-				assertPublishFailure(tc, uuid.NewString(), sharedContext.CacheName)
-				assertSubscribeFailure(tc, uuid.NewString(), sharedContext.CacheName)
+				assertPublishFailure(tc, NewRandomString(), sharedContext.CacheName)
+				assertSubscribeFailure(tc, NewRandomString(), sharedContext.CacheName)
 			})
 		})
 
 		Describe("CacheKeyPrefixWriteOnly tokens", func() {
 			It(`Generates disposable token CacheKeyPrefixWriteOnly for a specific cache, and validates its permissions`, func() {
-				key := NewStringKey()
+				key := NewRandomMomentoString()
 				scope := CacheKeyPrefixWriteOnly(CacheName{Name: sharedContext.CacheName}, key)
 				resp := generateDisposableTokenSuccess(sharedContext, scope)
 				credProvider := credProviderFromDisposableToken(resp)
@@ -489,12 +488,12 @@ var _ = Describe("auth auth-client", Label(AUTH_SERVICE_LABEL), func() {
 				// asserting topic permissions
 				tc := newTopicClient(sharedContext, credProvider)
 				defer tc.Close()
-				assertPublishFailure(tc, uuid.NewString(), sharedContext.CacheName)
-				assertSubscribeFailure(tc, uuid.NewString(), sharedContext.CacheName)
+				assertPublishFailure(tc, NewRandomString(), sharedContext.CacheName)
+				assertSubscribeFailure(tc, NewRandomString(), sharedContext.CacheName)
 			})
 
 			It(`Generates disposable token CacheKeyPrefixWriteOnly for all caches, and validates its permissions`, func() {
-				key := NewStringKey()
+				key := NewRandomMomentoString()
 				scope := CacheKeyPrefixWriteOnly(AllCaches{}, key)
 				resp := generateDisposableTokenSuccess(sharedContext, scope)
 				credProvider := credProviderFromDisposableToken(resp)
@@ -524,14 +523,14 @@ var _ = Describe("auth auth-client", Label(AUTH_SERVICE_LABEL), func() {
 				// asserting topic permissions
 				tc := newTopicClient(sharedContext, credProvider)
 				defer tc.Close()
-				assertPublishFailure(tc, uuid.NewString(), sharedContext.CacheName)
-				assertSubscribeFailure(tc, uuid.NewString(), sharedContext.CacheName)
+				assertPublishFailure(tc, NewRandomString(), sharedContext.CacheName)
+				assertSubscribeFailure(tc, NewRandomString(), sharedContext.CacheName)
 			})
 		})
 
 		Describe("TopicNamePrefixPublishSubscribe tokens", func() {
 			It(`Generates disposable token TopicNamePrefixPublishSubscribe for a specific cache, and validates its permissions`, func() {
-				topicName := uuid.NewString()
+				topicName := NewRandomString()
 				key := String(topicName)
 				scope := TopicNamePrefixPublishSubscribe(CacheName{Name: sharedContext.CacheName}, topicName)
 				resp := generateDisposableTokenSuccess(sharedContext, scope)
@@ -571,7 +570,7 @@ var _ = Describe("auth auth-client", Label(AUTH_SERVICE_LABEL), func() {
 			})
 
 			It(`Generates disposable token TopicNamePrefixPublishSubscribe for all caches, and validates its permissions`, func() {
-				topicName := uuid.NewString()
+				topicName := NewRandomString()
 				key := String(topicName)
 				scope := TopicNamePrefixPublishSubscribe(AllCaches{}, topicName)
 				resp := generateDisposableTokenSuccess(sharedContext, scope)
@@ -613,7 +612,7 @@ var _ = Describe("auth auth-client", Label(AUTH_SERVICE_LABEL), func() {
 
 		Describe("TopicNamePrefixPublishOnly tokens", func() {
 			It(`Generates disposable token TopicNamePrefixPublishOnly for a specific cache, and validates its permissions`, func() {
-				topicName := uuid.NewString()
+				topicName := NewRandomString()
 				key := String(topicName)
 				scope := TopicNamePrefixPublishOnly(CacheName{Name: sharedContext.CacheName}, topicName)
 				resp := generateDisposableTokenSuccess(sharedContext, scope)
@@ -653,7 +652,7 @@ var _ = Describe("auth auth-client", Label(AUTH_SERVICE_LABEL), func() {
 			})
 
 			It(`Generates disposable token TopicNamePrefixPublishOnly for all caches, and validates its permissions`, func() {
-				topicName := uuid.NewString()
+				topicName := NewRandomString()
 				key := String(topicName)
 				scope := TopicNamePrefixPublishOnly(AllCaches{}, topicName)
 				resp := generateDisposableTokenSuccess(sharedContext, scope)
@@ -695,7 +694,7 @@ var _ = Describe("auth auth-client", Label(AUTH_SERVICE_LABEL), func() {
 
 		Describe("TopicNamePrefixSubscribeOnly tokens", func() {
 			It(`Generates disposable token TopicNamePrefixSubscribeOnly for a specific cache, and validates its permissions`, func() {
-				topicName := uuid.NewString()
+				topicName := NewRandomString()
 				key := String(topicName)
 				scope := TopicNamePrefixSubscribeOnly(CacheName{Name: sharedContext.CacheName}, topicName)
 				resp := generateDisposableTokenSuccess(sharedContext, scope)
@@ -735,7 +734,7 @@ var _ = Describe("auth auth-client", Label(AUTH_SERVICE_LABEL), func() {
 			})
 
 			It(`Generates disposable token TopicNamePrefixSubscribeOnly for all caches, and validates its permissions`, func() {
-				topicName := uuid.NewString()
+				topicName := NewRandomString()
 				key := String(topicName)
 				scope := TopicNamePrefixSubscribeOnly(AllCaches{}, topicName)
 				resp := generateDisposableTokenSuccess(sharedContext, scope)
@@ -777,7 +776,7 @@ var _ = Describe("auth auth-client", Label(AUTH_SERVICE_LABEL), func() {
 
 		Describe("TopicPublishOnly tokens", func() {
 			It(`Generates disposable token TopicPublishOnly for a specific cache, and validates its permissions`, func() {
-				topicName := uuid.NewString()
+				topicName := NewRandomString()
 				key := String(topicName)
 				scope := TopicPublishOnly(CacheName{Name: sharedContext.CacheName}, TopicName{Name: topicName})
 				resp := generateDisposableTokenSuccess(sharedContext, scope)
@@ -817,7 +816,7 @@ var _ = Describe("auth auth-client", Label(AUTH_SERVICE_LABEL), func() {
 			})
 
 			It(`Generates disposable token TopicPublishOnly for all caches and all topics, and validates its permissions`, func() {
-				topicName := uuid.NewString()
+				topicName := NewRandomString()
 				key := String(topicName)
 				scope := TopicPublishOnly(AllCaches{}, AllTopics{})
 				resp := generateDisposableTokenSuccess(sharedContext, scope)
@@ -859,7 +858,7 @@ var _ = Describe("auth auth-client", Label(AUTH_SERVICE_LABEL), func() {
 
 		Describe("TopicSubscribeOnly tokens", func() {
 			It(`Generates disposable token TopicSubscribeOnly for a specific cache, and validates its permissions`, func() {
-				topicName := uuid.NewString()
+				topicName := NewRandomString()
 				key := String(topicName)
 				scope := TopicSubscribeOnly(CacheName{Name: sharedContext.CacheName}, TopicName{Name: topicName})
 				resp := generateDisposableTokenSuccess(sharedContext, scope)
@@ -899,7 +898,7 @@ var _ = Describe("auth auth-client", Label(AUTH_SERVICE_LABEL), func() {
 			})
 
 			It(`Generates disposable token TopicSubscribeOnly for all caches and all topics, and validates its permissions`, func() {
-				topicName := uuid.NewString()
+				topicName := NewRandomString()
 				key := String(topicName)
 				scope := TopicSubscribeOnly(AllCaches{}, AllTopics{})
 				resp := generateDisposableTokenSuccess(sharedContext, scope)
@@ -941,7 +940,7 @@ var _ = Describe("auth auth-client", Label(AUTH_SERVICE_LABEL), func() {
 
 		Describe("TopicPublishSubscribe tokens", func() {
 			It(`Generates disposable token TopicPublishSubscribe for a specific cache, and validates its permissions`, func() {
-				topicName := uuid.NewString()
+				topicName := NewRandomString()
 				key := String(topicName)
 				scope := TopicPublishSubscribe(CacheName{Name: sharedContext.CacheName}, TopicName{Name: topicName})
 				resp := generateDisposableTokenSuccess(sharedContext, scope)
@@ -981,7 +980,7 @@ var _ = Describe("auth auth-client", Label(AUTH_SERVICE_LABEL), func() {
 			})
 
 			It(`Generates disposable token TopicPublishSubscribe for all caches and all topics, and validates its permissions`, func() {
-				topicName := uuid.NewString()
+				topicName := NewRandomString()
 				key := String(topicName)
 				scope := TopicPublishSubscribe(AllCaches{}, AllTopics{})
 				resp := generateDisposableTokenSuccess(sharedContext, scope)
@@ -1023,7 +1022,7 @@ var _ = Describe("auth auth-client", Label(AUTH_SERVICE_LABEL), func() {
 
 		Describe("CacheReadWrite tokens", func() {
 			It(`Generates disposable token CacheReadWrite for a specific cache, and validates its permissions`, func() {
-				topicName := uuid.NewString()
+				topicName := NewRandomString()
 				key := String(topicName)
 				scope := CacheReadWrite(CacheName{Name: sharedContext.CacheName})
 				resp := generateDisposableTokenSuccess(sharedContext, scope)
@@ -1054,12 +1053,12 @@ var _ = Describe("auth auth-client", Label(AUTH_SERVICE_LABEL), func() {
 				// asserting topic permissions
 				tc := newTopicClient(sharedContext, credProvider)
 				defer tc.Close()
-				assertPublishFailure(tc, uuid.NewString(), sharedContext.CacheName)
-				assertSubscribeFailure(tc, uuid.NewString(), sharedContext.CacheName)
+				assertPublishFailure(tc, NewRandomString(), sharedContext.CacheName)
+				assertSubscribeFailure(tc, NewRandomString(), sharedContext.CacheName)
 			})
 
 			It(`Generates disposable token TopicPublishSubscribe for all caches, and validates its permissions`, func() {
-				topicName := uuid.NewString()
+				topicName := NewRandomString()
 				key := String(topicName)
 				scope := CacheReadWrite(AllCaches{})
 				resp := generateDisposableTokenSuccess(sharedContext, scope)
@@ -1090,14 +1089,14 @@ var _ = Describe("auth auth-client", Label(AUTH_SERVICE_LABEL), func() {
 				// asserting topic permissions
 				tc := newTopicClient(sharedContext, credProvider)
 				defer tc.Close()
-				assertPublishFailure(tc, uuid.NewString(), sharedContext.CacheName)
-				assertSubscribeFailure(tc, uuid.NewString(), sharedContext.CacheName)
+				assertPublishFailure(tc, NewRandomString(), sharedContext.CacheName)
+				assertSubscribeFailure(tc, NewRandomString(), sharedContext.CacheName)
 			})
 		})
 
 		Describe("CacheReadOnly tokens", func() {
 			It(`Generates disposable token CacheReadOnly for a specific cache, and validates its permissions`, func() {
-				topicName := uuid.NewString()
+				topicName := NewRandomString()
 				key := String(topicName)
 				scope := CacheReadOnly(CacheName{Name: sharedContext.CacheName})
 				resp := generateDisposableTokenSuccess(sharedContext, scope)
@@ -1128,12 +1127,12 @@ var _ = Describe("auth auth-client", Label(AUTH_SERVICE_LABEL), func() {
 				// asserting topic permissions
 				tc := newTopicClient(sharedContext, credProvider)
 				defer tc.Close()
-				assertPublishFailure(tc, uuid.NewString(), sharedContext.CacheName)
-				assertSubscribeFailure(tc, uuid.NewString(), sharedContext.CacheName)
+				assertPublishFailure(tc, NewRandomString(), sharedContext.CacheName)
+				assertSubscribeFailure(tc, NewRandomString(), sharedContext.CacheName)
 			})
 
 			It(`Generates disposable token CacheReadOnly for all caches, and validates its permissions`, func() {
-				topicName := uuid.NewString()
+				topicName := NewRandomString()
 				key := String(topicName)
 				scope := CacheReadOnly(AllCaches{})
 				resp := generateDisposableTokenSuccess(sharedContext, scope)
@@ -1164,14 +1163,14 @@ var _ = Describe("auth auth-client", Label(AUTH_SERVICE_LABEL), func() {
 				// asserting topic permissions
 				tc := newTopicClient(sharedContext, credProvider)
 				defer tc.Close()
-				assertPublishFailure(tc, uuid.NewString(), sharedContext.CacheName)
-				assertSubscribeFailure(tc, uuid.NewString(), sharedContext.CacheName)
+				assertPublishFailure(tc, NewRandomString(), sharedContext.CacheName)
+				assertSubscribeFailure(tc, NewRandomString(), sharedContext.CacheName)
 			})
 		})
 
 		Describe("CacheWriteOnly tokens", func() {
 			It(`Generates disposable token CacheWriteOnly for a specific cache, and validates its permissions`, func() {
-				topicName := uuid.NewString()
+				topicName := NewRandomString()
 				key := String(topicName)
 				scope := CacheWriteOnly(CacheName{Name: sharedContext.CacheName})
 				resp := generateDisposableTokenSuccess(sharedContext, scope)
@@ -1202,12 +1201,12 @@ var _ = Describe("auth auth-client", Label(AUTH_SERVICE_LABEL), func() {
 				// asserting topic permissions
 				tc := newTopicClient(sharedContext, credProvider)
 				defer tc.Close()
-				assertPublishFailure(tc, uuid.NewString(), sharedContext.CacheName)
-				assertSubscribeFailure(tc, uuid.NewString(), sharedContext.CacheName)
+				assertPublishFailure(tc, NewRandomString(), sharedContext.CacheName)
+				assertSubscribeFailure(tc, NewRandomString(), sharedContext.CacheName)
 			})
 
 			It(`Generates disposable token CacheWriteOnly for all caches, and validates its permissions`, func() {
-				topicName := uuid.NewString()
+				topicName := NewRandomString()
 				key := String(topicName)
 				scope := CacheWriteOnly(AllCaches{})
 				resp := generateDisposableTokenSuccess(sharedContext, scope)
@@ -1238,8 +1237,8 @@ var _ = Describe("auth auth-client", Label(AUTH_SERVICE_LABEL), func() {
 				// asserting topic permissions
 				tc := newTopicClient(sharedContext, credProvider)
 				defer tc.Close()
-				assertPublishFailure(tc, uuid.NewString(), sharedContext.CacheName)
-				assertSubscribeFailure(tc, uuid.NewString(), sharedContext.CacheName)
+				assertPublishFailure(tc, NewRandomString(), sharedContext.CacheName)
+				assertSubscribeFailure(tc, NewRandomString(), sharedContext.CacheName)
 			})
 		})
 	})
@@ -1257,8 +1256,8 @@ var _ = Describe("auth auth-client", Label(AUTH_SERVICE_LABEL), func() {
 			}
 
 			authTestingCacheClient := newCacheClient(sharedContext, sharedContext.CredentialProvider)
-			authTestCache1 = fmt.Sprintf("golang-auth-%s", uuid.NewString())
-			authTestCache2 = fmt.Sprintf("golang-auth-%s", uuid.NewString())
+			authTestCache1 = fmt.Sprintf("golang-auth-%s", NewRandomString())
+			authTestCache2 = fmt.Sprintf("golang-auth-%s", NewRandomString())
 
 			_, err = authTestingCacheClient.CreateCache(context.Background(), &CreateCacheRequest{
 				CacheName: authTestCache1,
@@ -1405,7 +1404,7 @@ var _ = Describe("auth auth-client", Label(AUTH_SERVICE_LABEL), func() {
 				Expect(err.(MomentoError).Code()).To(Equal(momentoerrors.PermissionError))
 
 				// Can set values in an existing cache
-				key := NewStringKey()
+				key := NewRandomMomentoString()
 				setResp, err := cacheClient.Set(sharedContext.Ctx, &SetRequest{
 					CacheName: authTestCache1,
 					Key:       key,
@@ -1644,7 +1643,7 @@ var _ = Describe("auth auth-client", Label(AUTH_SERVICE_LABEL), func() {
 				defer topicClient.Close()
 
 				// 1. Cache get/set on authTestCache1 should succeed
-				key := NewStringKey()
+				key := NewRandomMomentoString()
 				setResp, err := cacheClient.Set(sharedContext.Ctx, &SetRequest{
 					CacheName: authTestCache1,
 					Key:       key,

--- a/momento/control_test.go
+++ b/momento/control_test.go
@@ -191,14 +191,14 @@ var _ = Describe("control-ops", func() {
 			).Error().NotTo(HaveOccurred())
 			Expect(
 				clientWithDefaultCacheName.Get(
-					sharedContext.Ctx, &GetRequest{Key: helpers.NewStringKey()},
+					sharedContext.Ctx, &GetRequest{Key: helpers.NewRandomMomentoString()},
 				),
 			).Error().To(HaveMomentoErrorCode(CacheNotFoundError))
 			Expect(
 				clientWithDefaultCacheName.Get(
 					sharedContext.Ctx, &GetRequest{
 						CacheName: newCacheName,
-						Key:       helpers.NewStringKey(),
+						Key:       helpers.NewRandomMomentoString(),
 					},
 				),
 			).To(BeAssignableToTypeOf(&GetMiss{}))

--- a/momento/control_test.go
+++ b/momento/control_test.go
@@ -16,7 +16,7 @@ import (
 var _ = Describe("control-ops", func() {
 	Describe("cache-client happy-path", Label(CACHE_SERVICE_LABEL), func() {
 		It("creates, lists, and deletes caches", func() {
-			cacheNames := []string{uuid.NewString(), uuid.NewString()}
+			cacheNames := []string{helpers.NewRandomString(), helpers.NewRandomString()}
 			defer func() {
 				for _, cacheName := range cacheNames {
 					_, err := sharedContext.Client.DeleteCache(sharedContext.Ctx, &DeleteCacheRequest{CacheName: cacheName})
@@ -69,7 +69,7 @@ var _ = Describe("control-ops", func() {
 		It("creates and deletes using a default cache", func() {
 			// Create a separate client with a default cache name to be used only in this test
 			// to avoid affecting the shared context when all tests run
-			defaultCacheName := fmt.Sprintf("golang-default-%s", uuid.NewString())
+			defaultCacheName := fmt.Sprintf("golang-default-%s", helpers.NewRandomString())
 			clientWithDefaultCacheName, err := NewCacheClientWithDefaultCache(
 				sharedContext.Configuration, sharedContext.CredentialProvider, sharedContext.DefaultTtl, defaultCacheName,
 			)

--- a/momento/scalar_test.go
+++ b/momento/scalar_test.go
@@ -1237,10 +1237,16 @@ var _ = Describe("cache-client scalar-methods", Label(CACHE_SERVICE_LABEL), func
 	})
 
 	Describe("ItemGetType", func() {
+		scalarName := NewRandomMomentoString()
+		dictionaryName := NewRandomString()
+		listName := NewRandomString()
+		setName := NewRandomString()
+		sortedSetName := NewRandomString()
+
 		BeforeEach(func() {
 			_, err := sharedContext.Client.Set(sharedContext.Ctx, &SetRequest{
 				CacheName: sharedContext.CacheName,
-				Key:       String("SCALAR"),
+				Key:       scalarName,
 				Value:     String("hi"),
 			})
 			if err != nil {
@@ -1248,7 +1254,7 @@ var _ = Describe("cache-client scalar-methods", Label(CACHE_SERVICE_LABEL), func
 			}
 			_, err = sharedContext.Client.DictionarySetField(sharedContext.Ctx, &DictionarySetFieldRequest{
 				CacheName:      sharedContext.CacheName,
-				DictionaryName: "DICTIONARY",
+				DictionaryName: dictionaryName,
 				Field:          String("hi"),
 				Value:          String("there"),
 			})
@@ -1257,7 +1263,7 @@ var _ = Describe("cache-client scalar-methods", Label(CACHE_SERVICE_LABEL), func
 			}
 			_, err = sharedContext.Client.ListPushFront(sharedContext.Ctx, &ListPushFrontRequest{
 				CacheName: sharedContext.CacheName,
-				ListName:  "LIST",
+				ListName:  listName,
 				Value:     String("hi"),
 			})
 			if err != nil {
@@ -1265,7 +1271,7 @@ var _ = Describe("cache-client scalar-methods", Label(CACHE_SERVICE_LABEL), func
 			}
 			_, err = sharedContext.Client.SetAddElement(sharedContext.Ctx, &SetAddElementRequest{
 				CacheName: sharedContext.CacheName,
-				SetName:   "SET",
+				SetName:   setName,
 				Element:   String("hi"),
 			})
 			if err != nil {
@@ -1273,7 +1279,7 @@ var _ = Describe("cache-client scalar-methods", Label(CACHE_SERVICE_LABEL), func
 			}
 			_, err = sharedContext.Client.SortedSetPutElement(sharedContext.Ctx, &SortedSetPutElementRequest{
 				CacheName: sharedContext.CacheName,
-				SetName:   "SORTED_SET",
+				SetName:   sortedSetName,
 				Value:     String("hi"),
 				Score:     1.0,
 			})
@@ -1296,27 +1302,29 @@ var _ = Describe("cache-client scalar-methods", Label(CACHE_SERVICE_LABEL), func
 					Fail(fmt.Sprintf("expected ItemGetTypeHit but got %s", result))
 				}
 			},
-			Entry("scalar", String("SCALAR"), ItemTypeScalar),
-			Entry("dictionary", String("DICTIONARY"), ItemTypeDictionary),
-			Entry("set", String("SET"), ItemTypeSet),
-			Entry("list", String("LIST"), ItemTypeList),
-			Entry("sorted set", String("SORTED_SET"), ItemTypeSortedSet),
+			Entry("Scalar", scalarName, ItemTypeScalar),
+			Entry("Dictionary", String(dictionaryName), ItemTypeDictionary),
+			Entry("Set", String(setName), ItemTypeSet),
+			Entry("List", String(listName), ItemTypeList),
+			Entry("Sorted set", String(sortedSetName), ItemTypeSortedSet),
 		)
 	})
 
 	Describe("item get ttl", func() {
 		It("accurately reports the remaining TTL for a key", func() {
+			key := NewRandomMomentoString()
+			value := NewRandomMomentoString()
 			var ttl = time.Duration(time.Minute * 2)
 			_, err := sharedContext.Client.Set(sharedContext.Ctx, &SetRequest{
 				CacheName: sharedContext.CacheName,
-				Key:       String("hi"),
-				Value:     String("there"),
+				Key:       key,
+				Value:     value,
 				Ttl:       ttl,
 			})
 			Expect(err).To(BeNil())
 			resp, err := sharedContext.Client.ItemGetTtl(sharedContext.Ctx, &ItemGetTtlRequest{
 				CacheName: sharedContext.CacheName,
-				Key:       String("hi"),
+				Key:       key,
 			})
 			Expect(err).To(BeNil())
 			Expect(resp).To(BeAssignableToTypeOf(&ItemGetTtlHit{}))

--- a/momento/scalar_test.go
+++ b/momento/scalar_test.go
@@ -53,16 +53,16 @@ var _ = Describe("cache-client scalar-methods", Label(CACHE_SERVICE_LABEL), func
 				}),
 			).To(BeAssignableToTypeOf(&GetMiss{}))
 		},
-		Entry("when the key and value are strings", DefaultClient, NewStringKey(), String("value"), "value", []byte("value")),
-		Entry("when the key and value are bytes", DefaultClient, NewByteKey(), Bytes("string"), "string", []byte("string")),
-		Entry("when the value is empty", DefaultClient, NewStringKey(), String(""), "", []byte("")),
-		Entry("when the value is blank", DefaultClient, NewStringKey(), String("  "), "  ", []byte("  ")),
-		Entry("with default cache name when the key and value are strings", WithDefaultCache, NewStringKey(), String("value"), "value", []byte("value")),
-		Entry("with default cache name when the key and value are bytes", WithDefaultCache, NewByteKey(), Bytes("string"), "string", []byte("string")),
-		Entry("with default cache name when the value is empty", WithDefaultCache, NewStringKey(), String(""), "", []byte("")),
-		Entry("with default cache name when the value is blank", WithDefaultCache, NewStringKey(), String("  "), "  ", []byte("  ")),
-		Entry("using a consistent read concern client", WithConsistentReadConcern, NewStringKey(), String("value"), "value", []byte("value")),
-		Entry("using a balanced read concern client", DefaultClient, NewByteKey(), Bytes("string"), "string", []byte("string")),
+		Entry("when the key and value are strings", DefaultClient, NewRandomMomentoString(), String("value"), "value", []byte("value")),
+		Entry("when the key and value are bytes", DefaultClient, NewRandomMomentoBytes(), Bytes("string"), "string", []byte("string")),
+		Entry("when the value is empty", DefaultClient, NewRandomMomentoString(), String(""), "", []byte("")),
+		Entry("when the value is blank", DefaultClient, NewRandomMomentoString(), String("  "), "  ", []byte("  ")),
+		Entry("with default cache name when the key and value are strings", WithDefaultCache, NewRandomMomentoString(), String("value"), "value", []byte("value")),
+		Entry("with default cache name when the key and value are bytes", WithDefaultCache, NewRandomMomentoBytes(), Bytes("string"), "string", []byte("string")),
+		Entry("with default cache name when the value is empty", WithDefaultCache, NewRandomMomentoString(), String(""), "", []byte("")),
+		Entry("with default cache name when the value is blank", WithDefaultCache, NewRandomMomentoString(), String("  "), "  ", []byte("  ")),
+		Entry("using a consistent read concern client", WithConsistentReadConcern, NewRandomMomentoString(), String("value"), "value", []byte("value")),
+		Entry("using a balanced read concern client", DefaultClient, NewRandomMomentoBytes(), Bytes("string"), "string", []byte("string")),
 	)
 
 	DescribeTable("Set if not exists",
@@ -133,14 +133,14 @@ var _ = Describe("cache-client scalar-methods", Label(CACHE_SERVICE_LABEL), func
 				}),
 			).To(BeAssignableToTypeOf(&GetMiss{}))
 		},
-		Entry("when the key and value are strings", DefaultClient, NewStringKey(), String("value"), "value", []byte("value")),
-		Entry("when the key and value are bytes", DefaultClient, NewByteKey(), Bytes("string"), "string", []byte("string")),
-		Entry("when the value is empty", DefaultClient, NewStringKey(), String(""), "", []byte("")),
-		Entry("when the value is blank", DefaultClient, NewStringKey(), String("  "), "  ", []byte("  ")),
-		Entry("with default cache name when the key and value are strings", WithDefaultCache, NewStringKey(), String("value"), "value", []byte("value")),
-		Entry("with default cache name when the key and value are bytes", WithDefaultCache, NewByteKey(), Bytes("string"), "string", []byte("string")),
-		Entry("with default cache name when the value is empty", WithDefaultCache, NewStringKey(), String(""), "", []byte("")),
-		Entry("with default cache name when the value is blank", WithDefaultCache, NewStringKey(), String("  "), "  ", []byte("  ")),
+		Entry("when the key and value are strings", DefaultClient, NewRandomMomentoString(), String("value"), "value", []byte("value")),
+		Entry("when the key and value are bytes", DefaultClient, NewRandomMomentoBytes(), Bytes("string"), "string", []byte("string")),
+		Entry("when the value is empty", DefaultClient, NewRandomMomentoString(), String(""), "", []byte("")),
+		Entry("when the value is blank", DefaultClient, NewRandomMomentoString(), String("  "), "  ", []byte("  ")),
+		Entry("with default cache name when the key and value are strings", WithDefaultCache, NewRandomMomentoString(), String("value"), "value", []byte("value")),
+		Entry("with default cache name when the key and value are bytes", WithDefaultCache, NewRandomMomentoBytes(), Bytes("string"), "string", []byte("string")),
+		Entry("with default cache name when the value is empty", WithDefaultCache, NewRandomMomentoString(), String(""), "", []byte("")),
+		Entry("with default cache name when the value is blank", WithDefaultCache, NewRandomMomentoString(), String("  "), "  ", []byte("  ")),
 	)
 
 	DescribeTable("Set if present",
@@ -189,14 +189,14 @@ var _ = Describe("cache-client scalar-methods", Label(CACHE_SERVICE_LABEL), func
 				Fail("Unexpected type from Get")
 			}
 		},
-		Entry("when the key and value are strings", DefaultClient, NewStringKey(), String("value"), "value", []byte("value")),
-		Entry("when the key and value are bytes", DefaultClient, NewByteKey(), Bytes("string"), "string", []byte("string")),
-		Entry("when the value is empty", DefaultClient, NewStringKey(), String(""), "", []byte("")),
-		Entry("when the value is blank", DefaultClient, NewStringKey(), String("  "), "  ", []byte("  ")),
-		Entry("with default cache name when the key and value are strings", WithDefaultCache, NewStringKey(), String("value"), "value", []byte("value")),
-		Entry("with default cache name when the key and value are bytes", WithDefaultCache, NewByteKey(), Bytes("string"), "string", []byte("string")),
-		Entry("with default cache name when the value is empty", WithDefaultCache, NewStringKey(), String(""), "", []byte("")),
-		Entry("with default cache name when the value is blank", WithDefaultCache, NewStringKey(), String("  "), "  ", []byte("  ")),
+		Entry("when the key and value are strings", DefaultClient, NewRandomMomentoString(), String("value"), "value", []byte("value")),
+		Entry("when the key and value are bytes", DefaultClient, NewRandomMomentoBytes(), Bytes("string"), "string", []byte("string")),
+		Entry("when the value is empty", DefaultClient, NewRandomMomentoString(), String(""), "", []byte("")),
+		Entry("when the value is blank", DefaultClient, NewRandomMomentoString(), String("  "), "  ", []byte("  ")),
+		Entry("with default cache name when the key and value are strings", WithDefaultCache, NewRandomMomentoString(), String("value"), "value", []byte("value")),
+		Entry("with default cache name when the key and value are bytes", WithDefaultCache, NewRandomMomentoBytes(), Bytes("string"), "string", []byte("string")),
+		Entry("with default cache name when the value is empty", WithDefaultCache, NewRandomMomentoString(), String(""), "", []byte("")),
+		Entry("with default cache name when the value is blank", WithDefaultCache, NewRandomMomentoString(), String("  "), "  ", []byte("  ")),
 	)
 
 	DescribeTable("Set if absent",
@@ -253,14 +253,14 @@ var _ = Describe("cache-client scalar-methods", Label(CACHE_SERVICE_LABEL), func
 				Fail("Unexpected type from Get")
 			}
 		},
-		Entry("when the key and value are strings", DefaultClient, NewStringKey(), String("value"), "value", []byte("value")),
-		Entry("when the key and value are bytes", DefaultClient, NewByteKey(), Bytes("string"), "string", []byte("string")),
-		Entry("when the value is empty", DefaultClient, NewStringKey(), String(""), "", []byte("")),
-		Entry("when the value is blank", DefaultClient, NewStringKey(), String("  "), "  ", []byte("  ")),
-		Entry("with default cache name when the key and value are strings", WithDefaultCache, NewStringKey(), String("value"), "value", []byte("value")),
-		Entry("with default cache name when the key and value are bytes", WithDefaultCache, NewByteKey(), Bytes("string"), "string", []byte("string")),
-		Entry("with default cache name when the value is empty", WithDefaultCache, NewStringKey(), String(""), "", []byte("")),
-		Entry("with default cache name when the value is blank", WithDefaultCache, NewStringKey(), String("  "), "  ", []byte("  ")),
+		Entry("when the key and value are strings", DefaultClient, NewRandomMomentoString(), String("value"), "value", []byte("value")),
+		Entry("when the key and value are bytes", DefaultClient, NewRandomMomentoBytes(), Bytes("string"), "string", []byte("string")),
+		Entry("when the value is empty", DefaultClient, NewRandomMomentoString(), String(""), "", []byte("")),
+		Entry("when the value is blank", DefaultClient, NewRandomMomentoString(), String("  "), "  ", []byte("  ")),
+		Entry("with default cache name when the key and value are strings", WithDefaultCache, NewRandomMomentoString(), String("value"), "value", []byte("value")),
+		Entry("with default cache name when the key and value are bytes", WithDefaultCache, NewRandomMomentoBytes(), Bytes("string"), "string", []byte("string")),
+		Entry("with default cache name when the value is empty", WithDefaultCache, NewRandomMomentoString(), String(""), "", []byte("")),
+		Entry("with default cache name when the value is blank", WithDefaultCache, NewRandomMomentoString(), String("  "), "  ", []byte("  ")),
 	)
 
 	DescribeTable("Set if present and not equal",
@@ -332,14 +332,14 @@ var _ = Describe("cache-client scalar-methods", Label(CACHE_SERVICE_LABEL), func
 			})
 			Expect(err).To(HaveMomentoErrorCode(InvalidArgumentError))
 		},
-		Entry("when the key and value are strings", DefaultClient, NewStringKey(), String("value"), "value", []byte("value")),
-		Entry("when the key and value are bytes", DefaultClient, NewByteKey(), Bytes("string"), "string", []byte("string")),
-		Entry("when the value is empty", DefaultClient, NewStringKey(), String(""), "", []byte("")),
-		Entry("when the value is blank", DefaultClient, NewStringKey(), String("  "), "  ", []byte("  ")),
-		Entry("with default cache name when the key and value are strings", WithDefaultCache, NewStringKey(), String("value"), "value", []byte("value")),
-		Entry("with default cache name when the key and value are bytes", WithDefaultCache, NewByteKey(), Bytes("string"), "string", []byte("string")),
-		Entry("with default cache name when the value is empty", WithDefaultCache, NewStringKey(), String(""), "", []byte("")),
-		Entry("with default cache name when the value is blank", WithDefaultCache, NewStringKey(), String("  "), "  ", []byte("  ")),
+		Entry("when the key and value are strings", DefaultClient, NewRandomMomentoString(), String("value"), "value", []byte("value")),
+		Entry("when the key and value are bytes", DefaultClient, NewRandomMomentoBytes(), Bytes("string"), "string", []byte("string")),
+		Entry("when the value is empty", DefaultClient, NewRandomMomentoString(), String(""), "", []byte("")),
+		Entry("when the value is blank", DefaultClient, NewRandomMomentoString(), String("  "), "  ", []byte("  ")),
+		Entry("with default cache name when the key and value are strings", WithDefaultCache, NewRandomMomentoString(), String("value"), "value", []byte("value")),
+		Entry("with default cache name when the key and value are bytes", WithDefaultCache, NewRandomMomentoBytes(), Bytes("string"), "string", []byte("string")),
+		Entry("with default cache name when the value is empty", WithDefaultCache, NewRandomMomentoString(), String(""), "", []byte("")),
+		Entry("with default cache name when the value is blank", WithDefaultCache, NewRandomMomentoString(), String("  "), "  ", []byte("  ")),
 	)
 
 	DescribeTable("Set if equal",
@@ -412,14 +412,14 @@ var _ = Describe("cache-client scalar-methods", Label(CACHE_SERVICE_LABEL), func
 			Expect(err).To(HaveMomentoErrorCode(InvalidArgumentError))
 
 		},
-		Entry("when the key and value are strings", DefaultClient, NewStringKey(), String("value"), "value", []byte("value")),
-		Entry("when the key and value are bytes", DefaultClient, NewByteKey(), Bytes("string"), "string", []byte("string")),
-		Entry("when the value is empty", DefaultClient, NewStringKey(), String(""), "", []byte("")),
-		Entry("when the value is blank", DefaultClient, NewStringKey(), String("  "), "  ", []byte("  ")),
-		Entry("with default cache name when the key and value are strings", WithDefaultCache, NewStringKey(), String("value"), "value", []byte("value")),
-		Entry("with default cache name when the key and value are bytes", WithDefaultCache, NewByteKey(), Bytes("string"), "string", []byte("string")),
-		Entry("with default cache name when the value is empty", WithDefaultCache, NewStringKey(), String(""), "", []byte("")),
-		Entry("with default cache name when the value is blank", WithDefaultCache, NewStringKey(), String("  "), "  ", []byte("  ")),
+		Entry("when the key and value are strings", DefaultClient, NewRandomMomentoString(), String("value"), "value", []byte("value")),
+		Entry("when the key and value are bytes", DefaultClient, NewRandomMomentoBytes(), Bytes("string"), "string", []byte("string")),
+		Entry("when the value is empty", DefaultClient, NewRandomMomentoString(), String(""), "", []byte("")),
+		Entry("when the value is blank", DefaultClient, NewRandomMomentoString(), String("  "), "  ", []byte("  ")),
+		Entry("with default cache name when the key and value are strings", WithDefaultCache, NewRandomMomentoString(), String("value"), "value", []byte("value")),
+		Entry("with default cache name when the key and value are bytes", WithDefaultCache, NewRandomMomentoBytes(), Bytes("string"), "string", []byte("string")),
+		Entry("with default cache name when the value is empty", WithDefaultCache, NewRandomMomentoString(), String(""), "", []byte("")),
+		Entry("with default cache name when the value is blank", WithDefaultCache, NewRandomMomentoString(), String("  "), "  ", []byte("  ")),
 	)
 
 	DescribeTable("Set if absent or equal",
@@ -496,14 +496,14 @@ var _ = Describe("cache-client scalar-methods", Label(CACHE_SERVICE_LABEL), func
 			Expect(err).To(HaveMomentoErrorCode(InvalidArgumentError))
 
 		},
-		Entry("when the key and value are strings", DefaultClient, NewStringKey(), String("value"), "value", []byte("value")),
-		Entry("when the key and value are bytes", DefaultClient, NewByteKey(), Bytes("string"), "string", []byte("string")),
-		Entry("when the value is empty", DefaultClient, NewStringKey(), String(""), "", []byte("")),
-		Entry("when the value is blank", DefaultClient, NewStringKey(), String("  "), "  ", []byte("  ")),
-		Entry("with default cache name when the key and value are strings", WithDefaultCache, NewStringKey(), String("value"), "value", []byte("value")),
-		Entry("with default cache name when the key and value are bytes", WithDefaultCache, NewByteKey(), Bytes("string"), "string", []byte("string")),
-		Entry("with default cache name when the value is empty", WithDefaultCache, NewStringKey(), String(""), "", []byte("")),
-		Entry("with default cache name when the value is blank", WithDefaultCache, NewStringKey(), String("  "), "  ", []byte("  ")),
+		Entry("when the key and value are strings", DefaultClient, NewRandomMomentoString(), String("value"), "value", []byte("value")),
+		Entry("when the key and value are bytes", DefaultClient, NewRandomMomentoBytes(), Bytes("string"), "string", []byte("string")),
+		Entry("when the value is empty", DefaultClient, NewRandomMomentoString(), String(""), "", []byte("")),
+		Entry("when the value is blank", DefaultClient, NewRandomMomentoString(), String("  "), "  ", []byte("  ")),
+		Entry("with default cache name when the key and value are strings", WithDefaultCache, NewRandomMomentoString(), String("value"), "value", []byte("value")),
+		Entry("with default cache name when the key and value are bytes", WithDefaultCache, NewRandomMomentoBytes(), Bytes("string"), "string", []byte("string")),
+		Entry("with default cache name when the value is empty", WithDefaultCache, NewRandomMomentoString(), String(""), "", []byte("")),
+		Entry("with default cache name when the value is blank", WithDefaultCache, NewRandomMomentoString(), String("  "), "  ", []byte("  ")),
 	)
 
 	DescribeTable("Set if not equal",
@@ -580,21 +580,21 @@ var _ = Describe("cache-client scalar-methods", Label(CACHE_SERVICE_LABEL), func
 			Expect(err).To(HaveMomentoErrorCode(InvalidArgumentError))
 
 		},
-		Entry("when the key and value are strings", DefaultClient, NewStringKey(), String("value"), "value", []byte("value")),
-		Entry("when the key and value are bytes", DefaultClient, NewByteKey(), Bytes("string"), "string", []byte("string")),
-		Entry("when the value is empty", DefaultClient, NewStringKey(), String(""), "", []byte("")),
-		Entry("when the value is blank", DefaultClient, NewStringKey(), String("  "), "  ", []byte("  ")),
-		Entry("with default cache name when the key and value are strings", WithDefaultCache, NewStringKey(), String("value"), "value", []byte("value")),
-		Entry("with default cache name when the key and value are bytes", WithDefaultCache, NewByteKey(), Bytes("string"), "string", []byte("string")),
-		Entry("with default cache name when the value is empty", WithDefaultCache, NewStringKey(), String(""), "", []byte("")),
-		Entry("with default cache name when the value is blank", WithDefaultCache, NewStringKey(), String("  "), "  ", []byte("  ")),
+		Entry("when the key and value are strings", DefaultClient, NewRandomMomentoString(), String("value"), "value", []byte("value")),
+		Entry("when the key and value are bytes", DefaultClient, NewRandomMomentoBytes(), Bytes("string"), "string", []byte("string")),
+		Entry("when the value is empty", DefaultClient, NewRandomMomentoString(), String(""), "", []byte("")),
+		Entry("when the value is blank", DefaultClient, NewRandomMomentoString(), String("  "), "  ", []byte("  ")),
+		Entry("with default cache name when the key and value are strings", WithDefaultCache, NewRandomMomentoString(), String("value"), "value", []byte("value")),
+		Entry("with default cache name when the key and value are bytes", WithDefaultCache, NewRandomMomentoBytes(), Bytes("string"), "string", []byte("string")),
+		Entry("with default cache name when the value is empty", WithDefaultCache, NewRandomMomentoString(), String(""), "", []byte("")),
+		Entry("with default cache name when the value is blank", WithDefaultCache, NewRandomMomentoString(), String("  "), "  ", []byte("  ")),
 	)
 
 	DescribeTable("errors when the cache is missing",
 		func(clientType string) {
 			client, _ := sharedContext.GetClientPrereqsForType(clientType)
 			cacheName := uuid.NewString()
-			key := NewStringKey()
+			key := NewRandomMomentoString()
 			value := String("value")
 
 			getResp, err := client.Get(sharedContext.Ctx, &GetRequest{
@@ -655,7 +655,7 @@ var _ = Describe("cache-client scalar-methods", Label(CACHE_SERVICE_LABEL), func
 			Expect(
 				client.Get(sharedContext.Ctx, &GetRequest{
 					CacheName: cacheName,
-					Key:       NewStringKey(),
+					Key:       NewRandomMomentoString(),
 				}),
 			).To(BeAssignableToTypeOf(&GetMiss{}))
 		},
@@ -688,16 +688,16 @@ var _ = Describe("cache-client scalar-methods", Label(CACHE_SERVICE_LABEL), func
 			Expect(deleteResp).To(BeNil())
 			Expect(err).To(HaveMomentoErrorCode(InvalidArgumentError))
 		},
-		Entry("With default client and an empty cache name", DefaultClient, "", NewStringKey(), String("value")),
-		Entry("With default client and  an bank cache name", DefaultClient, "   ", NewStringKey(), String("value")),
+		Entry("With default client and an empty cache name", DefaultClient, "", NewRandomMomentoString(), String("value")),
+		Entry("With default client and  an bank cache name", DefaultClient, "   ", NewRandomMomentoString(), String("value")),
 		Entry("With default client and  an empty key", DefaultClient, uuid.NewString(), String(""), String("value")),
-		Entry("With client with default cache and an bank cache name", WithDefaultCache, "   ", NewStringKey(), String("value")),
+		Entry("With client with default cache and an bank cache name", WithDefaultCache, "   ", NewRandomMomentoString(), String("value")),
 		Entry("With client with default cache and an empty key", WithDefaultCache, uuid.NewString(), String(""), String("value")),
 	)
 
 	Describe("Set", func() {
 		It("Uses the default TTL", func() {
-			key := NewStringKey()
+			key := NewRandomMomentoString()
 			value := String("value")
 
 			Expect(
@@ -728,7 +728,7 @@ var _ = Describe("cache-client scalar-methods", Label(CACHE_SERVICE_LABEL), func
 		})
 
 		It("Overrides the default TTL", func() {
-			key := NewStringKey()
+			key := NewRandomMomentoString()
 			value := String("value")
 
 			Expect(
@@ -769,7 +769,7 @@ var _ = Describe("cache-client scalar-methods", Label(CACHE_SERVICE_LABEL), func
 		})
 
 		It("Overrides the default TTL without unit and invalid", func() {
-			key := NewStringKey()
+			key := NewRandomMomentoString()
 			value := String("value")
 
 			resp, err := sharedContext.Client.Set(sharedContext.Ctx, &SetRequest{
@@ -791,7 +791,7 @@ var _ = Describe("cache-client scalar-methods", Label(CACHE_SERVICE_LABEL), func
 		})
 
 		It("returns an error for a nil value", func() {
-			key := NewStringKey()
+			key := NewRandomMomentoString()
 			Expect(
 				sharedContext.Client.Set(sharedContext.Ctx, &SetRequest{
 					CacheName: sharedContext.CacheName,
@@ -851,7 +851,7 @@ var _ = Describe("cache-client scalar-methods", Label(CACHE_SERVICE_LABEL), func
 		DescribeTable("Overwrites Ttl",
 			func(clientType string) {
 				client, cacheName := sharedContext.GetClientPrereqsForType(clientType)
-				key := NewStringKey()
+				key := NewRandomMomentoString()
 				value := String("value")
 
 				Expect(
@@ -886,7 +886,7 @@ var _ = Describe("cache-client scalar-methods", Label(CACHE_SERVICE_LABEL), func
 		DescribeTable("Increases Ttl",
 			func(clientType string) {
 				client, cacheName := sharedContext.GetClientPrereqsForType(clientType)
-				key := NewStringKey()
+				key := NewRandomMomentoString()
 				value := String("value")
 
 				Expect(
@@ -923,7 +923,7 @@ var _ = Describe("cache-client scalar-methods", Label(CACHE_SERVICE_LABEL), func
 			func(clientType string) {
 				client, cacheName := sharedContext.GetClientPrereqsForType(clientType)
 
-				key := NewStringKey()
+				key := NewRandomMomentoString()
 				value := String("value")
 
 				Expect(
@@ -956,7 +956,7 @@ var _ = Describe("cache-client scalar-methods", Label(CACHE_SERVICE_LABEL), func
 		)
 
 		It("Returns InvalidArgumentError with negative or zero Ttl value for UpdateTtl", func() {
-			key := NewStringKey()
+			key := NewRandomMomentoString()
 			value := String("value")
 
 			Expect(
@@ -985,7 +985,7 @@ var _ = Describe("cache-client scalar-methods", Label(CACHE_SERVICE_LABEL), func
 		})
 
 		It("Returns InvalidArgumentError with negative or zero Ttl value for IncreaseTtl", func() {
-			key := NewStringKey()
+			key := NewRandomMomentoString()
 			value := String("value")
 
 			Expect(
@@ -1014,7 +1014,7 @@ var _ = Describe("cache-client scalar-methods", Label(CACHE_SERVICE_LABEL), func
 		})
 
 		It("Returns InvalidArgumentError with negative or zero Ttl value for DecreaseTtl", func() {
-			key := NewStringKey()
+			key := NewRandomMomentoString()
 			value := String("value")
 
 			Expect(
@@ -1127,7 +1127,7 @@ var _ = Describe("cache-client scalar-methods", Label(CACHE_SERVICE_LABEL), func
 		})
 
 		It("Increments from 0 to expected amount with bytes field", func() {
-			field := NewByteKey()
+			field := NewRandomMomentoBytes()
 
 			resp, err := sharedContext.Client.Increment(sharedContext.Ctx, &IncrementRequest{
 				CacheName: sharedContext.CacheName,

--- a/momento/test_helpers/utils.go
+++ b/momento/test_helpers/utils.go
@@ -5,10 +5,14 @@ import (
 	"github.com/momentohq/client-sdk-go/momento"
 )
 
-func NewStringKey() momento.String {
-	return momento.String(uuid.NewString())
+func NewRandomString() string {
+	return uuid.NewString()
 }
 
-func NewByteKey() momento.Bytes {
+func NewRandomMomentoString() momento.String {
+	return momento.String(NewRandomString())
+}
+
+func NewRandomMomentoBytes() momento.Bytes {
 	return momento.Bytes([]byte(uuid.NewString()))
 }


### PR DESCRIPTION
Some of the tests weren't using unique test keys. We fix where appropriate. The collection tests still scope a collection name too broadly; we fix the dictionary tests and leave the other collections for future PRs. Importantly we fix the `item get type` and `item get ttl` tests to use unique keys.