### PR TITLE
chore: Use the consistent reads flag in integration tests

### DIFF
--- a/momento/test_helpers/shared_context.go
+++ b/momento/test_helpers/shared_context.go
@@ -56,7 +56,7 @@ func NewSharedContext() SharedContext {
 	shared.StorageConfiguration = config.StorageLaptopLatestWithLogger(logger.NewNoopMomentoLoggerFactory())
 	shared.DefaultTtl = 3 * time.Second
 
-	client, err := momento.NewCacheClient(shared.Configuration, shared.CredentialProvider, shared.DefaultTtl)
+	client, err := momento.NewCacheClient(shared.Configuration.WithReadConcern(config.CONSISTENT), shared.CredentialProvider, shared.DefaultTtl)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
This will make some tests get throttled locally. If this works on github and the canaries, we will follow up with local fixes.