### PR TITLE
chore: debug canary tests

### DIFF
--- a/momento/scalar_test.go
+++ b/momento/scalar_test.go
@@ -1322,6 +1322,8 @@ var _ = Describe("cache-client scalar-methods", Label(CACHE_SERVICE_LABEL), func
 				Ttl:       ttl,
 			})
 			Expect(err).To(BeNil())
+			// Small delay to allow for processing time
+			time.Sleep(time.Millisecond * 10)
 			resp, err := sharedContext.Client.ItemGetTtl(sharedContext.Ctx, &ItemGetTtlRequest{
 				CacheName: sharedContext.CacheName,
 				Key:       key,
@@ -1330,7 +1332,11 @@ var _ = Describe("cache-client scalar-methods", Label(CACHE_SERVICE_LABEL), func
 			Expect(resp).To(BeAssignableToTypeOf(&ItemGetTtlHit{}))
 			switch result := resp.(type) {
 			case *ItemGetTtlHit:
-				Expect(ttl > result.RemainingTtl()).To(BeTrue())
+				fmt.Println(`original ttl`, ttl)
+				fmt.Println(`result.RemainingTtl()`, result.RemainingTtl())
+				const gracePeriod = time.Millisecond * 50
+				// Expect remaining TTL to be less than the original TTL (with grace period)
+				Expect(ttl-gracePeriod > result.RemainingTtl()).To(BeTrue())
 				Expect(result.RemainingTtl() > (time.Second * 30)).To(BeTrue())
 			default:
 				Fail(fmt.Sprintf("expected ItemGetTtlHit but got %s", result))

--- a/momento/scalar_test.go
+++ b/momento/scalar_test.go
@@ -1322,8 +1322,7 @@ var _ = Describe("cache-client scalar-methods", Label(CACHE_SERVICE_LABEL), func
 				Ttl:       ttl,
 			})
 			Expect(err).To(BeNil())
-			// Small delay to allow for processing time
-			time.Sleep(time.Millisecond * 10)
+
 			resp, err := sharedContext.Client.ItemGetTtl(sharedContext.Ctx, &ItemGetTtlRequest{
 				CacheName: sharedContext.CacheName,
 				Key:       key,
@@ -1332,11 +1331,8 @@ var _ = Describe("cache-client scalar-methods", Label(CACHE_SERVICE_LABEL), func
 			Expect(resp).To(BeAssignableToTypeOf(&ItemGetTtlHit{}))
 			switch result := resp.(type) {
 			case *ItemGetTtlHit:
-				fmt.Println(`original ttl`, ttl)
-				fmt.Println(`result.RemainingTtl()`, result.RemainingTtl())
-				const gracePeriod = time.Millisecond * 50
-				// Expect remaining TTL to be less than the original TTL (with grace period)
-				Expect(ttl-gracePeriod > result.RemainingTtl()).To(BeTrue())
+				fmt.Printf("Original TTL: %v, Remaining TTL: %v\n", ttl, result.RemainingTtl())
+				Expect(result.RemainingTtl()).To(BeNumerically("<", ttl))
 				Expect(result.RemainingTtl() > (time.Second * 30)).To(BeTrue())
 			default:
 				Fail(fmt.Sprintf("expected ItemGetTtlHit but got %s", result))

--- a/momento/topic_client_test.go
+++ b/momento/topic_client_test.go
@@ -158,11 +158,12 @@ var _ = Describe("topic-client", Label(TOPICS_SERVICE_LABEL), func() {
 		// Collect only TopicItem events for comparison
 		receivedTopicItems := []TopicItem{}
 		for _, receivedItem := range receivedItems {
-			if r, ok := receivedItem.(TopicItem); ok {
+			switch r := receivedItem.(type) {
+			case TopicItem:
 				receivedTopicItems = append(receivedTopicItems, r)
-			} else if _, ok := receivedItem.(TopicHeartbeat); ok {
+			case TopicHeartbeat:
 				numberOfHeartbeats++
-			} else if _, ok := receivedItem.(TopicDiscontinuity); ok {
+			case TopicDiscontinuity:
 				numberOfDiscontinuities++
 			}
 		}


### PR DESCRIPTION
## PR Description:

`**Test: [topics-service] "Publishes and receives detailed subscription items":**`
The test is failing because it's comparing the first received value (aaa) against the second expected value ([1, 2, 3]), which is causing the mismatch. This mismatch is likely because we have extra non-published items, such as a heartbeat, being included in the receivedItems array. The key issue is that we are not filtering out non-TopicItem events (e.g., TopicHeartbeat, TopicDiscontinuity) before doing the comparison with expectedValues.

Hence, this commit compares only the received **TopicItem values** to the expectedValues. 



`**Test: [cache-service][scalar-tests] "accurately reports the remaining TTL for a key":**`
My hunch is that it can be either of the 3 issues:
1. The TTL might not be exactly what is expected due to small timing discrepancies between setting the TTL and when it is retrieved. This might happen due to network latency or minor processing delays.
2. If ItemGetTtl is called immediately after setting the key, there may be too little difference between the ttl and RemainingTtl(), causing the comparison to fail.
3. If the system clocks between the client and server are not perfectly synchronized, it can cause discrepancies (maybe?)

I also found that gingko has an inbuilt  `BeNumerically` matcher, which is designed specifically to compare numerical values. So, instead of manual boolean checker, using inbuilt matcher to compare original ttl with remaining ttl. 
