### PR TITLE
chore: reduce eager connection timeout for test for low latency test environments

### DIFF
--- a/momento/cache_client_test.go
+++ b/momento/cache_client_test.go
@@ -108,7 +108,7 @@ var _ = Describe("cache-client", Label(CACHE_SERVICE_LABEL), func() {
 			config.LambdaLatestWithLogger(momento_default_logger.NewDefaultMomentoLoggerFactory(momento_default_logger.INFO)),
 			sharedContext.CredentialProvider,
 			sharedContext.DefaultTtl,
-			1*time.Millisecond,
+			1*time.Microsecond,
 		)
 
 		Expect(client).To(BeNil())


### PR DESCRIPTION
Canary tests run in much lower latency environments and the `Returns error when eager connection fails` test failed recently, apparently because the client was able to connect in under 1 millisecond. This PR reduces the eager connection timeout to 1 microsecond to try to avoid this test failure in future.