### PR TITLE
chore: add epsilon sleep durations/reduce default ttl on tests

### DIFF
--- a/momento/batch_set_get_test.go
+++ b/momento/batch_set_get_test.go
@@ -108,7 +108,7 @@ var _ = Describe("cache-client get-batch set-batch", Label(CACHE_SERVICE_LABEL),
 			setBatchResp, setBatchErr := sharedContext.Client.SetBatch(sharedContext.Ctx, &SetBatchRequest{
 				CacheName: sharedContext.DefaultCacheName,
 				Items:     items,
-				Ttl:       1 * time.Second,
+				Ttl:       500 * time.Millisecond,
 			})
 			Expect(setBatchErr).To(BeNil())
 			Expect(setBatchResp).To(BeAssignableToTypeOf(responses.SetBatchSuccess{}))
@@ -118,7 +118,7 @@ var _ = Describe("cache-client get-batch set-batch", Label(CACHE_SERVICE_LABEL),
 				Expect(setResp).To(BeAssignableToTypeOf(&responses.SetSuccess{}))
 			}
 
-			time.Sleep(3 * time.Second)
+			time.Sleep(2 * time.Second)
 
 			getBatchResp, getBatchErr := sharedContext.Client.GetBatch(sharedContext.Ctx, &GetBatchRequest{
 				CacheName: sharedContext.DefaultCacheName,

--- a/momento/dictionary_test.go
+++ b/momento/dictionary_test.go
@@ -863,6 +863,7 @@ var _ = Describe("cache-client dictionary-methods", Label(CACHE_SERVICE_LABEL), 
 
 			It("returns a miss for the collection", func() {
 				dictionaryName := NewRandomString()
+				var cacheTtl = 500 * time.Millisecond
 				Expect(
 					sharedContext.Client.DictionarySetFields(sharedContext.Ctx, &DictionarySetFieldsRequest{
 						CacheName:      sharedContext.CacheName,
@@ -870,6 +871,9 @@ var _ = Describe("cache-client dictionary-methods", Label(CACHE_SERVICE_LABEL), 
 						Elements: DictionaryElementsFromMapStringValue(
 							map[string]Value{"myField1": String("myValue1"), "myField2": String("myValue2")},
 						),
+						Ttl: &CollectionTtl{
+							Ttl: cacheTtl,
+						},
 					}),
 				).Error().To(BeNil())
 
@@ -880,7 +884,7 @@ var _ = Describe("cache-client dictionary-methods", Label(CACHE_SERVICE_LABEL), 
 					}),
 				).To(BeAssignableToTypeOf(&DictionaryFetchHit{}))
 
-				time.Sleep(sharedContext.DefaultTtl)
+				time.Sleep(1 * time.Second)
 
 				Expect(
 					sharedContext.Client.DictionaryFetch(sharedContext.Ctx, &DictionaryFetchRequest{
@@ -938,6 +942,7 @@ var _ = Describe("cache-client dictionary-methods", Label(CACHE_SERVICE_LABEL), 
 
 			It("is ignored if refresh ttl is false", func() {
 				dictionaryName := NewRandomString()
+				var cacheTtl = 500 * time.Millisecond
 
 				// Create a new dictionary with a TTL
 				Expect(sharedContext.Client.DictionarySetFields(sharedContext.Ctx, &DictionarySetFieldsRequest{
@@ -947,7 +952,7 @@ var _ = Describe("cache-client dictionary-methods", Label(CACHE_SERVICE_LABEL), 
 						map[string]Value{"myField1": String("myValue1"), "myField2": String("myValue2")},
 					),
 					Ttl: &CollectionTtl{
-						Ttl:        sharedContext.DefaultTtl,
+						Ttl:        cacheTtl,
 						RefreshTtl: false,
 					},
 				})).To(BeAssignableToTypeOf(&DictionarySetFieldsSuccess{}))
@@ -960,13 +965,13 @@ var _ = Describe("cache-client dictionary-methods", Label(CACHE_SERVICE_LABEL), 
 						Field:          String("myField3"),
 						Value:          String("myValue3"),
 						Ttl: &CollectionTtl{
-							Ttl:        sharedContext.DefaultTtl + time.Second*60,
+							Ttl:        cacheTtl + time.Second*60,
 							RefreshTtl: false,
 						},
 					}),
 				).To(BeAssignableToTypeOf(&DictionarySetFieldSuccess{}))
 
-				time.Sleep(sharedContext.DefaultTtl)
+				time.Sleep(1 * time.Second)
 
 				Expect(
 					sharedContext.Client.DictionaryFetch(sharedContext.Ctx, &DictionaryFetchRequest{

--- a/momento/scalar_test.go
+++ b/momento/scalar_test.go
@@ -719,7 +719,7 @@ var _ = Describe("cache-client scalar-methods", Label(CACHE_SERVICE_LABEL), func
 				}),
 			).To(BeAssignableToTypeOf(&GetHit{}))
 
-			time.Sleep(sharedContext.DefaultTtl)
+			time.Sleep(sharedContext.DefaultTtl + 100*time.Millisecond)
 
 			Expect(
 				sharedContext.Client.Get(sharedContext.Ctx, &GetRequest{
@@ -760,7 +760,7 @@ var _ = Describe("cache-client scalar-methods", Label(CACHE_SERVICE_LABEL), func
 				}),
 			).To(BeAssignableToTypeOf(&GetHit{}))
 
-			time.Sleep(sharedContext.DefaultTtl)
+			time.Sleep(sharedContext.DefaultTtl + 100*time.Millisecond)
 
 			Expect(
 				sharedContext.Client.Get(sharedContext.Ctx, &GetRequest{
@@ -933,6 +933,7 @@ var _ = Describe("cache-client scalar-methods", Label(CACHE_SERVICE_LABEL), func
 						CacheName: cacheName,
 						Key:       key,
 						Value:     value,
+						Ttl:       4 * time.Second,
 					}),
 				).To(BeAssignableToTypeOf(&SetSuccess{}))
 
@@ -940,7 +941,7 @@ var _ = Describe("cache-client scalar-methods", Label(CACHE_SERVICE_LABEL), func
 					client.DecreaseTtl(sharedContext.Ctx, &DecreaseTtlRequest{
 						CacheName: cacheName,
 						Key:       key,
-						Ttl:       2 * time.Second,
+						Ttl:       1*time.Second + 500*time.Millisecond,
 					}),
 				).To(BeAssignableToTypeOf(&DecreaseTtlSet{}))
 

--- a/momento/set_test.go
+++ b/momento/set_test.go
@@ -499,6 +499,9 @@ var _ = Describe("cache-client set-methods", Label(CACHE_SERVICE_LABEL), func() 
 						CacheName: sharedContext.CacheName,
 						SetName:   setName,
 						Element:   String("hello"),
+						Ttl: &utils.CollectionTtl{
+							Ttl: 500 * time.Millisecond,
+						},
 					}),
 				).Error().To(BeNil())
 


### PR DESCRIPTION
## PR Description
This commit reduces the ttl on some of the tests. 
For the tests that verify default ttl, adding epsilon sleep durations.  