### PR TITLE
chore: add logging to failing canary tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ install-devtools: install-ginkgo
 
 install-ginkgo:
 	@echo "Installing ginkgo..."
-	@go install github.com/onsi/ginkgo/v2/ginkgo@latest
+	@go install github.com/onsi/ginkgo/v2/ginkgo@v2.8.1
 
 format:
 	@echo "Formatting code..."

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ install-devtools: install-ginkgo
 
 install-ginkgo:
 	@echo "Installing ginkgo..."
-	@go install github.com/onsi/ginkgo/v2/ginkgo@v2.8.1
+	@go install github.com/onsi/ginkgo/v2/ginkgo@latest
 
 format:
 	@echo "Formatting code..."

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ GINKGO_OPTS = --no-color -v
 
 install-devtools: install-ginkgo
 	@echo "Installing dev tools..."
-	go install golang.org/x/tools/cmd/goimports@latest
+	go install golang.org/x/tools/cmd/goimports@v0.24.0
 	go install honnef.co/go/tools/cmd/staticcheck@v0.4.7
 
 

--- a/momento/scalar_test.go
+++ b/momento/scalar_test.go
@@ -91,7 +91,7 @@ var _ = Describe("cache-client scalar-methods", Label(CACHE_SERVICE_LABEL), func
 				Expect(result.ValueByte()).To(Equal(expectedBytes))
 				Expect(result.ValueString()).To(Equal(expectedString))
 			default:
-				Fail("Unexpected type from Get")
+				Fail(fmt.Sprintf("Expected GetHit, got: %T, %v", result, result))
 			}
 
 			// we make another call and make sure that the value is not stored again
@@ -117,7 +117,8 @@ var _ = Describe("cache-client scalar-methods", Label(CACHE_SERVICE_LABEL), func
 				Expect(result.ValueByte()).To(Equal(expectedBytes))
 				Expect(result.ValueString()).To(Equal(expectedString))
 			default:
-				Fail("Unexpected type from Get")
+				Fail(fmt.Sprintf("Expected GetHit, got: %T, %v", result, result))
+
 			}
 
 			Expect(
@@ -187,7 +188,7 @@ var _ = Describe("cache-client scalar-methods", Label(CACHE_SERVICE_LABEL), func
 				Expect(result.ValueByte()).To(Equal(expectedBytes))
 				Expect(result.ValueString()).To(Equal(expectedString))
 			default:
-				Fail("Unexpected type from Get")
+				Fail(fmt.Sprintf("Expected GetHit, got: %T, %v", result, result))
 			}
 		},
 		Entry("when the key and value are strings", DefaultClient, NewRandomMomentoString(), String("value"), "value", []byte("value")),
@@ -225,7 +226,7 @@ var _ = Describe("cache-client scalar-methods", Label(CACHE_SERVICE_LABEL), func
 				Expect(result.ValueByte()).To(Equal(expectedBytes))
 				Expect(result.ValueString()).To(Equal(expectedString))
 			default:
-				Fail("Unexpected type from Get")
+				Fail(fmt.Sprintf("Expected GetHit, got: %T, %v", result, result))
 			}
 
 			// we make another call and make sure that the value is not stored again
@@ -251,7 +252,7 @@ var _ = Describe("cache-client scalar-methods", Label(CACHE_SERVICE_LABEL), func
 				Expect(result.ValueByte()).To(Equal(expectedBytes))
 				Expect(result.ValueString()).To(Equal(expectedString))
 			default:
-				Fail("Unexpected type from Get")
+				Fail(fmt.Sprintf("Expected GetHit, got: %T, %v", result, result))
 			}
 		},
 		Entry("when the key and value are strings", DefaultClient, NewRandomMomentoString(), String("value"), "value", []byte("value")),
