### PR TITLE
ci: ensure dev prereqs are installed before running targets

### DIFF
--- a/.github/workflows/update-and-generate-protos.yml
+++ b/.github/workflows/update-and-generate-protos.yml
@@ -37,13 +37,19 @@ jobs:
               echo "changes_detected=true" >> $GITHUB_OUTPUT
           fi
 
+      - name: Detect latest version
+        id: detect_latest_version
+        run: |
+          LATEST_VERSION=$(make fetch-latest-client-protos-version)
+          echo "latest_version=$LATEST_VERSION" >> $GITHUB_OUTPUT
+
       - name: Create Pull Request
         if: steps.check_changes.outputs.changes_detected == 'true'
         uses: peter-evans/create-pull-request@v7
         with:
           token: ${{ secrets.MOMENTO_MACHINE_USER_GITHUB_TOKEN }}
-          commit-message: "chore: update protos to latest release and regenerate code"
+          commit-message: "chore(protos): update protos to ${{ steps.detect_latest_version.outputs.latest_version }} and regenerate code"
           branch: "chore/update-protos"
-          title: "chore: update protos to latest release and regenerate code"
-          body: This PR was created automatically by the CI pipeline to update the `.proto` files to the latest release from `client_protos` and regenerate the Go code.
+          title: "chore(protos): update protos to ${{ steps.detect_latest_version.outputs.latest_version }} and regenerate code"
+          body: This PR was created automatically by the CI pipeline to update the `.proto` files to the latest release from `client_protos`, $${{ steps.detect_latest_version.outputs.latest_version }} and regenerate the go protobuf code.
           labels: "automated pr, proto-update"

--- a/.github/workflows/update-and-generate-protos.yml
+++ b/.github/workflows/update-and-generate-protos.yml
@@ -22,9 +22,6 @@ jobs:
       - name: Install protoc
         run: make install-protoc-from-client-protos
 
-      - name: install protoc devtools
-        run: make install-protos-devtools
-
       - name: Update and Build Protos
         run: make update-and-build-protos
 

--- a/.github/workflows/update-and-generate-protos.yml
+++ b/.github/workflows/update-and-generate-protos.yml
@@ -37,7 +37,7 @@ jobs:
               echo "changes_detected=true" >> $GITHUB_OUTPUT
           fi
 
-      - name: Detect latest version
+      - name: Detect latest client-protos version
         id: detect_latest_version
         run: |
           LATEST_VERSION=$(make fetch-latest-client-protos-version)

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: install-goimport install-staticcheck install-ginkgo install-devtools \
 	format imports tidy vet staticcheck lint \
-	install-protoc-from-client-protos install-protos-devtools update-protos build-protos update-and-build-protos \
+	fetch-latest-client-protos-version install-protoc-from-client-protos install-protos-devtools update-protos build-protos update-and-build-protos \
 	build precommit \
 	test test-auth-service test-cache-service test-leaderboard-service test-storage-service test-topics-service \
 	vendor build-examples run-docs-examples
@@ -67,10 +67,13 @@ install-protos-devtools:
 		go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.4.0; \
 	fi
 
+fetch-latest-client-protos-version:
+	@echo $$(git ls-remote --tags --sort="v:refname" https://github.com/momentohq/client_protos.git | tail -n 1 | sed 's!.*/!!')
+
 install-protoc-from-client-protos: install-protos-devtools
 	@echo "Installing protoc from latest client_protos release..."
 	@temp_dir=$$(mktemp -d) && \
-		latest_tag=$$(git ls-remote --tags --sort="v:refname" https://github.com/momentohq/client_protos.git | tail -n 1 | sed 's!.*/!!') && \
+		latest_tag=$(shell $(MAKE) fetch-latest-client-protos-version) && \
 		echo "Latest release tag: $$latest_tag" && \
 		git -c advice.detachedHead=false clone --branch "$$latest_tag" https://github.com/momentohq/client_protos.git $$temp_dir && \
 		cd $$temp_dir && \
@@ -81,7 +84,7 @@ update-protos:
 	@echo "Updating .proto files from the latest release of the client_protos repository..."
 # Note: httpcache.proto is not needed and causes errors, so make sure it's not present
 	@temp_dir=$$(mktemp -d) && \
-		latest_tag=$$(git ls-remote --tags --sort="v:refname" https://github.com/momentohq/client_protos.git | tail -n 1 | sed 's!.*/!!') && \
+		latest_tag=$(shell $(MAKE) fetch-latest-client-protos-version) && \
 		echo "Latest release tag: $$latest_tag" && \
 		git -c advice.detachedHead=false clone --branch "$$latest_tag" https://github.com/momentohq/client_protos.git $$temp_dir && \
 		cp $$temp_dir/proto/*.proto internal/protos/ && \


### PR DESCRIPTION
Updates the `imports` and `staticcheck` targets to ensure the tools
are installed first before running. We update the install targets to
quietly check if installed already, otherwise install.

We do the same for the go proto plugins.
