### PR TITLE
fix: remaining ttl <= ttl

### DIFF
--- a/momento/scalar_test.go
+++ b/momento/scalar_test.go
@@ -1332,7 +1332,7 @@ var _ = Describe("cache-client scalar-methods", Label(CACHE_SERVICE_LABEL), func
 			switch result := resp.(type) {
 			case *ItemGetTtlHit:
 				fmt.Printf("Original TTL: %v, Remaining TTL: %v\n", ttl, result.RemainingTtl())
-				Expect(result.RemainingTtl()).To(BeNumerically("<", ttl))
+				Expect(result.RemainingTtl()).To(BeNumerically("<=", ttl))
 				Expect(result.RemainingTtl() > (time.Second * 30)).To(BeTrue())
 			default:
 				Fail(fmt.Sprintf("expected ItemGetTtlHit but got %s", result))


### PR DESCRIPTION
## PR Description:
Yesterday, I added logging ([PR](https://github.com/momentohq/client-sdk-go/pull/494)) to the cache service scalar test: `accurately reports the remaining TTL for a key` which was failing in go-lang canaries. 
Today, it failed again and I noticed that in the canary environment, original and remaining ttl are exactly equal:
`Original TTL: 2m0s, Remaining TTL: 2m0s`. Therefore, this commit asserts that remaining ttl is `<=` rather than `<` to originally set ttl. 