@@ -322,7 +323,7 @@ var _ = Describe("cache-client scalar-methods", Label(CACHE_SERVICE_LABEL), func
 				Expect(result.ValueByte()).To(Equal(expectedBytes))
 				Expect(result.ValueString()).To(Equal(expectedString))
 			default:
-				Fail("Unexpected type from Get")
+				Fail(fmt.Sprintf("Expected GetHit, got: %T, %v", result, result))
 			}
 
 			// make sure we error when NotEqual is nil
@@ -401,7 +402,7 @@ var _ = Describe("cache-client scalar-methods", Label(CACHE_SERVICE_LABEL), func
 				Expect(result.ValueByte()).To(Equal(expectedBytes))
 				Expect(result.ValueString()).To(Equal(expectedString))
 			default:
-				Fail("Unexpected type from Get")
+				Fail(fmt.Sprintf("Expected GetHit, got: %T, %v", result, result))
 			}
 
 			// make sure we error when Equal is nil
@@ -448,7 +449,7 @@ var _ = Describe("cache-client scalar-methods", Label(CACHE_SERVICE_LABEL), func
 				Expect(result.ValueByte()).To(Equal(expectedBytes))
 				Expect(result.ValueString()).To(Equal(expectedString))
 			default:
-				Fail("Unexpected type from Get")
+				Fail(fmt.Sprintf("Expected GetHit, got: %T, %v", result, result))
 			}
 
 			// make sure we don't overwrite the value when current value is different from Equal
@@ -485,7 +486,7 @@ var _ = Describe("cache-client scalar-methods", Label(CACHE_SERVICE_LABEL), func
 			case *GetHit:
 				Expect(result.ValueString()).To(Equal("overwritten value"))
 			default:
-				Fail("Unexpected type from Get")
+				Fail(fmt.Sprintf("Expected GetHit, got: %T, %v", result, result))
 			}
 
 			// make sure we error when Equal is nil
@@ -532,7 +533,7 @@ var _ = Describe("cache-client scalar-methods", Label(CACHE_SERVICE_LABEL), func
 				Expect(result.ValueByte()).To(Equal(expectedBytes))
 				Expect(result.ValueString()).To(Equal(expectedString))
 			default:
-				Fail("Unexpected type from Get")
+				Fail(fmt.Sprintf("Expected GetHit, got: %T, %v", result, result))
 			}
 
 			// make sure we don't overwrite the value when current value is the same as from NotEqual
@@ -569,7 +570,7 @@ var _ = Describe("cache-client scalar-methods", Label(CACHE_SERVICE_LABEL), func
 			case *GetHit:
 				Expect(result.ValueString()).To(Equal("bingo!"))
 			default:
-				Fail("Unexpected type from Get")
+				Fail(fmt.Sprintf("Expected GetHit, got: %T, %v", result, result))
 			}
 
 			// make sure we error when Equal is nil

--- a/momento/scalar_test.go
+++ b/momento/scalar_test.go
@@ -36,6 +36,7 @@ var _ = Describe("cache-client scalar-methods", Label(CACHE_SERVICE_LABEL), func
 				Expect(result.ValueByte()).To(Equal(expectedBytes))
 				Expect(result.ValueString()).To(Equal(expectedString))
 			default:
+				fmt.Println(`Expected GetHit, got:`, result)
 				Fail("Unexpected type from Get")
 			}
 

--- a/momento/set_test.go
+++ b/momento/set_test.go
@@ -174,6 +174,7 @@ var _ = Describe("cache-client set-methods", Label(CACHE_SERVICE_LABEL), func() 
 					Expect(result.ValueString()).To(Equal(expectedStrings))
 					Expect(result.ValueByte()).To(Equal(expectedBytes))
 				default:
+					fmt.Println(`Expected SetFetchHit but got:`, result)
 					Fail("Unexpected result for Set Fetch")
 				}
 			},

