### PR TITLE
ci: update protos to latest version

### DIFF
--- a/.github/workflows/update-and-generate-protos.yml
+++ b/.github/workflows/update-and-generate-protos.yml
@@ -34,10 +34,10 @@ jobs:
           git add .
           if git diff --cached --quiet; then
               echo "No changes detected."
-              echo "::set-output name=changes_detected::false"
+              echo "changes_detected=false" >> $GITHUB_OUTPUT
           else
               echo "Changes detected."
-              echo "::set-output name=changes_detected::true"
+              echo "changes_detected=true" >> $GITHUB_OUTPUT
           fi
 
       - name: Create Pull Request

--- a/.github/workflows/update-and-generate-protos.yml
+++ b/.github/workflows/update-and-generate-protos.yml
@@ -1,0 +1,52 @@
+name: Update and Build Protos
+
+on:
+  workflow_dispatch:
+
+jobs:
+  update-and-generate:
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # Necessary to push branches
+          persist-credentials: false # Required to use a custom token later
+
+      - name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: "1.19.x"
+
+      - name: Install protoc
+        run: make install-protoc-from-client-protos
+
+      - name: install protoc devtools
+        run: make install-protos-devtools
+
+      - name: Update and Build Protos
+        run: make update-and-build-protos
+
+      - name: Check for Changes
+        id: check_changes
+        run: |
+          git add .
+          if git diff --cached --quiet; then
+              echo "No changes detected."
+              echo "::set-output name=changes_detected::false"
+          else
+              echo "Changes detected."
+              echo "::set-output name=changes_detected::true"
+          fi
+
+      - name: Create Pull Request
+        if: steps.check_changes.outputs.changes_detected == 'true'
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.MOMENTO_MACHINE_USER_GITHUB_TOKEN }}
+          commit-message: "chore: update protos to latest release and regenerate code"
+          branch: "chore/update-protos"
+          title: "chore: update protos to latest release and regenerate code"
+          body: This PR was created automatically by the CI pipeline to update the `.proto` files to the latest release from `client_protos` and regenerate the Go code.
+          labels: "automated pr, proto-update"

--- a/Makefile
+++ b/Makefile
@@ -52,10 +52,12 @@ install-protos-devtools:
 	go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest
 
 update-protos:
-	@echo "Updating .proto files from client_protos repository..."
+	@echo "Updating .proto files from the latest release of the client_protos repository..."
 # Note: httpcache.proto is not needed and causes errors, so make sure it's not present
 	@temp_dir=$$(mktemp -d) && \
-		git clone https://github.com/momentohq/client_protos.git $$temp_dir && \
+		latest_tag=$$(git ls-remote --tags --sort="v:refname" https://github.com/momentohq/client_protos.git | tail -n 1 | sed 's!.*/!!') && \
+		echo "Latest release tag: $$latest_tag" && \
+		git -c advice.detachedHead=false clone --branch "$$latest_tag" https://github.com/momentohq/client_protos.git $$temp_dir && \
 		cp $$temp_dir/proto/*.proto internal/protos/ && \
 		rm -f internal/protos/httpcache.proto && \
 		rm -rf $$temp_dir

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .PHONY: install-devtools install-ginkgo format imports tidy vet staticcheck lint \
-	install-protos-devtools update-protos build-protos update-and-build-protos \
+	install-protoc-from-client-protos install-protos-devtools update-protos build-protos update-and-build-protos \
 	build precommit \
 	test test-auth-service test-cache-service test-leaderboard-service test-storage-service test-topics-service \
 	vendor build-examples run-docs-examples
@@ -45,11 +45,20 @@ staticcheck:
 
 lint: format imports tidy vet staticcheck
 
+install-protoc-from-client-protos:
+	@echo "Installing protoc from latest client_protos release..."
+	@temp_dir=$$(mktemp -d) && \
+		latest_tag=$$(git ls-remote --tags --sort="v:refname" https://github.com/momentohq/client_protos.git | tail -n 1 | sed 's!.*/!!') && \
+		echo "Latest release tag: $$latest_tag" && \
+		git -c advice.detachedHead=false clone --branch "$$latest_tag" https://github.com/momentohq/client_protos.git $$temp_dir && \
+		cd $$temp_dir && \
+		./install-protoc.sh && \
+		rm -rf $$temp_dir
 
 install-protos-devtools:
 	@echo "Installing protos dev tools..."
-	go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
-	go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest
+	go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.34.2
+	go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.5.1
 
 update-protos:
 	@echo "Updating .proto files from the latest release of the client_protos repository..."


### PR DESCRIPTION
In order to ensure consistency in the protoc version and the go
plugins version, we install protoc using the script from client-protos
and we pin the go protoc plugins.

We then add a manual workflow that clones the client protos repo at the
latest release; copies protos; generates code; and, if there are any differences, 
opens a PR.