### PR TITLE
feat: improve logger interface to accept `any`

### DIFF
--- a/config/logger/momento-logger.go
+++ b/config/logger/momento-logger.go
@@ -1,11 +1,11 @@
 package logger
 
 type MomentoLogger interface {
-	Trace(message string, args ...string)
-	Debug(message string, args ...string)
-	Info(message string, args ...string)
-	Warn(message string, args ...string)
-	Error(message string, args ...string)
+	Trace(message string, args ...any)
+	Debug(message string, args ...any)
+	Info(message string, args ...any)
+	Warn(message string, args ...any)
+	Error(message string, args ...any)
 }
 
 type MomentoLoggerFactory interface {


### PR DESCRIPTION
The MomentoLogger interface currently only accepts `...string` arguments
for its varargs. These are intended to allow logger implementations to
interpolate the varargs into the template string using functions like
`fmt.Sprintf`, which support `...any` arguments.

The current interface is too restrictive and makes the logger more
difficult to use than it should be. This change will make it more
compatible with real production logging systems.