--- a/momento/set_test.go
+++ b/momento/set_test.go
@@ -206,7 +206,7 @@ var _ = Describe("cache-client set-methods", Label(CACHE_SERVICE_LABEL), func() 
 					Expect(result.ValueString()).To(ConsistOf(expectedStrings))
 					Expect(result.ValueByte()).To(ConsistOf(expectedBytes))
 				default:
-					Fail("Unexpected results for Set Fetch")
+					Fail(fmt.Sprintf("Expected SetFetchHit, got: %T, %v", result, result))
 				}
 			},
 			Entry(
@@ -335,7 +335,7 @@ var _ = Describe("cache-client set-methods", Label(CACHE_SERVICE_LABEL), func() 
 				case *SetFetchHit:
 					Expect(result.ValueString()).ToNot(ContainElement(toRemove))
 				default:
-					Fail("something really weird happened")
+					Fail(fmt.Sprintf("Expected SetFetchHit, got: %T, %v", result, result))
 				}
 			},
 			Entry("with default client as string", DefaultClient, String("#5"), 9),
@@ -367,7 +367,7 @@ var _ = Describe("cache-client set-methods", Label(CACHE_SERVICE_LABEL), func() 
 				case *SetFetchHit:
 					Expect(result.ValueString()).ToNot(ContainElements(toRemove))
 				default:
-					Fail("something really weird happened")
+					Fail(fmt.Sprintf("Expected SetFetchHit, got: %T, %v", result, result))
 				}
 			},
 			Entry("with default client as strings", DefaultClient, getElements(5), 5),
@@ -425,7 +425,7 @@ var _ = Describe("cache-client set-methods", Label(CACHE_SERVICE_LABEL), func() 
 		case *SetLengthHit:
 			Expect(result.Length()).To(Equal(uint32(len(elements))))
 		default:
-			Fail("expected a hit for set length but got a miss")
+			Fail(fmt.Sprintf("Expected SetLengthHit, got: %T, %v", result, result))
 		}
 
 		resp, err = sharedContext.Client.SetLength(sharedContext.Ctx, &SetLengthRequest{
@@ -467,6 +467,8 @@ var _ = Describe("cache-client set-methods", Label(CACHE_SERVICE_LABEL), func() 
 				switch result := containsResp.(type) {
 				case *SetContainsElementsHit:
 					Expect(result.ContainsElements()).To(Equal(expected))
+				default:
+					Fail(fmt.Sprintf("Expected SetContainsElementsHit, got: %T, %v", result, result))
 				}
 			},
 			Entry("with default client all hits", DefaultClient, []Value{String("#1"), String("#2"), String("#3")}, []bool{true, true, true}),


### PR DESCRIPTION
## PR Description:
[Got error for unexpected results in cell-alpha-dev and cell-privatelink-alpha-dev on 09/10/24 ](https://momento.chronosphere.io/dashboards/canaries?start=3h). 

This commit 
- adds logging to the tests that were failing in the canary.
- pins down the goimports lib version instead of using latest because it was giving the following error in github ci:
 ```
Run make install-devtools
Installing ginkgo...
go: downloading github.com/onsi/ginkgo/v2 v2.8.1
go: downloading github.com/go-task/slim-sprig v0.0.0-202101071[6](https://github.com/momentohq/client-sdk-go/actions/runs/10798417463/job/29951871882#step:4:7)5309-348f09dbbbc0
go: downloading golang.org/x/tools v0.6.0
go: downloading github.com/google/pprof v0.0.0-2021040[7](https://github.com/momentohq/client-sdk-go/actions/runs/10798417463/job/29951871882#step:4:8)192527-94a9f03dee38
Installing dev tools...
go install golang.org/x/tools/cmd/goimports@latest
go: downloading golang.org/x/tools v0.25.0
go: golang.org/x/tools/cmd/goimports@latest (in golang.org/x/tools@v0.25.0): go.mod:3: invalid go version '1.22.0': must match format 1.23
make: *** [Makefile:[12](https://github.com/momentohq/client-sdk-go/actions/runs/10798417463/job/29951871882#step:4:13): install-devtools] Error 1
Error: Process completed with exit code 2.
```