### PR TITLE
chore: Add a flag and make command to use consistent reads in tests

### DIFF
--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -85,4 +85,4 @@ jobs:
         run: make run-docs-examples
 
       - name: Run test
-        run: make test
+        run: make prod-test

--- a/.github/workflows/on-push-to-main.yml
+++ b/.github/workflows/on-push-to-main.yml
@@ -83,7 +83,7 @@ jobs:
         run: make build-examples
 
       - name: Run test
-        run: make test
+        run: make prod-test
 
   release-please:
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -72,6 +72,10 @@ test: install-ginkgo
 	@echo "Running tests..."
 	@ginkgo ${GINKGO_OPTS} ${TEST_DIRS}
 
+prod-test: install-ginkgo
+	@echo "Running tests with consistent reads..."
+	@CONSISTENT_READS=1 ginkgo ${GINKGO_OPTS} ${TEST_DIRS}
+
 
 test-auth-service: install-ginkgo
 	@echo "Testing auth service..."

--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,7 @@ test-auth-service: install-ginkgo
 
 test-cache-service: install-ginkgo
 	@echo "Testing cache service..."
-	@ginkgo ${GINKGO_OPTS} --label-filter cache-service ${TEST_DIRS}
+	@CONSISTENT_READS=1 ginkgo ${GINKGO_OPTS} --label-filter cache-service ${TEST_DIRS}
 
 
 test-leaderboard-service: install-ginkgo


### PR DESCRIPTION
Add a flag and make command to use consistent reads in tests. This lets us avoid using them locally, making local development easier.