### PR TITLE
fix: interpret get rank response when sorted set found

### DIFF
--- a/momento/sorted_set_get_rank.go
+++ b/momento/sorted_set_get_rank.go
@@ -65,7 +65,14 @@ func (r *SortedSetGetRankRequest) interpretGrpcResponse() error {
 	var resp responses.SortedSetGetRankResponse
 	switch rank := grpcResp.Rank.(type) {
 	case *pb.XSortedSetGetRankResponse_ElementRank:
-		resp = responses.SortedSetGetRankHit(rank.ElementRank.Rank)
+		switch rank.ElementRank.Result {
+		case pb.ECacheResult_Hit:
+			resp = responses.SortedSetGetRankHit(rank.ElementRank.Rank)
+		case pb.ECacheResult_Miss:
+			resp = &responses.SortedSetGetRankMiss{}
+		default:
+			return errUnexpectedGrpcResponse(r, r.grpcResponse)
+		}
 	case *pb.XSortedSetGetRankResponse_Missing:
 		resp = &responses.SortedSetGetRankMiss{}
 	default:

--- a/momento/sorted_set_test.go
+++ b/momento/sorted_set_test.go
@@ -773,7 +773,10 @@ var _ = Describe("cache-client sortedset-methods", Label(CACHE_SERVICE_LABEL), f
 	})
 
 	Describe("SortedSetGetRank", func() {
-		It("Misses when the element does not exist", func() {
+		It("Misses when the element does not exist but the sorted set does", func() {
+			putElements([]SortedSetElement{
+				{Value: String("bar"), Score: 0},
+			})
 			Expect(
 				sharedContext.Client.SortedSetGetRank(
 					sharedContext.Ctx,


### PR DESCRIPTION
Previously we did not interpret an element hit vs miss when the sorted
set was found on a sorted set get rank request. In the event a user
queried the rank of an element not present in an existing sorted set,
a rank 0 would be returned.

To correct this we inspect the `result` field, check hit vs miss, and
return a `SortedSetGetRankMiss` on a miss.
