### PR TITLE
chore: remove unused publish-golang step

### DIFF
--- a/.github/workflows/on-push-to-main.yml
+++ b/.github/workflows/on-push-to-main.yml
@@ -100,25 +100,3 @@ jobs:
           changelog-types: '[{"type":"feat","section":"Features","hidden":false},{"type":"fix","section":"Bug Fixes","hidden":false},{"type":"chore","section":"Miscellaneous","hidden":false}]'
           extra-files: |
             internal/metadata.go
-
-  publish-golang:
-    needs: [ release-please ]
-    if: needs.release-please.outputs.release_created == 'true'
-    runs-on: ubuntu-24.04
-    steps:
-      - name: Setup repo
-        uses: actions/checkout@v3
-
-      - name: Publish package
-        run: |
-          set -e
-          set -x
-          export MOMENTO_SDK_VERSION="${{needs.release-please.outputs.tag_name}}"
-          if [ -z "$MOMENTO_SDK_VERSION" ]
-          then
-            echo "Unable to determine SDK version!  Exiting!"
-            exit 1
-          fi
-          echo "MOMENTO_SDK_VERSION=${MOMENTO_SDK_VERSION}"
-          GOPROXY=proxy.golang.org go list -m github.com/momentohq/client-sdk-go@${MOMENTO_SDK_VERSION}
-        shell: bash


### PR DESCRIPTION
Apparently this step is NOT used after the addition of the release-please workflow and caused major confusion around whether the latest go version was published to gopkg. 

This PR removes the unneeded `publish-golang` step to eliminate this confusion in the future.