### PR TITLE
chore: minor tweaks to logging inside of topic client

### DIFF
--- a/momento/pubsub_client.go
+++ b/momento/pubsub_client.go
@@ -2,7 +2,6 @@ package momento
 
 import (
 	"context"
-	"fmt"
 	"math"
 	"sync/atomic"
 
@@ -101,7 +100,7 @@ func (client *pubSubClient) topicSubscribe(ctx context.Context, request *TopicSu
 	}
 
 	if numGrpcStreams > 0 && (int64(numChannels*100)-numGrpcStreams < 10) {
-		client.log.Warn(fmt.Sprintf("WARNING: approaching grpc maximum concurrent stream limit, %d remaining of total %d streams\n", int64(numChannels*100)-numGrpcStreams, numChannels*100))
+		client.log.Warn("WARNING: approaching grpc maximum concurrent stream limit, %d remaining of total %d streams\n", int64(numChannels*100)-numGrpcStreams, numChannels*100)
 	}
 
 	return topicManager, clientStream, cancelContext, cancelFunction, err

--- a/momento/topic_client.go
+++ b/momento/topic_client.go
@@ -84,7 +84,7 @@ func (c defaultTopicClient) Subscribe(ctx context.Context, request *TopicSubscri
 
 	for failedAttempts < maxAttempts {
 		if failedAttempts > 0 {
-			c.log.Info(fmt.Sprintf("Retrying topic subscription due to subscription limit; retry attempt %d of %d", failedAttempts, maxAttempts-1))
+			c.log.Info("Retrying topic subscription due to subscription limit; retry attempt %d of %d", failedAttempts, maxAttempts-1)
 		}
 
 		topicManager, clientStream, cancelContext, cancelFunction, err = c.pubSubClient.topicSubscribe(ctx, &TopicSubscribeRequest{


### PR DESCRIPTION
This commit just improves a few things about the logging in the
topic client:

1. Don't log a DEBUG message for every single received item. We
   now do this at TRACE, so users can toggle their logger to DEBUG
   without being overwhelmed by these.
2. Move a few other important log messages to info/warn for better
   visibility.
3. Get rid of some `fmt.Sprintf` interpolations which would cause
   minor performance impact even when the log level was set to a higher
   value and the log message should not be emitted.
