### PR TITLE
chore: debug sorted fetch by rank - remove elements test

### DIFF
--- a/momento/sorted_set_test.go
+++ b/momento/sorted_set_test.go
@@ -1427,28 +1427,28 @@ var _ = Describe("cache-client sortedset-methods", Label(CACHE_SERVICE_LABEL), f
 					},
 				)
 
-				Expect(
-					client.SortedSetRemoveElements(
-						sharedContext.Ctx,
-						&SortedSetRemoveElementsRequest{
-							CacheName: cacheName,
-							SetName:   sortedSetName,
-							Values: []Value{
-								String("first"), String("dne"),
-							},
+				sortedSetRemoveElementsResponse, err := client.SortedSetRemoveElements(
+					sharedContext.Ctx,
+					&SortedSetRemoveElementsRequest{
+						CacheName: cacheName,
+						SetName:   sortedSetName,
+						Values: []Value{
+							String("first"), String("dne"),
 						},
-					),
-				).To(BeAssignableToTypeOf(&SortedSetRemoveElementsSuccess{}))
+					},
+				)
+				Expect(err).To(BeNil())
+				Expect(sortedSetRemoveElementsResponse).To(BeAssignableToTypeOf(&SortedSetRemoveElementsSuccess{}))
 
-				Expect(
-					client.SortedSetFetchByRank(
-						sharedContext.Ctx,
-						&SortedSetFetchByRankRequest{
-							CacheName: cacheName,
-							SetName:   sortedSetName,
-						},
-					),
-				).To(HaveSortedSetElements(
+				sortedFetchByRankResponse, err := client.SortedSetFetchByRank(
+					sharedContext.Ctx,
+					&SortedSetFetchByRankRequest{
+						CacheName: cacheName,
+						SetName:   sortedSetName,
+					},
+				)
+				Expect(err).To(BeNil())
+				Expect(sortedFetchByRankResponse).To(HaveSortedSetElements(
 					[]SortedSetBytesElement{
 						{Value: []byte("last"), Score: -9999},
 						{Value: []byte("middle"), Score: 50},

--- a/momento/sorted_set_test.go
+++ b/momento/sorted_set_test.go
@@ -1440,7 +1440,7 @@ var _ = Describe("cache-client sortedset-methods", Label(CACHE_SERVICE_LABEL), f
 				Expect(err).To(BeNil())
 				Expect(sortedSetRemoveElementsResponse).To(BeAssignableToTypeOf(&SortedSetRemoveElementsSuccess{}))
 
-				sortedFetchByRankResponse, err := client.SortedSetFetchByRank(
+				sortedSetFetchByRankResponse, err := client.SortedSetFetchByRank(
 					sharedContext.Ctx,
 					&SortedSetFetchByRankRequest{
 						CacheName: cacheName,
@@ -1448,7 +1448,8 @@ var _ = Describe("cache-client sortedset-methods", Label(CACHE_SERVICE_LABEL), f
 					},
 				)
 				Expect(err).To(BeNil())
-				Expect(sortedFetchByRankResponse).To(HaveSortedSetElements(
+				fmt.Printf("SortedSetFetchByRankResponse type: %T, value: %+v\n", sortedSetFetchByRankResponse, sortedSetFetchByRankResponse)
+				Expect(sortedSetFetchByRankResponse).To(HaveSortedSetElements(
 					[]SortedSetBytesElement{
 						{Value: []byte("last"), Score: -9999},
 						{Value: []byte("middle"), Score: 50},


### PR DESCRIPTION
## PR Description:
Saw a canary failure on SortedSetFetchByRank - Remove Elements test today (09/16) at around 7am [(dashboard link)](https://momento.chronosphere.io/dashboards/canaries?start=1726494652000&end=1726495711000)

Error:

```
2024-09-16T13:58:07.277Z
cache-client sortedset-methods SortedSetRemoveElements Removes elements [It] with client with default cache [cache-service]
	
cache-client sortedset-methods SortedSetRemoveElements Removes elements [It] with client with default cache [cache-service]
	
2024-09-16T13:58:07.277Z
	
/.sdks/client-sdk-go/momento/sorted_set_test.go:1459
	
2024-09-16T13:58:07.277Z
  [FAILED] Transform function failed: expected SortedSetFetchHit, but got *responses.SortedSetFetchMiss
```

My hunch is that the key expired from cache till the time it reached the fetch method. 
This commit just splits out the response and expect statements in order to add logging for the response. 


