### PR TITLE
chore: improve logging if we exceed the max number of concurrent streams

### DIFF
--- a/momento/pubsub_client.go
+++ b/momento/pubsub_client.go
@@ -155,6 +155,8 @@ func (client *pubSubClient) close() {
 
 func checkNumConcurrentStreams(log logger.MomentoLogger) {
 	if numGrpcStreams > 0 && numGrpcStreams >= int64(numChannels*100) {
-		log.Warn("Already at maximum number of concurrent grpc streams, cannot make new publish or subscribe requests")
+		log.Warn("Number of grpc streams: %d; number of channels: %d; max concurrent streams: %d; Already at maximum number of concurrent grpc streams, cannot make new publish or subscribe requests",
+			numGrpcStreams, numChannels, numChannels*100,
+		)
 	}
 }


### PR DESCRIPTION
This commit improves the log message if we detect that a user is trying
to create too many concurrent streams; it adds the current number of streams,
channels, and max number of streams to the log message so that the user
can adjust their configuration.
