### PR TITLE
fix: add message wrapper to errors and improve resource exhausted error message by using metadata

### DIFF
--- a/batchutils/batch_set_test.go
+++ b/batchutils/batch_set_test.go
@@ -193,7 +193,7 @@ var _ = Describe("batch-utils", Label("cache-service"), func() {
 			// Assuming errors is an instance of *BatchSetError
 			Expect(len(errors.Errors())).To(Equal(len(batchSetErrorKeys)))
 			for v, e := range errors.Errors() {
-				Expect(e.Error()).To(Equal("InvalidArgumentError: value cannot be nil"))
+				Expect(e.(MomentoError).Code()).To(Equal("InvalidArgumentError"))
 				isValidKey := false
 				for _, erroredKey := range batchSetErrorKeys {
 					if v == erroredKey {

--- a/internal/momentoerrors/error_messages.go
+++ b/internal/momentoerrors/error_messages.go
@@ -1,0 +1,30 @@
+package momentoerrors
+
+// LimitExceededError message wrappers to indicate the type of limit exceeded
+const (
+	TopicSubscriptionsLimitExceeded = "Topic subscriptions limit exceeded for this account"
+	OperationsRateLimitExceeded     = "Request rate limit exceeded for this account"
+	ThroughputRateLimitExceeded     = "Bandwidth limit exceeded for this account"
+	RequestSizeLimitExceeded        = "Request size limit exceeded for this account"
+	ItemSizeLimitExceeded           = "Item size limit exceeded for this account"
+	ElementSizeLimitExceeded        = "Element size limit exceeded for this account"
+	UnknownLimitExceeded            = "Limit exceeded for this account"
+)
+
+const (
+	InvalidArgumentMessageWrapper     = "Invalid argument passed to Momento client"
+	BadRequestMessageWrapper          = "The request was invalid; please contact us at support@momentohq.com"
+	FailedPreconditionMessageWrapper  = "System is not in a state required for the operation's execution"
+	CanceledMessageWrapper            = "The request was cancelled by the server; please contact us at support@momentohq.com"
+	TimeoutMessageWrapper             = "The client's configured timeout was exceeded; you may need to use a Configuration with more lenient timeouts"
+	PermissionMessageWrapper          = "Insufficient permissions to perform operation"
+	AuthenticationMessageWrapper      = "Invalid authentication credentials to connect to Momento service"
+	CacheNotFoundMessageWrapper       = "A cache with the specified name does not exist.  To resolve this error, make sure you have created the cache before attempting to use it"
+	StoreNotFoundMessageWrapper       = "A store with the specified name does not exist.  To resolve this error, make sure you have created the store before attempting to use it"
+	ItemNotFoundMessageWrapper        = "An item with the specified key does not exist"
+	CacheAlreadyExistsMessageWrapper  = "A cache with the specified name already exists.  To resolve this error, either delete the existing cache and make a new one, or use a different name"
+	StoreAlreadyExistsMessageWrapper  = "A store with the specified name already exists.  To resolve this error, either delete the existing store and make a new one, or use a different name"
+	UnknownServiceErrorMessageWrapper = "Service returned an unknown response; please contact us at support@momentohq.com"
+	InternalServerErrorMessageWrapper = "Unexpected error encountered while trying to fulfill the request; please contact us at support@momentohq.com"
+	ServerUnavailableMessageWrapper   = "The server was unable to handle the request; consider retrying.  If the error persists, please contact us at support@momentohq.com"
+)

--- a/internal/momentoerrors/scs_errors.go
+++ b/internal/momentoerrors/scs_errors.go
@@ -176,23 +176,23 @@ func determineLimitExceededMessageWrapper(errorMessage string, metadata ...metad
 			case "element_size_limit_exceeded":
 				messageWrapper = ElementSizeLimitExceeded
 			}
-		} else {
-			// If err metadata is not available, try string matching on the
-			// error details to return the most specific message wrapper.
-			lowerCasedMessage := strings.ToLower(errorMessage)
-			if strings.Contains(lowerCasedMessage, "subscribers") {
-				messageWrapper = TopicSubscriptionsLimitExceeded
-			} else if strings.Contains(lowerCasedMessage, "operations") {
-				messageWrapper = OperationsRateLimitExceeded
-			} else if strings.Contains(lowerCasedMessage, "throughput") {
-				messageWrapper = ThroughputRateLimitExceeded
-			} else if strings.Contains(lowerCasedMessage, "request limit") {
-				messageWrapper = RequestSizeLimitExceeded
-			} else if strings.Contains(lowerCasedMessage, "item size") {
-				messageWrapper = ItemSizeLimitExceeded
-			} else if strings.Contains(lowerCasedMessage, "element size") {
-				messageWrapper = ElementSizeLimitExceeded
-			}
+		}
+	} else {
+		// If err metadata is not available, try string matching on the
+		// error details to return the most specific message wrapper.
+		lowerCasedMessage := strings.ToLower(errorMessage)
+		if strings.Contains(lowerCasedMessage, "subscribers") {
+			messageWrapper = TopicSubscriptionsLimitExceeded
+		} else if strings.Contains(lowerCasedMessage, "operations") {
+			messageWrapper = OperationsRateLimitExceeded
+		} else if strings.Contains(lowerCasedMessage, "throughput") {
+			messageWrapper = ThroughputRateLimitExceeded
+		} else if strings.Contains(lowerCasedMessage, "request limit") {
+			messageWrapper = RequestSizeLimitExceeded
+		} else if strings.Contains(lowerCasedMessage, "item size") {
+			messageWrapper = ItemSizeLimitExceeded
+		} else if strings.Contains(lowerCasedMessage, "element size") {
+			messageWrapper = ElementSizeLimitExceeded
 		}
 	}
 	return messageWrapper

--- a/internal/momentoerrors/scs_errors.go
+++ b/internal/momentoerrors/scs_errors.go
@@ -16,7 +16,12 @@ type MomentoSvcErr interface {
 }
 
 // NewMomentoSvcErr returns a new Momento service error.
+// Used internally, mostly for invalid argument errors.
+// Default to using the code as the message wrapper otherwise.
 func NewMomentoSvcErr(code string, message string, originalErr error) MomentoSvcErr {
+	if code == InvalidArgumentError {
+		return newMomentoSvcErr(code, message, originalErr, "Invalid argument passed to Momento client")
+	}
 	return newMomentoSvcErr(code, message, originalErr, code)
 }
 

--- a/internal/momentoerrors/scs_errors.go
+++ b/internal/momentoerrors/scs_errors.go
@@ -1,6 +1,8 @@
 package momentoerrors
 
 import (
+	"strings"
+
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
@@ -15,7 +17,7 @@ type MomentoSvcErr interface {
 
 // NewMomentoSvcErr returns a new Momento service error.
 func NewMomentoSvcErr(code string, message string, originalErr error) MomentoSvcErr {
-	return newMomentoSvcErr(code, message, originalErr)
+	return newMomentoSvcErr(code, message, originalErr, code)
 }
 
 const (
@@ -37,23 +39,29 @@ const (
 	AuthenticationError = "AuthenticationError"
 	// LimitExceededError occurs when request rate, bandwidth, or object size exceeded the limits for the account.
 	LimitExceededError = "LimitExceededError"
-	// NotFoundError occurs when a cache with specified name doesn't exist.
+	// NotFoundError occurs when a cache with specified name doesn"t exist.
 	//
 	// Deprecated: Use more specific CacheNotFoundError, StoreNotFoundError, or ItemNotFoundError instead.
 	NotFoundError = "NotFoundError"
-	// CacheNotFoundError occurs when a cache with specified name doesn't exist.
+	// CacheNotFoundError occurs when a cache with specified name doesn"t exist.
 	CacheNotFoundError = "NotFoundError"
-	// StoreNotFoundError occurs when a store with specified name doesn't exist.
+	// StoreNotFoundError occurs when a store with specified name doesn"t exist.
 	StoreNotFoundError = "StoreNotFoundError"
-	// ItemNotFoundError occurs when an item with specified key doesn't exist.
+	// ItemNotFoundError occurs when an item with specified key doesn"t exist.
 	ItemNotFoundError = "ItemNotFoundError"
 	// AlreadyExistsError occurs when a cache with specified name already exists.
+	//
+	// Deprecated: Use more specific CacheAlreadyExistsError or StoreAlreadyExistsError instead.
 	AlreadyExistsError = "AlreadyExistsError"
+	// CacheAlreadyExistsError occurs when a cache with specified name already exists.
+	CacheAlreadyExistsError = "AlreadyExistsError"
+	// StoreAlreadyExistsError occurs when a store with specified name already exists.
+	StoreAlreadyExistsError = "StoreAlreadyExistsError"
 	// UnknownServiceError occurs when an unknown error has occurred.
 	UnknownServiceError = "UnknownServiceError"
 	// ServerUnavailableError occurs when the server was unable to handle the request.
 	ServerUnavailableError = "ServerUnavailableError"
-	// FailedPreconditionError occurs when the system is not in a state required for the operation's execution.
+	// FailedPreconditionError occurs when the system is not in a state required for the operation"s execution.
 	FailedPreconditionError = "FailedPreconditionError"
 	// InternalServerErrorMessage is the message for an unexpected error occurring while trying to fulfill the request.
 	InternalServerErrorMessage = "CacheService failed with an internal error"
@@ -63,60 +71,204 @@ const (
 	ConnectionError = "ConnectionError"
 )
 
+const (
+	TopicSubscriptionsLimitExceeded = "Topic subscriptions limit exceeded for this account"
+	OperationsRateLimitExceeded     = "Request rate limit exceeded for this account"
+	ThroughputRateLimitExceeded     = "Bandwidth limit exceeded for this account"
+	RequestSizeLimitExceeded        = "Request size limit exceeded for this account"
+	ItemSizeLimitExceeded           = "Item size limit exceeded for this account"
+	ElementSizeLimitExceeded        = "Element size limit exceeded for this account"
+	UnknownLimitExceeded            = "Limit exceeded for this account"
+)
+
 // ConvertSvcErr converts gRPC error to MomentoSvcErr.
 func ConvertSvcErr(err error, metadata ...metadata.MD) MomentoSvcErr {
 	if grpcStatus, ok := status.FromError(err); ok {
 		switch grpcStatus.Code() {
 		case codes.InvalidArgument:
-			return NewMomentoSvcErr(InvalidArgumentError, grpcStatus.Message(), err)
+			return newMomentoSvcErr(
+				InvalidArgumentError,
+				grpcStatus.Message(),
+				err,
+				"Invalid argument passed to Momento client",
+			)
 		case codes.Unimplemented:
-			return NewMomentoSvcErr(BadRequestError, grpcStatus.Message(), err)
+			return newMomentoSvcErr(
+				BadRequestError,
+				grpcStatus.Message(),
+				err,
+				"The request was invalid; please contact us at support@momentohq.com",
+			)
 		case codes.OutOfRange:
-			return NewMomentoSvcErr(BadRequestError, grpcStatus.Message(), err)
+			return newMomentoSvcErr(
+				BadRequestError,
+				grpcStatus.Message(),
+				err,
+				"The request was invalid; please contact us at support@momentohq.com",
+			)
 		case codes.FailedPrecondition:
-			return NewMomentoSvcErr(FailedPreconditionError, grpcStatus.Message(), err)
+			return newMomentoSvcErr(
+				FailedPreconditionError,
+				grpcStatus.Message(),
+				err,
+				"System is not in a state required for the operation's execution",
+			)
 		case codes.Canceled:
-			return NewMomentoSvcErr(CanceledError, grpcStatus.Message(), err)
+			return newMomentoSvcErr(
+				CanceledError,
+				grpcStatus.Message(),
+				err,
+				"The request was cancelled by the server; please contact us at support@momentohq.com",
+			)
 		case codes.DeadlineExceeded:
-			return NewMomentoSvcErr(TimeoutError, grpcStatus.Message(), err)
+			return newMomentoSvcErr(
+				TimeoutError,
+				grpcStatus.Message(),
+				err,
+				"The client's configured timeout was exceeded; you may need to use a Configuration with more lenient timeouts",
+			)
 		case codes.PermissionDenied:
-			return NewMomentoSvcErr(PermissionError, grpcStatus.Message(), err)
+			return newMomentoSvcErr(
+				PermissionError,
+				grpcStatus.Message(),
+				err,
+				"Insufficient permissions to perform operation",
+			)
 		case codes.Unauthenticated:
-			return NewMomentoSvcErr(AuthenticationError, grpcStatus.Message(), err)
+			return newMomentoSvcErr(
+				AuthenticationError,
+				grpcStatus.Message(),
+				err,
+				"Invalid authentication credentials to connect to Momento service",
+			)
 		case codes.ResourceExhausted:
-			return NewMomentoSvcErr(LimitExceededError, grpcStatus.Message(), err)
+			// By default, use the generic limit exceeded message wrapper.
+			messageWrapper := UnknownLimitExceeded
+
+			// If available, use metadata to determine cause of resource exhausted error.
+			if len(metadata) > 1 {
+				errData, ok := metadata[1]["err"]
+				if ok && errData[0] != "" {
+					switch errData[0] {
+					case "topic_subscriptions_limit_exceeded":
+						messageWrapper = TopicSubscriptionsLimitExceeded
+					case "operations_rate_limit_exceeded":
+						messageWrapper = OperationsRateLimitExceeded
+					case "throughput_rate_limit_exceeded":
+						messageWrapper = ThroughputRateLimitExceeded
+					case "request_size_limit_exceeded":
+						messageWrapper = RequestSizeLimitExceeded
+					case "item_size_limit_exceeded":
+						messageWrapper = ItemSizeLimitExceeded
+					case "element_size_limit_exceeded":
+						messageWrapper = ElementSizeLimitExceeded
+					}
+				} else {
+					// If err metadata is not available, try string matching on the
+					// error details to return the most specific message wrapper.
+					lowerCasedMessage := strings.ToLower(grpcStatus.Message())
+					if strings.Contains(lowerCasedMessage, "subscribers") {
+						messageWrapper = TopicSubscriptionsLimitExceeded
+					} else if strings.Contains(lowerCasedMessage, "operations") {
+						messageWrapper = OperationsRateLimitExceeded
+					} else if strings.Contains(lowerCasedMessage, "throughput") {
+						messageWrapper = ThroughputRateLimitExceeded
+					} else if strings.Contains(lowerCasedMessage, "request limit") {
+						messageWrapper = RequestSizeLimitExceeded
+					} else if strings.Contains(lowerCasedMessage, "item size") {
+						messageWrapper = ItemSizeLimitExceeded
+					} else if strings.Contains(lowerCasedMessage, "element size") {
+						messageWrapper = ElementSizeLimitExceeded
+					}
+				}
+			}
+			return newMomentoSvcErr(LimitExceededError, grpcStatus.Message(), err, messageWrapper)
 		case codes.NotFound:
+			cacheMessageWrapper := "A cache with the specified name does not exist.  To resolve this error, make sure you have created the cache before attempting to use it"
+			storeMessageWrapper := "A store with the specified name does not exist.  To resolve this error, make sure you have created the store before attempting to use it"
 			// Use metadata to determine cause of not found error
 			if len(metadata) > 1 {
 				errData, ok := metadata[1]["err"]
 				// In the absence of error metadata, return CacheNotFoundError.
-				// This is currently re-mapped to a StoreNotFoundError in the PreviewStorageClient's
+				// This is currently re-mapped to a StoreNotFoundError in the PreviewStorageClient"s
 				// DeleteStore method.
 				if !ok {
-					return NewMomentoSvcErr(CacheNotFoundError, grpcStatus.Message(), err)
+					return newMomentoSvcErr(CacheNotFoundError, grpcStatus.Message(), err, cacheMessageWrapper)
 				}
 				errCause := errData[0]
 				if errCause == "item_not_found" {
-					return NewMomentoSvcErr(ItemNotFoundError, grpcStatus.Message(), err)
+					return newMomentoSvcErr(
+						ItemNotFoundError,
+						grpcStatus.Message(),
+						err,
+						"An item with the specified key does not exist",
+					)
 				} else if errCause == "store_not_found" {
-					return NewMomentoSvcErr(StoreNotFoundError, grpcStatus.Message(), err)
+					return newMomentoSvcErr(StoreNotFoundError, grpcStatus.Message(), err, storeMessageWrapper)
 				}
 			}
-			return NewMomentoSvcErr(CacheNotFoundError, grpcStatus.Message(), err)
+			return newMomentoSvcErr(CacheNotFoundError, grpcStatus.Message(), err, cacheMessageWrapper)
 		case codes.AlreadyExists:
-			return NewMomentoSvcErr(AlreadyExistsError, grpcStatus.Message(), err)
+			cacheMessageWrapper := "A cache with the specified name already exists.  To resolve this error, either delete the existing cache and make a new one, or use a different name"
+			storeMessageWrapper := "A store with the specified name already exists.  To resolve this error, either delete the existing store and make a new one, or use a different name"
+			if len(metadata) > 1 {
+				errData, ok := metadata[1]["err"]
+				// In the absence of error metadata, return CacheAlreadyExistsError.
+				if !ok {
+					return newMomentoSvcErr(CacheAlreadyExistsError, grpcStatus.Message(), err, cacheMessageWrapper)
+				}
+				errCause := errData[0]
+				switch errCause {
+				case "store_already_exists":
+					return newMomentoSvcErr(StoreAlreadyExistsError, grpcStatus.Message(), err, storeMessageWrapper)
+				default:
+					return newMomentoSvcErr(CacheAlreadyExistsError, grpcStatus.Message(), err, cacheMessageWrapper)
+				}
+			}
+			// If no metadata is available, return CacheAlreadyExistsError by default.
+			return newMomentoSvcErr(CacheAlreadyExistsError, grpcStatus.Message(), err, cacheMessageWrapper)
 		case codes.Unknown:
-			return NewMomentoSvcErr(UnknownServiceError, grpcStatus.Message(), err)
+			return newMomentoSvcErr(
+				UnknownServiceError,
+				grpcStatus.Message(),
+				err,
+				"Service returned an unknown response; please contact us at support@momentohq.com",
+			)
 		case codes.Aborted:
-			return NewMomentoSvcErr(InternalServerError, grpcStatus.Message(), err)
+			return newMomentoSvcErr(
+				InternalServerError,
+				grpcStatus.Message(),
+				err,
+				"Unexpected error encountered while trying to fulfill the request; please contact us at support@momentohq.com",
+			)
 		case codes.Internal:
-			return NewMomentoSvcErr(InternalServerError, grpcStatus.Message(), err)
+			return newMomentoSvcErr(
+				InternalServerError,
+				grpcStatus.Message(),
+				err,
+				"Unexpected error encountered while trying to fulfill the request; please contact us at support@momentohq.com",
+			)
 		case codes.Unavailable:
-			return NewMomentoSvcErr(ServerUnavailableError, grpcStatus.Message(), err)
+			return newMomentoSvcErr(
+				ServerUnavailableError,
+				grpcStatus.Message(),
+				err,
+				"The server was unable to handle the request; consider retrying.  If the error persists, please contact us at support@momentohq.com",
+			)
 		case codes.DataLoss:
-			return NewMomentoSvcErr(InternalServerError, grpcStatus.Message(), err)
+			return newMomentoSvcErr(
+				InternalServerError,
+				grpcStatus.Message(),
+				err,
+				"Unexpected error encountered while trying to fulfill the request; please contact us at support@momentohq.com",
+			)
 		default:
-			return NewMomentoSvcErr(UnknownServiceError, InternalServerErrorMessage, err)
+			return newMomentoSvcErr(
+				UnknownServiceError,
+				InternalServerErrorMessage,
+				err,
+				"Service returned an unknown response; please contact us at support@momentohq.com",
+			)
 		}
 	}
 	return NewMomentoSvcErr(ClientSdkError, ClientSdkErrorMessage, err)

--- a/internal/momentoerrors/scs_errors.go
+++ b/internal/momentoerrors/scs_errors.go
@@ -39,15 +39,15 @@ const (
 	AuthenticationError = "AuthenticationError"
 	// LimitExceededError occurs when request rate, bandwidth, or object size exceeded the limits for the account.
 	LimitExceededError = "LimitExceededError"
-	// NotFoundError occurs when a cache with specified name doesn"t exist.
+	// NotFoundError occurs when a cache with specified name doesn't exist.
 	//
 	// Deprecated: Use more specific CacheNotFoundError, StoreNotFoundError, or ItemNotFoundError instead.
 	NotFoundError = "NotFoundError"
-	// CacheNotFoundError occurs when a cache with specified name doesn"t exist.
+	// CacheNotFoundError occurs when a cache with specified name doesn't exist.
 	CacheNotFoundError = "NotFoundError"
-	// StoreNotFoundError occurs when a store with specified name doesn"t exist.
+	// StoreNotFoundError occurs when a store with specified name doesn't exist.
 	StoreNotFoundError = "StoreNotFoundError"
-	// ItemNotFoundError occurs when an item with specified key doesn"t exist.
+	// ItemNotFoundError occurs when an item with specified key doesn't exist.
 	ItemNotFoundError = "ItemNotFoundError"
 	// AlreadyExistsError occurs when a cache with specified name already exists.
 	//
@@ -61,7 +61,7 @@ const (
 	UnknownServiceError = "UnknownServiceError"
 	// ServerUnavailableError occurs when the server was unable to handle the request.
 	ServerUnavailableError = "ServerUnavailableError"
-	// FailedPreconditionError occurs when the system is not in a state required for the operation"s execution.
+	// FailedPreconditionError occurs when the system is not in a state required for the operation's execution.
 	FailedPreconditionError = "FailedPreconditionError"
 	// InternalServerErrorMessage is the message for an unexpected error occurring while trying to fulfill the request.
 	InternalServerErrorMessage = "CacheService failed with an internal error"

--- a/internal/momentoerrors/scs_errors.go
+++ b/internal/momentoerrors/scs_errors.go
@@ -176,24 +176,25 @@ func determineLimitExceededMessageWrapper(errorMessage string, metadata ...metad
 			case "element_size_limit_exceeded":
 				messageWrapper = ElementSizeLimitExceeded
 			}
+			return messageWrapper
 		}
-	} else {
-		// If err metadata is not available, try string matching on the
-		// error details to return the most specific message wrapper.
-		lowerCasedMessage := strings.ToLower(errorMessage)
-		if strings.Contains(lowerCasedMessage, "subscribers") {
-			messageWrapper = TopicSubscriptionsLimitExceeded
-		} else if strings.Contains(lowerCasedMessage, "operations") {
-			messageWrapper = OperationsRateLimitExceeded
-		} else if strings.Contains(lowerCasedMessage, "throughput") {
-			messageWrapper = ThroughputRateLimitExceeded
-		} else if strings.Contains(lowerCasedMessage, "request limit") {
-			messageWrapper = RequestSizeLimitExceeded
-		} else if strings.Contains(lowerCasedMessage, "item size") {
-			messageWrapper = ItemSizeLimitExceeded
-		} else if strings.Contains(lowerCasedMessage, "element size") {
-			messageWrapper = ElementSizeLimitExceeded
-		}
+	}
+
+	// If err metadata is not available, try string matching on the
+	// error details to return the most specific message wrapper.
+	lowerCasedMessage := strings.ToLower(errorMessage)
+	if strings.Contains(lowerCasedMessage, "subscribers") {
+		messageWrapper = TopicSubscriptionsLimitExceeded
+	} else if strings.Contains(lowerCasedMessage, "operations") {
+		messageWrapper = OperationsRateLimitExceeded
+	} else if strings.Contains(lowerCasedMessage, "throughput") {
+		messageWrapper = ThroughputRateLimitExceeded
+	} else if strings.Contains(lowerCasedMessage, "request limit") {
+		messageWrapper = RequestSizeLimitExceeded
+	} else if strings.Contains(lowerCasedMessage, "item size") {
+		messageWrapper = ItemSizeLimitExceeded
+	} else if strings.Contains(lowerCasedMessage, "element size") {
+		messageWrapper = ElementSizeLimitExceeded
 	}
 	return messageWrapper
 }

--- a/internal/momentoerrors/types.go
+++ b/internal/momentoerrors/types.go
@@ -3,16 +3,18 @@ package momentoerrors
 import "fmt"
 
 type momentoSvcError struct {
-	code        string
-	message     string
-	originalErr error
+	code           string
+	message        string
+	originalErr    error
+	messageWrapper string
 }
 
-func newMomentoSvcErr(code string, message string, originalErr error) *momentoSvcError {
+func newMomentoSvcErr(code string, message string, originalErr error, messageWrapper string) *momentoSvcError {
 	return &momentoSvcError{
 		code,
 		message,
 		originalErr,
+		messageWrapper,
 	}
 }
 
@@ -21,7 +23,10 @@ func (err momentoSvcError) Code() string {
 }
 
 func (err momentoSvcError) Message() string {
-	return err.message
+	if err.messageWrapper == "" {
+		return err.message
+	}
+	return err.messageWrapper + ": " + err.message
 }
 
 func (err momentoSvcError) OriginalErr() error {

--- a/internal/services/scs_control_service.go
+++ b/internal/services/scs_control_service.go
@@ -39,9 +39,15 @@ func (client *ScsControlClient) Close() momentoerrors.MomentoSvcErr {
 func (client *ScsControlClient) CreateCache(ctx context.Context, request *models.CreateCacheRequest) momentoerrors.MomentoSvcErr {
 	ctx, cancel := context.WithTimeout(ctx, ControlCtxTimeout)
 	defer cancel()
-	_, err := client.grpcClient.CreateCache(ctx, &pb.XCreateCacheRequest{CacheName: request.CacheName})
+	var header, trailer metadata.MD
+	_, err := client.grpcClient.CreateCache(
+		ctx,
+		&pb.XCreateCacheRequest{CacheName: request.CacheName},
+		grpc.Header(&header),
+		grpc.Trailer(&trailer),
+	)
 	if err != nil {
-		return momentoerrors.ConvertSvcErr(err)
+		return momentoerrors.ConvertSvcErr(err, header, trailer)
 	}
 	return nil
 }
@@ -49,9 +55,15 @@ func (client *ScsControlClient) CreateCache(ctx context.Context, request *models
 func (client *ScsControlClient) DeleteCache(ctx context.Context, request *models.DeleteCacheRequest) momentoerrors.MomentoSvcErr {
 	ctx, cancel := context.WithTimeout(ctx, ControlCtxTimeout)
 	defer cancel()
-	_, err := client.grpcClient.DeleteCache(ctx, &pb.XDeleteCacheRequest{CacheName: request.CacheName})
+	var header, trailer metadata.MD
+	_, err := client.grpcClient.DeleteCache(
+		ctx,
+		&pb.XDeleteCacheRequest{CacheName: request.CacheName},
+		grpc.Header(&header),
+		grpc.Trailer(&trailer),
+	)
 	if err != nil {
-		return momentoerrors.ConvertSvcErr(err)
+		return momentoerrors.ConvertSvcErr(err, header, trailer)
 	}
 	return nil
 }
@@ -59,9 +71,15 @@ func (client *ScsControlClient) DeleteCache(ctx context.Context, request *models
 func (client *ScsControlClient) ListCaches(ctx context.Context, request *models.ListCachesRequest) (*models.ListCachesResponse, momentoerrors.MomentoSvcErr) {
 	ctx, cancel := context.WithTimeout(ctx, ControlCtxTimeout)
 	defer cancel()
-	resp, err := client.grpcClient.ListCaches(ctx, &pb.XListCachesRequest{NextToken: request.NextToken})
+	var header, trailer metadata.MD
+	resp, err := client.grpcClient.ListCaches(
+		ctx,
+		&pb.XListCachesRequest{NextToken: request.NextToken},
+		grpc.Header(&header),
+		grpc.Trailer(&trailer),
+	)
 	if err != nil {
-		return nil, momentoerrors.ConvertSvcErr(err)
+		return nil, momentoerrors.ConvertSvcErr(err, header, trailer)
 	}
 	return models.NewListCacheResponse(resp), nil
 }
@@ -69,9 +87,15 @@ func (client *ScsControlClient) ListCaches(ctx context.Context, request *models.
 func (client *ScsControlClient) CreateStore(ctx context.Context, request *models.CreateStoreRequest) momentoerrors.MomentoSvcErr {
 	ctx, cancel := context.WithTimeout(ctx, ControlCtxTimeout)
 	defer cancel()
-	_, err := client.grpcClient.CreateStore(ctx, &pb.XCreateStoreRequest{StoreName: request.StoreName})
+	var header, trailer metadata.MD
+	_, err := client.grpcClient.CreateStore(
+		ctx,
+		&pb.XCreateStoreRequest{StoreName: request.StoreName},
+		grpc.Header(&header),
+		grpc.Trailer(&trailer),
+	)
 	if err != nil {
-		return momentoerrors.ConvertSvcErr(err)
+		return momentoerrors.ConvertSvcErr(err, header, trailer)
 	}
 	return nil
 }
@@ -95,9 +119,15 @@ func (client *ScsControlClient) DeleteStore(ctx context.Context, request *models
 func (client *ScsControlClient) ListStores(ctx context.Context, request *models.ListStoresRequest) (*models.ListStoresResponse, momentoerrors.MomentoSvcErr) {
 	ctx, cancel := context.WithTimeout(ctx, ControlCtxTimeout)
 	defer cancel()
-	resp, err := client.grpcClient.ListStores(ctx, &pb.XListStoresRequest{NextToken: request.NextToken})
+	var header, trailer metadata.MD
+	resp, err := client.grpcClient.ListStores(
+		ctx,
+		&pb.XListStoresRequest{NextToken: request.NextToken},
+		grpc.Header(&header),
+		grpc.Trailer(&trailer),
+	)
 	if err != nil {
-		return nil, momentoerrors.ConvertSvcErr(err)
+		return nil, momentoerrors.ConvertSvcErr(err, header, trailer)
 	}
 	return models.NewListStoresResponse(resp), nil
 }

--- a/momento/decrease_ttl.go
+++ b/momento/decrease_ttl.go
@@ -6,6 +6,8 @@ import (
 
 	pb "github.com/momentohq/client-sdk-go/internal/protos"
 	"github.com/momentohq/client-sdk-go/responses"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
 )
 
 type DecreaseTtlRequest struct {
@@ -46,15 +48,17 @@ func (r *DecreaseTtlRequest) initGrpcRequest(client scsDataClient) error {
 	return nil
 }
 
-func (r *DecreaseTtlRequest) makeGrpcRequest(metadata context.Context, client scsDataClient) (grpcResponse, error) {
-	resp, err := client.grpcClient.UpdateTtl(metadata, r.grpcRequest)
+func (r *DecreaseTtlRequest) makeGrpcRequest(requestMetadata context.Context, client scsDataClient) (grpcResponse, []metadata.MD, error) {
+	var header, trailer metadata.MD
+	resp, err := client.grpcClient.UpdateTtl(requestMetadata, r.grpcRequest, grpc.Header(&header), grpc.Trailer(&trailer))
+	responseMetadata := []metadata.MD{header, trailer}
 	if err != nil {
-		return nil, err
+		return nil, responseMetadata, err
 	}
 
 	r.grpcResponse = resp
 
-	return resp, nil
+	return resp, nil, nil
 }
 
 func (r *DecreaseTtlRequest) interpretGrpcResponse() error {

--- a/momento/delete.go
+++ b/momento/delete.go
@@ -4,6 +4,8 @@ import (
 	"context"
 
 	"github.com/momentohq/client-sdk-go/responses"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
 
 	pb "github.com/momentohq/client-sdk-go/internal/protos"
 )
@@ -38,15 +40,17 @@ func (r *DeleteRequest) initGrpcRequest(scsDataClient) error {
 	return nil
 }
 
-func (r *DeleteRequest) makeGrpcRequest(metadata context.Context, client scsDataClient) (grpcResponse, error) {
-	resp, err := client.grpcClient.Delete(metadata, r.grpcRequest)
+func (r *DeleteRequest) makeGrpcRequest(requestMetadata context.Context, client scsDataClient) (grpcResponse, []metadata.MD, error) {
+	var header, trailer metadata.MD
+	resp, err := client.grpcClient.Delete(requestMetadata, r.grpcRequest, grpc.Header(&header), grpc.Trailer(&trailer))
+	responseMetadata := []metadata.MD{header, trailer}
 	if err != nil {
-		return nil, err
+		return nil, responseMetadata, err
 	}
 
 	r.grpcResponse = resp
 
-	return resp, nil
+	return resp, nil, nil
 }
 
 func (r *DeleteRequest) interpretGrpcResponse() error {

--- a/momento/dictionary_fetch.go
+++ b/momento/dictionary_fetch.go
@@ -4,6 +4,8 @@ import (
 	"context"
 
 	"github.com/momentohq/client-sdk-go/responses"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
 
 	pb "github.com/momentohq/client-sdk-go/internal/protos"
 )
@@ -33,13 +35,15 @@ func (r *DictionaryFetchRequest) initGrpcRequest(scsDataClient) error {
 	return nil
 }
 
-func (r *DictionaryFetchRequest) makeGrpcRequest(metadata context.Context, client scsDataClient) (grpcResponse, error) {
-	resp, err := client.grpcClient.DictionaryFetch(metadata, r.grpcRequest)
+func (r *DictionaryFetchRequest) makeGrpcRequest(requestMetadata context.Context, client scsDataClient) (grpcResponse, []metadata.MD, error) {
+	var header, trailer metadata.MD
+	resp, err := client.grpcClient.DictionaryFetch(requestMetadata, r.grpcRequest, grpc.Header(&header), grpc.Trailer(&trailer))
+	responseMetadata := []metadata.MD{header, trailer}
 	if err != nil {
-		return nil, err
+		return nil, responseMetadata, err
 	}
 	r.grpcResponse = resp
-	return resp, nil
+	return resp, nil, nil
 }
 
 func (r *DictionaryFetchRequest) interpretGrpcResponse() error {

--- a/momento/dictionary_get_fields.go
+++ b/momento/dictionary_get_fields.go
@@ -4,6 +4,8 @@ import (
 	"context"
 
 	"github.com/momentohq/client-sdk-go/responses"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
 
 	pb "github.com/momentohq/client-sdk-go/internal/protos"
 )
@@ -44,13 +46,15 @@ func (r *DictionaryGetFieldsRequest) initGrpcRequest(scsDataClient) error {
 	return nil
 }
 
-func (r *DictionaryGetFieldsRequest) makeGrpcRequest(metadata context.Context, client scsDataClient) (grpcResponse, error) {
-	resp, err := client.grpcClient.DictionaryGet(metadata, r.grpcRequest)
+func (r *DictionaryGetFieldsRequest) makeGrpcRequest(requestMetadata context.Context, client scsDataClient) (grpcResponse, []metadata.MD, error) {
+	var header, trailer metadata.MD
+	resp, err := client.grpcClient.DictionaryGet(requestMetadata, r.grpcRequest, grpc.Header(&header), grpc.Trailer(&trailer))
+	responseMetadata := []metadata.MD{header, trailer}
 	if err != nil {
-		return nil, err
+		return nil, responseMetadata, err
 	}
 	r.grpcResponse = resp
-	return resp, nil
+	return resp, nil, nil
 }
 
 func (r *DictionaryGetFieldsRequest) interpretGrpcResponse() error {

--- a/momento/dictionary_increment.go
+++ b/momento/dictionary_increment.go
@@ -8,6 +8,8 @@ import (
 	"github.com/momentohq/client-sdk-go/internal/momentoerrors"
 	"github.com/momentohq/client-sdk-go/responses"
 	"github.com/momentohq/client-sdk-go/utils"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
 
 	pb "github.com/momentohq/client-sdk-go/internal/protos"
 )
@@ -71,13 +73,15 @@ func (r *DictionaryIncrementRequest) initGrpcRequest(client scsDataClient) error
 	return nil
 }
 
-func (r *DictionaryIncrementRequest) makeGrpcRequest(metadata context.Context, client scsDataClient) (grpcResponse, error) {
-	resp, err := client.grpcClient.DictionaryIncrement(metadata, r.grpcRequest)
+func (r *DictionaryIncrementRequest) makeGrpcRequest(requestMetadata context.Context, client scsDataClient) (grpcResponse, []metadata.MD, error) {
+	var header, trailer metadata.MD
+	resp, err := client.grpcClient.DictionaryIncrement(requestMetadata, r.grpcRequest, grpc.Header(&header), grpc.Trailer(&trailer))
+	responseMetadata := []metadata.MD{header, trailer}
 	if err != nil {
-		return nil, err
+		return nil, responseMetadata, err
 	}
 	r.grpcResponse = resp
-	return resp, nil
+	return resp, nil, nil
 }
 
 func (r *DictionaryIncrementRequest) interpretGrpcResponse() error {

--- a/momento/dictionary_length.go
+++ b/momento/dictionary_length.go
@@ -4,6 +4,8 @@ import (
 	"context"
 
 	"github.com/momentohq/client-sdk-go/responses"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
 
 	pb "github.com/momentohq/client-sdk-go/internal/protos"
 )
@@ -33,13 +35,15 @@ func (r *DictionaryLengthRequest) initGrpcRequest(scsDataClient) error {
 	return nil
 }
 
-func (r *DictionaryLengthRequest) makeGrpcRequest(metadata context.Context, client scsDataClient) (grpcResponse, error) {
-	resp, err := client.grpcClient.DictionaryLength(metadata, r.grpcRequest)
+func (r *DictionaryLengthRequest) makeGrpcRequest(requestMetadata context.Context, client scsDataClient) (grpcResponse, []metadata.MD, error) {
+	var header, trailer metadata.MD
+	resp, err := client.grpcClient.DictionaryLength(requestMetadata, r.grpcRequest, grpc.Header(&header), grpc.Trailer(&trailer))
+	responseMetadata := []metadata.MD{header, trailer}
 	if err != nil {
-		return nil, err
+		return nil, responseMetadata, err
 	}
 	r.grpcResponse = resp
-	return resp, nil
+	return resp, nil, nil
 }
 
 func (r *DictionaryLengthRequest) interpretGrpcResponse() error {

--- a/momento/dictionary_remove_fields.go
+++ b/momento/dictionary_remove_fields.go
@@ -4,6 +4,8 @@ import (
 	"context"
 
 	"github.com/momentohq/client-sdk-go/responses"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
 
 	pb "github.com/momentohq/client-sdk-go/internal/protos"
 )
@@ -43,13 +45,15 @@ func (r *DictionaryRemoveFieldsRequest) initGrpcRequest(scsDataClient) error {
 	return nil
 }
 
-func (r *DictionaryRemoveFieldsRequest) makeGrpcRequest(metadata context.Context, client scsDataClient) (grpcResponse, error) {
-	resp, err := client.grpcClient.DictionaryDelete(metadata, r.grpcRequest)
+func (r *DictionaryRemoveFieldsRequest) makeGrpcRequest(requestMetadata context.Context, client scsDataClient) (grpcResponse, []metadata.MD, error) {
+	var header, trailer metadata.MD
+	resp, err := client.grpcClient.DictionaryDelete(requestMetadata, r.grpcRequest, grpc.Header(&header), grpc.Trailer(&trailer))
+	responseMetadata := []metadata.MD{header, trailer}
 	if err != nil {
-		return nil, err
+		return nil, responseMetadata, err
 	}
 	r.grpcResponse = resp
-	return resp, nil
+	return resp, nil, nil
 }
 
 func (r *DictionaryRemoveFieldsRequest) interpretGrpcResponse() error {

--- a/momento/dictionary_set_fields.go
+++ b/momento/dictionary_set_fields.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/momentohq/client-sdk-go/responses"
 	"github.com/momentohq/client-sdk-go/utils"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
 
 	pb "github.com/momentohq/client-sdk-go/internal/protos"
 )
@@ -70,13 +72,15 @@ func (r *DictionarySetFieldsRequest) initGrpcRequest(client scsDataClient) error
 	return nil
 }
 
-func (r *DictionarySetFieldsRequest) makeGrpcRequest(metadata context.Context, client scsDataClient) (grpcResponse, error) {
-	resp, err := client.grpcClient.DictionarySet(metadata, r.grpcRequest)
+func (r *DictionarySetFieldsRequest) makeGrpcRequest(requestMetadata context.Context, client scsDataClient) (grpcResponse, []metadata.MD, error) {
+	var header, trailer metadata.MD
+	resp, err := client.grpcClient.DictionarySet(requestMetadata, r.grpcRequest, grpc.Header(&header), grpc.Trailer(&trailer))
+	responseMetadata := []metadata.MD{header, trailer}
 	if err != nil {
-		return nil, err
+		return nil, responseMetadata, err
 	}
 	r.grpcResponse = resp
-	return resp, nil
+	return resp, nil, nil
 }
 
 func (r *DictionarySetFieldsRequest) interpretGrpcResponse() error {

--- a/momento/get.go
+++ b/momento/get.go
@@ -4,6 +4,8 @@ import (
 	"context"
 
 	"github.com/momentohq/client-sdk-go/responses"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
 
 	pb "github.com/momentohq/client-sdk-go/internal/protos"
 )
@@ -40,15 +42,17 @@ func (r *GetRequest) initGrpcRequest(scsDataClient) error {
 	return nil
 }
 
-func (r *GetRequest) makeGrpcRequest(metadata context.Context, client scsDataClient) (grpcResponse, error) {
-	resp, err := client.grpcClient.Get(metadata, r.grpcRequest)
+func (r *GetRequest) makeGrpcRequest(requestMetadata context.Context, client scsDataClient) (grpcResponse, []metadata.MD, error) {
+	var header, trailer metadata.MD
+	resp, err := client.grpcClient.Get(requestMetadata, r.grpcRequest, grpc.Header(&header), grpc.Trailer(&trailer))
+	responseMetadata := []metadata.MD{header, trailer}
 	if err != nil {
-		return nil, err
+		return nil, responseMetadata, err
 	}
 
 	r.grpcResponse = resp
 
-	return resp, nil
+	return resp, nil, nil
 }
 
 func (r *GetRequest) interpretGrpcResponse() error {

--- a/momento/get_batch.go
+++ b/momento/get_batch.go
@@ -7,6 +7,7 @@ import (
 	"github.com/momentohq/client-sdk-go/internal/momentoerrors"
 	pb "github.com/momentohq/client-sdk-go/internal/protos"
 	"github.com/momentohq/client-sdk-go/responses"
+	"google.golang.org/grpc/metadata"
 )
 
 type GetBatchRequest struct {
@@ -49,14 +50,18 @@ func (r *GetBatchRequest) initGrpcRequest(scsDataClient) error {
 	return nil
 }
 
-func (r *GetBatchRequest) makeGrpcRequest(metadata context.Context, client scsDataClient) (grpcResponse, error) {
-	resp, err := client.grpcClient.GetBatch(metadata, r.grpcRequest)
+func (r *GetBatchRequest) makeGrpcRequest(requestMetadata context.Context, client scsDataClient) (grpcResponse, []metadata.MD, error) {
+	var header, trailer metadata.MD
+	resp, err := client.grpcClient.GetBatch(requestMetadata, r.grpcRequest)
+	header, _ = resp.Header()
+	trailer = resp.Trailer()
+	responseMetadata := []metadata.MD{header, trailer}
 	if err != nil {
-		return nil, err
+		return nil, responseMetadata, err
 	}
 	r.grpcStream = resp
 	// Not sure what to return here, don't think it's even used
-	return nil, nil
+	return nil, nil, nil
 }
 
 func (r *GetBatchRequest) interpretGrpcResponse() error {

--- a/momento/increase_ttl.go
+++ b/momento/increase_ttl.go
@@ -6,6 +6,8 @@ import (
 
 	pb "github.com/momentohq/client-sdk-go/internal/protos"
 	"github.com/momentohq/client-sdk-go/responses"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
 )
 
 type IncreaseTtlRequest struct {
@@ -46,15 +48,17 @@ func (r *IncreaseTtlRequest) initGrpcRequest(client scsDataClient) error {
 	return nil
 }
 
-func (r *IncreaseTtlRequest) makeGrpcRequest(metadata context.Context, client scsDataClient) (grpcResponse, error) {
-	resp, err := client.grpcClient.UpdateTtl(metadata, r.grpcRequest)
+func (r *IncreaseTtlRequest) makeGrpcRequest(requestMetadata context.Context, client scsDataClient) (grpcResponse, []metadata.MD, error) {
+	var header, trailer metadata.MD
+	resp, err := client.grpcClient.UpdateTtl(requestMetadata, r.grpcRequest, grpc.Header(&header), grpc.Trailer(&trailer))
+	responseMetadata := []metadata.MD{header, trailer}
 	if err != nil {
-		return nil, err
+		return nil, responseMetadata, err
 	}
 
 	r.grpcResponse = resp
 
-	return resp, nil
+	return resp, nil, nil
 }
 
 func (r *IncreaseTtlRequest) interpretGrpcResponse() error {

--- a/momento/increment.go
+++ b/momento/increment.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/momentohq/client-sdk-go/responses"
 	"github.com/momentohq/client-sdk-go/utils"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
 
 	pb "github.com/momentohq/client-sdk-go/internal/protos"
 )
@@ -53,13 +55,15 @@ func (r *IncrementRequest) initGrpcRequest(client scsDataClient) error {
 	return nil
 }
 
-func (r *IncrementRequest) makeGrpcRequest(metadata context.Context, client scsDataClient) (grpcResponse, error) {
-	resp, err := client.grpcClient.Increment(metadata, r.grpcRequest)
+func (r *IncrementRequest) makeGrpcRequest(requestMetadata context.Context, client scsDataClient) (grpcResponse, []metadata.MD, error) {
+	var header, trailer metadata.MD
+	resp, err := client.grpcClient.Increment(requestMetadata, r.grpcRequest, grpc.Header(&header), grpc.Trailer(&trailer))
+	responseMetadata := []metadata.MD{header, trailer}
 	if err != nil {
-		return nil, err
+		return nil, responseMetadata, err
 	}
 	r.grpcResponse = resp
-	return resp, nil
+	return resp, nil, nil
 }
 
 func (r *IncrementRequest) interpretGrpcResponse() error {

--- a/momento/item_get_ttl.go
+++ b/momento/item_get_ttl.go
@@ -5,6 +5,8 @@ import (
 
 	pb "github.com/momentohq/client-sdk-go/internal/protos"
 	"github.com/momentohq/client-sdk-go/responses"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
 )
 
 type ItemGetTtlRequest struct {
@@ -34,15 +36,17 @@ func (r *ItemGetTtlRequest) initGrpcRequest(scsDataClient) error {
 	return nil
 }
 
-func (r *ItemGetTtlRequest) makeGrpcRequest(metadata context.Context, client scsDataClient) (grpcResponse, error) {
-	resp, err := client.grpcClient.ItemGetTtl(metadata, r.grpcRequest)
+func (r *ItemGetTtlRequest) makeGrpcRequest(requestMetadata context.Context, client scsDataClient) (grpcResponse, []metadata.MD, error) {
+	var header, trailer metadata.MD
+	resp, err := client.grpcClient.ItemGetTtl(requestMetadata, r.grpcRequest, grpc.Header(&header), grpc.Trailer(&trailer))
+	responseMetadata := []metadata.MD{header, trailer}
 	if err != nil {
-		return nil, err
+		return nil, responseMetadata, err
 	}
 
 	r.grpcResponse = resp
 
-	return resp, nil
+	return resp, nil, nil
 }
 
 func (r *ItemGetTtlRequest) interpretGrpcResponse() error {

--- a/momento/item_get_type.go
+++ b/momento/item_get_type.go
@@ -4,6 +4,8 @@ import (
 	"context"
 
 	"github.com/momentohq/client-sdk-go/responses"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
 
 	pb "github.com/momentohq/client-sdk-go/internal/protos"
 )
@@ -35,15 +37,17 @@ func (r *ItemGetTypeRequest) initGrpcRequest(scsDataClient) error {
 	return nil
 }
 
-func (r *ItemGetTypeRequest) makeGrpcRequest(metadata context.Context, client scsDataClient) (grpcResponse, error) {
-	resp, err := client.grpcClient.ItemGetType(metadata, r.grpcRequest)
+func (r *ItemGetTypeRequest) makeGrpcRequest(requestMetadata context.Context, client scsDataClient) (grpcResponse, []metadata.MD, error) {
+	var header, trailer metadata.MD
+	resp, err := client.grpcClient.ItemGetType(requestMetadata, r.grpcRequest, grpc.Header(&header), grpc.Trailer(&trailer))
+	responseMetadata := []metadata.MD{header, trailer}
 	if err != nil {
-		return nil, err
+		return nil, responseMetadata, err
 	}
 
 	r.grpcResponse = resp
 
-	return resp, nil
+	return resp, nil, nil
 }
 
 func (r *ItemGetTypeRequest) interpretGrpcResponse() error {

--- a/momento/keys_exist.go
+++ b/momento/keys_exist.go
@@ -4,6 +4,8 @@ import (
 	"context"
 
 	"github.com/momentohq/client-sdk-go/responses"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
 
 	pb "github.com/momentohq/client-sdk-go/internal/protos"
 )
@@ -37,15 +39,17 @@ func (r *KeysExistRequest) initGrpcRequest(scsDataClient) error {
 	return nil
 }
 
-func (r *KeysExistRequest) makeGrpcRequest(metadata context.Context, client scsDataClient) (grpcResponse, error) {
-	resp, err := client.grpcClient.KeysExist(metadata, r.grpcRequest)
+func (r *KeysExistRequest) makeGrpcRequest(requestMetadata context.Context, client scsDataClient) (grpcResponse, []metadata.MD, error) {
+	var header, trailer metadata.MD
+	resp, err := client.grpcClient.KeysExist(requestMetadata, r.grpcRequest, grpc.Header(&header), grpc.Trailer(&trailer))
+	responseMetadata := []metadata.MD{header, trailer}
 	if err != nil {
-		return nil, err
+		return nil, responseMetadata, err
 	}
 
 	r.grpcResponse = resp
 
-	return resp, nil
+	return resp, nil, nil
 }
 
 func (r *KeysExistRequest) interpretGrpcResponse() error {

--- a/momento/leaderboard_data_client.go
+++ b/momento/leaderboard_data_client.go
@@ -9,6 +9,8 @@ import (
 	"github.com/momentohq/client-sdk-go/internal/models"
 	"github.com/momentohq/client-sdk-go/internal/momentoerrors"
 	pb "github.com/momentohq/client-sdk-go/internal/protos"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
 )
 
 type leaderboardDataClient struct {
@@ -42,12 +44,13 @@ func (client *leaderboardDataClient) delete(ctx context.Context, request *Leader
 
 	requestMetadata := internal.CreateLeaderboardMetadata(ctx, request.CacheName)
 
+	var header, trailer metadata.MD
 	_, err := client.leaderboardClient.DeleteLeaderboard(requestMetadata, &pb.XDeleteLeaderboardRequest{
 		CacheName:   request.CacheName,
 		Leaderboard: request.LeaderboardName,
-	})
+	}, grpc.Header(&header), grpc.Trailer(&trailer))
 	if err != nil {
-		return momentoerrors.ConvertSvcErr(err)
+		return momentoerrors.ConvertSvcErr(err, header, trailer)
 	}
 	return nil
 }
@@ -68,14 +71,15 @@ func (client *leaderboardDataClient) fetchByRank(ctx context.Context, request *L
 		leaderboardOrder = pb.XOrder_DESCENDING
 	}
 
+	var header, trailer metadata.MD
 	result, err := client.leaderboardClient.GetByRank(requestMetadata, &pb.XGetByRankRequest{
 		CacheName:   request.CacheName,
 		Leaderboard: request.LeaderboardName,
 		RankRange:   rankRange,
 		Order:       leaderboardOrder,
-	})
+	}, grpc.Header(&header), grpc.Trailer(&trailer))
 	if err != nil {
-		return nil, momentoerrors.ConvertSvcErr(err)
+		return nil, momentoerrors.ConvertSvcErr(err, header, trailer)
 	}
 	return result.Elements, nil
 }
@@ -115,6 +119,7 @@ func (client *leaderboardDataClient) fetchByScore(ctx context.Context, request *
 		count = *request.Count
 	}
 
+	var header, trailer metadata.MD
 	result, err := client.leaderboardClient.GetByScore(requestMetadata, &pb.XGetByScoreRequest{
 		CacheName:     request.CacheName,
 		Leaderboard:   request.LeaderboardName,
@@ -122,9 +127,9 @@ func (client *leaderboardDataClient) fetchByScore(ctx context.Context, request *
 		Offset:        offset,
 		LimitElements: count,
 		Order:         leaderboardOrder,
-	})
+	}, grpc.Header(&header), grpc.Trailer(&trailer))
 	if err != nil {
-		return nil, momentoerrors.ConvertSvcErr(err)
+		return nil, momentoerrors.ConvertSvcErr(err, header, trailer)
 	}
 	return result.Elements, nil
 }
@@ -140,14 +145,15 @@ func (client *leaderboardDataClient) getRank(ctx context.Context, request *Leade
 
 	requestMetadata := internal.CreateLeaderboardMetadata(ctx, request.CacheName)
 
+	var header, trailer metadata.MD
 	result, err := client.leaderboardClient.GetRank(requestMetadata, &pb.XGetRankRequest{
 		CacheName:   request.CacheName,
 		Leaderboard: request.LeaderboardName,
 		Ids:         request.Ids,
 		Order:       leaderboardOrder,
-	})
+	}, grpc.Header(&header), grpc.Trailer(&trailer))
 	if err != nil {
-		return nil, momentoerrors.ConvertSvcErr(err)
+		return nil, momentoerrors.ConvertSvcErr(err, header, trailer)
 	}
 	return result.Elements, nil
 }
@@ -158,12 +164,13 @@ func (client *leaderboardDataClient) length(ctx context.Context, request *Leader
 
 	requestMetadata := internal.CreateLeaderboardMetadata(ctx, request.CacheName)
 
+	var header, trailer metadata.MD
 	result, err := client.leaderboardClient.GetLeaderboardLength(requestMetadata, &pb.XGetLeaderboardLengthRequest{
 		CacheName:   request.CacheName,
 		Leaderboard: request.LeaderboardName,
-	})
+	}, grpc.Header(&header), grpc.Trailer(&trailer))
 	if err != nil {
-		return 0, momentoerrors.ConvertSvcErr(err)
+		return 0, momentoerrors.ConvertSvcErr(err, header, trailer)
 	}
 	return result.Count, nil
 }
@@ -174,13 +181,14 @@ func (client *leaderboardDataClient) removeElements(ctx context.Context, request
 
 	requestMetadata := internal.CreateLeaderboardMetadata(ctx, request.CacheName)
 
+	var header, trailer metadata.MD
 	_, err := client.leaderboardClient.RemoveElements(requestMetadata, &pb.XRemoveElementsRequest{
 		CacheName:   request.CacheName,
 		Leaderboard: request.LeaderboardName,
 		Ids:         request.Ids,
-	})
+	}, grpc.Header(&header), grpc.Trailer(&trailer))
 	if err != nil {
-		return momentoerrors.ConvertSvcErr(err)
+		return momentoerrors.ConvertSvcErr(err, header, trailer)
 	}
 	return nil
 }
@@ -191,13 +199,14 @@ func (client *leaderboardDataClient) upsert(ctx context.Context, request *Leader
 
 	requestMetadata := internal.CreateLeaderboardMetadata(ctx, request.CacheName)
 
+	var header, trailer metadata.MD
 	_, err := client.leaderboardClient.UpsertElements(requestMetadata, &pb.XUpsertElementsRequest{
 		CacheName:   request.CacheName,
 		Leaderboard: request.LeaderboardName,
 		Elements:    leaderboardUpsertElementToGrpc(request.Elements),
-	})
+	}, grpc.Header(&header), grpc.Trailer(&trailer))
 	if err != nil {
-		return momentoerrors.ConvertSvcErr(err)
+		return momentoerrors.ConvertSvcErr(err, header, trailer)
 	}
 	return nil
 }

--- a/momento/list_concatenate_back.go
+++ b/momento/list_concatenate_back.go
@@ -5,6 +5,8 @@ import (
 	"time"
 
 	"github.com/momentohq/client-sdk-go/responses"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
 
 	pb "github.com/momentohq/client-sdk-go/internal/protos"
 	"github.com/momentohq/client-sdk-go/utils"
@@ -61,13 +63,15 @@ func (r *ListConcatenateBackRequest) initGrpcRequest(client scsDataClient) error
 	return nil
 }
 
-func (r *ListConcatenateBackRequest) makeGrpcRequest(metadata context.Context, client scsDataClient) (grpcResponse, error) {
-	resp, err := client.grpcClient.ListConcatenateBack(metadata, r.grpcRequest)
+func (r *ListConcatenateBackRequest) makeGrpcRequest(requestMetadata context.Context, client scsDataClient) (grpcResponse, []metadata.MD, error) {
+	var header, trailer metadata.MD
+	resp, err := client.grpcClient.ListConcatenateBack(requestMetadata, r.grpcRequest, grpc.Header(&header), grpc.Trailer(&trailer))
+	responseMetadata := []metadata.MD{header, trailer}
 	if err != nil {
-		return nil, err
+		return nil, responseMetadata, err
 	}
 	r.grpcResponse = resp
-	return resp, nil
+	return resp, nil, nil
 }
 
 func (r *ListConcatenateBackRequest) interpretGrpcResponse() error {

--- a/momento/list_concatenate_front.go
+++ b/momento/list_concatenate_front.go
@@ -7,6 +7,8 @@ import (
 	pb "github.com/momentohq/client-sdk-go/internal/protos"
 	"github.com/momentohq/client-sdk-go/responses"
 	"github.com/momentohq/client-sdk-go/utils"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
 )
 
 type ListConcatenateFrontRequest struct {
@@ -60,13 +62,15 @@ func (r *ListConcatenateFrontRequest) initGrpcRequest(client scsDataClient) erro
 	return nil
 }
 
-func (r *ListConcatenateFrontRequest) makeGrpcRequest(metadata context.Context, client scsDataClient) (grpcResponse, error) {
-	resp, err := client.grpcClient.ListConcatenateFront(metadata, r.grpcRequest)
+func (r *ListConcatenateFrontRequest) makeGrpcRequest(requestMetadata context.Context, client scsDataClient) (grpcResponse, []metadata.MD, error) {
+	var header, trailer metadata.MD
+	resp, err := client.grpcClient.ListConcatenateFront(requestMetadata, r.grpcRequest, grpc.Header(&header), grpc.Trailer(&trailer))
+	responseMetadata := []metadata.MD{header, trailer}
 	if err != nil {
-		return nil, err
+		return nil, responseMetadata, err
 	}
 	r.grpcResponse = resp
-	return resp, nil
+	return resp, nil, nil
 }
 
 func (r *ListConcatenateFrontRequest) interpretGrpcResponse() error {

--- a/momento/list_fetch.go
+++ b/momento/list_fetch.go
@@ -4,6 +4,8 @@ import (
 	"context"
 
 	"github.com/momentohq/client-sdk-go/responses"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
 
 	pb "github.com/momentohq/client-sdk-go/internal/protos"
 )
@@ -52,15 +54,17 @@ func (r *ListFetchRequest) initGrpcRequest(scsDataClient) error {
 	return nil
 }
 
-func (r *ListFetchRequest) makeGrpcRequest(metadata context.Context, client scsDataClient) (grpcResponse, error) {
-	resp, err := client.grpcClient.ListFetch(metadata, r.grpcRequest)
+func (r *ListFetchRequest) makeGrpcRequest(requestMetadata context.Context, client scsDataClient) (grpcResponse, []metadata.MD, error) {
+	var header, trailer metadata.MD
+	resp, err := client.grpcClient.ListFetch(requestMetadata, r.grpcRequest, grpc.Header(&header), grpc.Trailer(&trailer))
+	responseMetadata := []metadata.MD{header, trailer}
 	if err != nil {
-		return nil, err
+		return nil, responseMetadata, err
 	}
 
 	r.grpcResponse = resp
 
-	return resp, nil
+	return resp, nil, nil
 }
 
 func (r *ListFetchRequest) interpretGrpcResponse() error {

--- a/momento/list_length.go
+++ b/momento/list_length.go
@@ -4,6 +4,8 @@ import (
 	"context"
 
 	"github.com/momentohq/client-sdk-go/responses"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
 
 	pb "github.com/momentohq/client-sdk-go/internal/protos"
 )
@@ -33,13 +35,15 @@ func (r *ListLengthRequest) initGrpcRequest(scsDataClient) error {
 	return nil
 }
 
-func (r *ListLengthRequest) makeGrpcRequest(metadata context.Context, client scsDataClient) (grpcResponse, error) {
-	resp, err := client.grpcClient.ListLength(metadata, r.grpcRequest)
+func (r *ListLengthRequest) makeGrpcRequest(requestMetadata context.Context, client scsDataClient) (grpcResponse, []metadata.MD, error) {
+	var header, trailer metadata.MD
+	resp, err := client.grpcClient.ListLength(requestMetadata, r.grpcRequest, grpc.Header(&header), grpc.Trailer(&trailer))
+	responseMetadata := []metadata.MD{header, trailer}
 	if err != nil {
-		return nil, err
+		return nil, responseMetadata, err
 	}
 	r.grpcResponse = resp
-	return resp, nil
+	return resp, nil, nil
 }
 
 func (r *ListLengthRequest) interpretGrpcResponse() error {

--- a/momento/list_pop_back.go
+++ b/momento/list_pop_back.go
@@ -4,6 +4,8 @@ import (
 	"context"
 
 	"github.com/momentohq/client-sdk-go/responses"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
 
 	pb "github.com/momentohq/client-sdk-go/internal/protos"
 )
@@ -31,13 +33,15 @@ func (r *ListPopBackRequest) initGrpcRequest(scsDataClient) error {
 	return nil
 }
 
-func (r *ListPopBackRequest) makeGrpcRequest(metadata context.Context, client scsDataClient) (grpcResponse, error) {
-	resp, err := client.grpcClient.ListPopBack(metadata, r.grpcRequest)
+func (r *ListPopBackRequest) makeGrpcRequest(requestMetadata context.Context, client scsDataClient) (grpcResponse, []metadata.MD, error) {
+	var header, trailer metadata.MD
+	resp, err := client.grpcClient.ListPopBack(requestMetadata, r.grpcRequest, grpc.Header(&header), grpc.Trailer(&trailer))
+	responseMetadata := []metadata.MD{header, trailer}
 	if err != nil {
-		return nil, err
+		return nil, responseMetadata, err
 	}
 	r.grpcResponse = resp
-	return resp, nil
+	return resp, nil, nil
 }
 
 func (r *ListPopBackRequest) interpretGrpcResponse() error {

--- a/momento/list_pop_front.go
+++ b/momento/list_pop_front.go
@@ -4,6 +4,8 @@ import (
 	"context"
 
 	"github.com/momentohq/client-sdk-go/responses"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
 
 	pb "github.com/momentohq/client-sdk-go/internal/protos"
 )
@@ -31,13 +33,15 @@ func (r *ListPopFrontRequest) initGrpcRequest(scsDataClient) error {
 	return nil
 }
 
-func (r *ListPopFrontRequest) makeGrpcRequest(metadata context.Context, client scsDataClient) (grpcResponse, error) {
-	resp, err := client.grpcClient.ListPopFront(metadata, r.grpcRequest)
+func (r *ListPopFrontRequest) makeGrpcRequest(requestMetadata context.Context, client scsDataClient) (grpcResponse, []metadata.MD, error) {
+	var header, trailer metadata.MD
+	resp, err := client.grpcClient.ListPopFront(requestMetadata, r.grpcRequest, grpc.Header(&header), grpc.Trailer(&trailer))
+	responseMetadata := []metadata.MD{header, trailer}
 	if err != nil {
-		return nil, err
+		return nil, responseMetadata, err
 	}
 	r.grpcResponse = resp
-	return resp, nil
+	return resp, nil, nil
 }
 
 func (r *ListPopFrontRequest) interpretGrpcResponse() error {

--- a/momento/list_push_back.go
+++ b/momento/list_push_back.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/momentohq/client-sdk-go/responses"
 	"github.com/momentohq/client-sdk-go/utils"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
 
 	pb "github.com/momentohq/client-sdk-go/internal/protos"
 )
@@ -61,13 +63,15 @@ func (r *ListPushBackRequest) initGrpcRequest(client scsDataClient) error {
 	return nil
 }
 
-func (r *ListPushBackRequest) makeGrpcRequest(metadata context.Context, client scsDataClient) (grpcResponse, error) {
-	resp, err := client.grpcClient.ListPushBack(metadata, r.grpcRequest)
+func (r *ListPushBackRequest) makeGrpcRequest(requestMetadata context.Context, client scsDataClient) (grpcResponse, []metadata.MD, error) {
+	var header, trailer metadata.MD
+	resp, err := client.grpcClient.ListPushBack(requestMetadata, r.grpcRequest, grpc.Header(&header), grpc.Trailer(&trailer))
+	responseMetadata := []metadata.MD{header, trailer}
 	if err != nil {
-		return nil, err
+		return nil, responseMetadata, err
 	}
 	r.grpcResponse = resp
-	return resp, nil
+	return resp, nil, nil
 }
 
 func (r *ListPushBackRequest) interpretGrpcResponse() error {

--- a/momento/list_push_front.go
+++ b/momento/list_push_front.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/momentohq/client-sdk-go/responses"
 	"github.com/momentohq/client-sdk-go/utils"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
 
 	pb "github.com/momentohq/client-sdk-go/internal/protos"
 )
@@ -61,13 +63,15 @@ func (r *ListPushFrontRequest) initGrpcRequest(client scsDataClient) error {
 	return nil
 }
 
-func (r *ListPushFrontRequest) makeGrpcRequest(metadata context.Context, client scsDataClient) (grpcResponse, error) {
-	resp, err := client.grpcClient.ListPushFront(metadata, r.grpcRequest)
+func (r *ListPushFrontRequest) makeGrpcRequest(requestMetadata context.Context, client scsDataClient) (grpcResponse, []metadata.MD, error) {
+	var header, trailer metadata.MD
+	resp, err := client.grpcClient.ListPushFront(requestMetadata, r.grpcRequest, grpc.Header(&header), grpc.Trailer(&trailer))
+	responseMetadata := []metadata.MD{header, trailer}
 	if err != nil {
-		return nil, err
+		return nil, responseMetadata, err
 	}
 	r.grpcResponse = resp
-	return resp, nil
+	return resp, nil, nil
 }
 
 func (r *ListPushFrontRequest) interpretGrpcResponse() error {

--- a/momento/list_remove_value.go
+++ b/momento/list_remove_value.go
@@ -4,6 +4,8 @@ import (
 	"context"
 
 	"github.com/momentohq/client-sdk-go/responses"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
 
 	pb "github.com/momentohq/client-sdk-go/internal/protos"
 )
@@ -44,13 +46,15 @@ func (r *ListRemoveValueRequest) initGrpcRequest(scsDataClient) error {
 	return nil
 }
 
-func (r *ListRemoveValueRequest) makeGrpcRequest(metadata context.Context, client scsDataClient) (grpcResponse, error) {
-	resp, err := client.grpcClient.ListRemove(metadata, r.grpcRequest)
+func (r *ListRemoveValueRequest) makeGrpcRequest(requestMetadata context.Context, client scsDataClient) (grpcResponse, []metadata.MD, error) {
+	var header, trailer metadata.MD
+	resp, err := client.grpcClient.ListRemove(requestMetadata, r.grpcRequest, grpc.Header(&header), grpc.Trailer(&trailer))
+	responseMetadata := []metadata.MD{header, trailer}
 	if err != nil {
-		return nil, err
+		return nil, responseMetadata, err
 	}
 	r.grpcResponse = resp
-	return resp, nil
+	return resp, nil, nil
 }
 
 func (r *ListRemoveValueRequest) interpretGrpcResponse() error {

--- a/momento/requester.go
+++ b/momento/requester.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/momentohq/client-sdk-go/utils"
+	"google.golang.org/grpc/metadata"
 
 	"github.com/momentohq/client-sdk-go/internal/momentoerrors"
 )
@@ -30,7 +31,7 @@ func errUnexpectedGrpcResponse(r requester, grpcResp grpcResponse) momentoerrors
 type requester interface {
 	hasCacheName
 	initGrpcRequest(client scsDataClient) error
-	makeGrpcRequest(metadata context.Context, client scsDataClient) (grpcResponse, error)
+	makeGrpcRequest(requestMetadata context.Context, client scsDataClient) (grpcResponse, []metadata.MD, error)
 	interpretGrpcResponse() error
 	requestName() string
 }

--- a/momento/scs_data_client.go
+++ b/momento/scs_data_client.go
@@ -68,9 +68,9 @@ func (client scsDataClient) makeRequest(ctx context.Context, r requester) error 
 
 	requestMetadata := internal.CreateCacheMetadata(ctx, r.cacheName())
 
-	_, err := r.makeGrpcRequest(requestMetadata, client)
+	_, responseMetadata, err := r.makeGrpcRequest(requestMetadata, client)
 	if err != nil {
-		return momentoerrors.ConvertSvcErr(err)
+		return momentoerrors.ConvertSvcErr(err, responseMetadata...)
 	}
 
 	if err := r.interpretGrpcResponse(); err != nil {

--- a/momento/set.go
+++ b/momento/set.go
@@ -5,6 +5,8 @@ import (
 	"time"
 
 	"github.com/momentohq/client-sdk-go/responses"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
 
 	pb "github.com/momentohq/client-sdk-go/internal/protos"
 )
@@ -62,13 +64,15 @@ func (r *SetRequest) initGrpcRequest(client scsDataClient) error {
 	return nil
 }
 
-func (r *SetRequest) makeGrpcRequest(metadata context.Context, client scsDataClient) (grpcResponse, error) {
-	resp, err := client.grpcClient.Set(metadata, r.grpcRequest)
+func (r *SetRequest) makeGrpcRequest(requestMetadata context.Context, client scsDataClient) (grpcResponse, []metadata.MD, error) {
+	var header, trailer metadata.MD
+	resp, err := client.grpcClient.Set(requestMetadata, r.grpcRequest, grpc.Header(&header), grpc.Trailer(&trailer))
+	responseMetadata := []metadata.MD{header, trailer}
 	if err != nil {
-		return nil, err
+		return nil, responseMetadata, err
 	}
 	r.grpcResponse = resp
-	return resp, nil
+	return resp, nil, nil
 }
 
 func (r *SetRequest) interpretGrpcResponse() error {

--- a/momento/set_add_elements.go
+++ b/momento/set_add_elements.go
@@ -5,6 +5,8 @@ import (
 	"time"
 
 	"github.com/momentohq/client-sdk-go/responses"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
 
 	pb "github.com/momentohq/client-sdk-go/internal/protos"
 	"github.com/momentohq/client-sdk-go/utils"
@@ -59,13 +61,15 @@ func (r *SetAddElementsRequest) initGrpcRequest(client scsDataClient) error {
 	return nil
 }
 
-func (r *SetAddElementsRequest) makeGrpcRequest(metadata context.Context, client scsDataClient) (grpcResponse, error) {
-	resp, err := client.grpcClient.SetUnion(metadata, r.grpcRequest)
+func (r *SetAddElementsRequest) makeGrpcRequest(requestMetadata context.Context, client scsDataClient) (grpcResponse, []metadata.MD, error) {
+	var header, trailer metadata.MD
+	resp, err := client.grpcClient.SetUnion(requestMetadata, r.grpcRequest, grpc.Header(&header), grpc.Trailer(&trailer))
+	responseMetadata := []metadata.MD{header, trailer}
 	if err != nil {
-		return nil, err
+		return nil, responseMetadata, err
 	}
 	r.grpcResponse = resp
-	return resp, nil
+	return resp, nil, nil
 }
 
 func (r *SetAddElementsRequest) interpretGrpcResponse() error {

--- a/momento/set_batch.go
+++ b/momento/set_batch.go
@@ -8,6 +8,7 @@ import (
 	"github.com/momentohq/client-sdk-go/internal/momentoerrors"
 	pb "github.com/momentohq/client-sdk-go/internal/protos"
 	"github.com/momentohq/client-sdk-go/responses"
+	"google.golang.org/grpc/metadata"
 )
 
 type SetBatchRequest struct {
@@ -54,14 +55,18 @@ func (r *SetBatchRequest) initGrpcRequest(client scsDataClient) error {
 	return nil
 }
 
-func (r *SetBatchRequest) makeGrpcRequest(metadata context.Context, client scsDataClient) (grpcResponse, error) {
-	resp, err := client.grpcClient.SetBatch(metadata, r.grpcRequest)
+func (r *SetBatchRequest) makeGrpcRequest(requestMetadata context.Context, client scsDataClient) (grpcResponse, []metadata.MD, error) {
+	var header, trailer metadata.MD
+	resp, err := client.grpcClient.SetBatch(requestMetadata, r.grpcRequest)
+	header, _ = resp.Header()
+	trailer = resp.Trailer()
+	responseMetadata := []metadata.MD{header, trailer}
 	if err != nil {
-		return nil, err
+		return nil, responseMetadata, err
 	}
 	r.grpcStream = resp
 	// Not sure what to return here, don't think it's even used
-	return nil, nil
+	return nil, nil, nil
 }
 
 func (r *SetBatchRequest) interpretGrpcResponse() error {

--- a/momento/set_contains_elements.go
+++ b/momento/set_contains_elements.go
@@ -4,6 +4,8 @@ import (
 	"context"
 
 	"github.com/momentohq/client-sdk-go/responses"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
 
 	pb "github.com/momentohq/client-sdk-go/internal/protos"
 )
@@ -42,13 +44,15 @@ func (r *SetContainsElementsRequest) initGrpcRequest(scsDataClient) error {
 	return nil
 }
 
-func (r *SetContainsElementsRequest) makeGrpcRequest(metadata context.Context, client scsDataClient) (grpcResponse, error) {
-	resp, err := client.grpcClient.SetContains(metadata, r.grpcRequest)
+func (r *SetContainsElementsRequest) makeGrpcRequest(requestMetadata context.Context, client scsDataClient) (grpcResponse, []metadata.MD, error) {
+	var header, trailer metadata.MD
+	resp, err := client.grpcClient.SetContains(requestMetadata, r.grpcRequest, grpc.Header(&header), grpc.Trailer(&trailer))
+	responseMetadata := []metadata.MD{header, trailer}
 	if err != nil {
-		return nil, err
+		return nil, responseMetadata, err
 	}
 	r.grpcResponse = resp
-	return resp, nil
+	return resp, nil, nil
 }
 
 func (r *SetContainsElementsRequest) interpretGrpcResponse() error {

--- a/momento/set_fetch.go
+++ b/momento/set_fetch.go
@@ -4,6 +4,8 @@ import (
 	"context"
 
 	"github.com/momentohq/client-sdk-go/responses"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
 
 	pb "github.com/momentohq/client-sdk-go/internal/protos"
 )
@@ -33,13 +35,15 @@ func (r *SetFetchRequest) initGrpcRequest(client scsDataClient) error {
 	return nil
 }
 
-func (r *SetFetchRequest) makeGrpcRequest(metadata context.Context, client scsDataClient) (grpcResponse, error) {
-	resp, err := client.grpcClient.SetFetch(metadata, r.grpcRequest)
+func (r *SetFetchRequest) makeGrpcRequest(requestMetadata context.Context, client scsDataClient) (grpcResponse, []metadata.MD, error) {
+	var header, trailer metadata.MD
+	resp, err := client.grpcClient.SetFetch(requestMetadata, r.grpcRequest, grpc.Header(&header), grpc.Trailer(&trailer))
+	responseMetadata := []metadata.MD{header, trailer}
 	if err != nil {
-		return nil, err
+		return nil, responseMetadata, err
 	}
 	r.grpcResponse = resp
-	return resp, nil
+	return resp, nil, nil
 }
 
 func (r *SetFetchRequest) interpretGrpcResponse() error {

--- a/momento/set_if_absent.go
+++ b/momento/set_if_absent.go
@@ -5,6 +5,8 @@ import (
 	"time"
 
 	"github.com/momentohq/client-sdk-go/responses"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
 
 	pb "github.com/momentohq/client-sdk-go/internal/protos"
 )
@@ -68,13 +70,15 @@ func (r *SetIfAbsentRequest) initGrpcRequest(client scsDataClient) error {
 	return nil
 }
 
-func (r *SetIfAbsentRequest) makeGrpcRequest(metadata context.Context, client scsDataClient) (grpcResponse, error) {
-	resp, err := client.grpcClient.SetIf(metadata, r.grpcRequest)
+func (r *SetIfAbsentRequest) makeGrpcRequest(requestMetadata context.Context, client scsDataClient) (grpcResponse, []metadata.MD, error) {
+	var header, trailer metadata.MD
+	resp, err := client.grpcClient.SetIf(requestMetadata, r.grpcRequest, grpc.Header(&header), grpc.Trailer(&trailer))
+	responseMetadata := []metadata.MD{header, trailer}
 	if err != nil {
-		return nil, err
+		return nil, responseMetadata, err
 	}
 	r.grpcResponse = resp
-	return resp, nil
+	return resp, nil, nil
 }
 
 func (r *SetIfAbsentRequest) interpretGrpcResponse() error {

--- a/momento/set_if_absent_or_equal.go
+++ b/momento/set_if_absent_or_equal.go
@@ -5,6 +5,8 @@ import (
 	"time"
 
 	"github.com/momentohq/client-sdk-go/responses"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
 
 	pb "github.com/momentohq/client-sdk-go/internal/protos"
 )
@@ -77,13 +79,15 @@ func (r *SetIfAbsentOrEqualRequest) initGrpcRequest(client scsDataClient) error 
 	return nil
 }
 
-func (r *SetIfAbsentOrEqualRequest) makeGrpcRequest(metadata context.Context, client scsDataClient) (grpcResponse, error) {
-	resp, err := client.grpcClient.SetIf(metadata, r.grpcRequest)
+func (r *SetIfAbsentOrEqualRequest) makeGrpcRequest(requestMetadata context.Context, client scsDataClient) (grpcResponse, []metadata.MD, error) {
+	var header, trailer metadata.MD
+	resp, err := client.grpcClient.SetIf(requestMetadata, r.grpcRequest, grpc.Header(&header), grpc.Trailer(&trailer))
+	responseMetadata := []metadata.MD{header, trailer}
 	if err != nil {
-		return nil, err
+		return nil, responseMetadata, err
 	}
 	r.grpcResponse = resp
-	return resp, nil
+	return resp, nil, nil
 }
 
 func (r *SetIfAbsentOrEqualRequest) interpretGrpcResponse() error {

--- a/momento/set_if_equal.go
+++ b/momento/set_if_equal.go
@@ -5,6 +5,8 @@ import (
 	"time"
 
 	"github.com/momentohq/client-sdk-go/responses"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
 
 	pb "github.com/momentohq/client-sdk-go/internal/protos"
 )
@@ -77,13 +79,15 @@ func (r *SetIfEqualRequest) initGrpcRequest(client scsDataClient) error {
 	return nil
 }
 
-func (r *SetIfEqualRequest) makeGrpcRequest(metadata context.Context, client scsDataClient) (grpcResponse, error) {
-	resp, err := client.grpcClient.SetIf(metadata, r.grpcRequest)
+func (r *SetIfEqualRequest) makeGrpcRequest(requestMetadata context.Context, client scsDataClient) (grpcResponse, []metadata.MD, error) {
+	var header, trailer metadata.MD
+	resp, err := client.grpcClient.SetIf(requestMetadata, r.grpcRequest, grpc.Header(&header), grpc.Trailer(&trailer))
+	responseMetadata := []metadata.MD{header, trailer}
 	if err != nil {
-		return nil, err
+		return nil, responseMetadata, err
 	}
 	r.grpcResponse = resp
-	return resp, nil
+	return resp, nil, nil
 }
 
 func (r *SetIfEqualRequest) interpretGrpcResponse() error {

--- a/momento/set_if_not_equal.go
+++ b/momento/set_if_not_equal.go
@@ -5,6 +5,8 @@ import (
 	"time"
 
 	"github.com/momentohq/client-sdk-go/responses"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
 
 	pb "github.com/momentohq/client-sdk-go/internal/protos"
 )
@@ -77,13 +79,15 @@ func (r *SetIfNotEqualRequest) initGrpcRequest(client scsDataClient) error {
 	return nil
 }
 
-func (r *SetIfNotEqualRequest) makeGrpcRequest(metadata context.Context, client scsDataClient) (grpcResponse, error) {
-	resp, err := client.grpcClient.SetIf(metadata, r.grpcRequest)
+func (r *SetIfNotEqualRequest) makeGrpcRequest(requestMetadata context.Context, client scsDataClient) (grpcResponse, []metadata.MD, error) {
+	var header, trailer metadata.MD
+	resp, err := client.grpcClient.SetIf(requestMetadata, r.grpcRequest, grpc.Header(&header), grpc.Trailer(&trailer))
+	responseMetadata := []metadata.MD{header, trailer}
 	if err != nil {
-		return nil, err
+		return nil, responseMetadata, err
 	}
 	r.grpcResponse = resp
-	return resp, nil
+	return resp, nil, nil
 }
 
 func (r *SetIfNotEqualRequest) interpretGrpcResponse() error {

--- a/momento/set_if_not_exists.go
+++ b/momento/set_if_not_exists.go
@@ -5,6 +5,8 @@ import (
 	"time"
 
 	"github.com/momentohq/client-sdk-go/responses"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
 
 	pb "github.com/momentohq/client-sdk-go/internal/protos"
 )
@@ -66,13 +68,15 @@ func (r *SetIfNotExistsRequest) initGrpcRequest(client scsDataClient) error {
 	return nil
 }
 
-func (r *SetIfNotExistsRequest) makeGrpcRequest(metadata context.Context, client scsDataClient) (grpcResponse, error) {
-	resp, err := client.grpcClient.SetIf(metadata, r.grpcRequest)
+func (r *SetIfNotExistsRequest) makeGrpcRequest(requestMetadata context.Context, client scsDataClient) (grpcResponse, []metadata.MD, error) {
+	var header, trailer metadata.MD
+	resp, err := client.grpcClient.SetIf(requestMetadata, r.grpcRequest, grpc.Header(&header), grpc.Trailer(&trailer))
+	responseMetadata := []metadata.MD{header, trailer}
 	if err != nil {
-		return nil, err
+		return nil, responseMetadata, err
 	}
 	r.grpcResponse = resp
-	return resp, nil
+	return resp, nil, nil
 }
 
 func (r *SetIfNotExistsRequest) interpretGrpcResponse() error {

--- a/momento/set_if_present.go
+++ b/momento/set_if_present.go
@@ -5,6 +5,8 @@ import (
 	"time"
 
 	"github.com/momentohq/client-sdk-go/responses"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
 
 	pb "github.com/momentohq/client-sdk-go/internal/protos"
 )
@@ -63,13 +65,15 @@ func (r *SetIfPresentRequest) initGrpcRequest(client scsDataClient) error {
 	return nil
 }
 
-func (r *SetIfPresentRequest) makeGrpcRequest(metadata context.Context, client scsDataClient) (grpcResponse, error) {
-	resp, err := client.grpcClient.SetIf(metadata, r.grpcRequest)
+func (r *SetIfPresentRequest) makeGrpcRequest(requestMetadata context.Context, client scsDataClient) (grpcResponse, []metadata.MD, error) {
+	var header, trailer metadata.MD
+	resp, err := client.grpcClient.SetIf(requestMetadata, r.grpcRequest, grpc.Header(&header), grpc.Trailer(&trailer))
+	responseMetadata := []metadata.MD{header, trailer}
 	if err != nil {
-		return nil, err
+		return nil, responseMetadata, err
 	}
 	r.grpcResponse = resp
-	return resp, nil
+	return resp, nil, nil
 }
 
 func (r *SetIfPresentRequest) interpretGrpcResponse() error {

--- a/momento/set_if_present_and_not_equal.go
+++ b/momento/set_if_present_and_not_equal.go
@@ -5,6 +5,8 @@ import (
 	"time"
 
 	"github.com/momentohq/client-sdk-go/responses"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
 
 	pb "github.com/momentohq/client-sdk-go/internal/protos"
 )
@@ -77,13 +79,15 @@ func (r *SetIfPresentAndNotEqualRequest) initGrpcRequest(client scsDataClient) e
 	return nil
 }
 
-func (r *SetIfPresentAndNotEqualRequest) makeGrpcRequest(metadata context.Context, client scsDataClient) (grpcResponse, error) {
-	resp, err := client.grpcClient.SetIf(metadata, r.grpcRequest)
+func (r *SetIfPresentAndNotEqualRequest) makeGrpcRequest(requestMetadata context.Context, client scsDataClient) (grpcResponse, []metadata.MD, error) {
+	var header, trailer metadata.MD
+	resp, err := client.grpcClient.SetIf(requestMetadata, r.grpcRequest, grpc.Header(&header), grpc.Trailer(&trailer))
+	responseMetadata := []metadata.MD{header, trailer}
 	if err != nil {
-		return nil, err
+		return nil, responseMetadata, err
 	}
 	r.grpcResponse = resp
-	return resp, nil
+	return resp, nil, nil
 }
 
 func (r *SetIfPresentAndNotEqualRequest) interpretGrpcResponse() error {

--- a/momento/set_length.go
+++ b/momento/set_length.go
@@ -4,6 +4,8 @@ import (
 	"context"
 
 	"github.com/momentohq/client-sdk-go/responses"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
 
 	pb "github.com/momentohq/client-sdk-go/internal/protos"
 )
@@ -33,13 +35,15 @@ func (r *SetLengthRequest) initGrpcRequest(scsDataClient) error {
 	return nil
 }
 
-func (r *SetLengthRequest) makeGrpcRequest(metadata context.Context, client scsDataClient) (grpcResponse, error) {
-	resp, err := client.grpcClient.SetLength(metadata, r.grpcRequest)
+func (r *SetLengthRequest) makeGrpcRequest(requestMetadata context.Context, client scsDataClient) (grpcResponse, []metadata.MD, error) {
+	var header, trailer metadata.MD
+	resp, err := client.grpcClient.SetLength(requestMetadata, r.grpcRequest, grpc.Header(&header), grpc.Trailer(&trailer))
+	responseMetadata := []metadata.MD{header, trailer}
 	if err != nil {
-		return nil, err
+		return nil, responseMetadata, err
 	}
 	r.grpcResponse = resp
-	return resp, nil
+	return resp, nil, nil
 }
 
 func (r *SetLengthRequest) interpretGrpcResponse() error {

--- a/momento/set_pop.go
+++ b/momento/set_pop.go
@@ -4,6 +4,8 @@ import (
 	"context"
 
 	"github.com/momentohq/client-sdk-go/responses"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
 
 	pb "github.com/momentohq/client-sdk-go/internal/protos"
 )
@@ -42,13 +44,15 @@ func (r *SetPopRequest) initGrpcRequest(client scsDataClient) error {
 	return nil
 }
 
-func (r *SetPopRequest) makeGrpcRequest(metadata context.Context, client scsDataClient) (grpcResponse, error) {
-	resp, err := client.grpcClient.SetPop(metadata, r.grpcRequest)
+func (r *SetPopRequest) makeGrpcRequest(requestMetadata context.Context, client scsDataClient) (grpcResponse, []metadata.MD, error) {
+	var header, trailer metadata.MD
+	resp, err := client.grpcClient.SetPop(requestMetadata, r.grpcRequest, grpc.Header(&header), grpc.Trailer(&trailer))
+	responseMetadata := []metadata.MD{header, trailer}
 	if err != nil {
-		return nil, err
+		return nil, responseMetadata, err
 	}
 	r.grpcResponse = resp
-	return resp, nil
+	return resp, nil, nil
 }
 
 func (r *SetPopRequest) interpretGrpcResponse() error {

--- a/momento/set_remove_elements.go
+++ b/momento/set_remove_elements.go
@@ -4,6 +4,8 @@ import (
 	"context"
 
 	"github.com/momentohq/client-sdk-go/responses"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
 
 	pb "github.com/momentohq/client-sdk-go/internal/protos"
 )
@@ -50,13 +52,15 @@ func (r *SetRemoveElementsRequest) initGrpcRequest(client scsDataClient) error {
 	return nil
 }
 
-func (r *SetRemoveElementsRequest) makeGrpcRequest(metadata context.Context, client scsDataClient) (grpcResponse, error) {
-	resp, err := client.grpcClient.SetDifference(metadata, r.grpcRequest)
+func (r *SetRemoveElementsRequest) makeGrpcRequest(requestMetadata context.Context, client scsDataClient) (grpcResponse, []metadata.MD, error) {
+	var header, trailer metadata.MD
+	resp, err := client.grpcClient.SetDifference(requestMetadata, r.grpcRequest, grpc.Header(&header), grpc.Trailer(&trailer))
+	responseMetadata := []metadata.MD{header, trailer}
 	if err != nil {
-		return nil, err
+		return nil, responseMetadata, err
 	}
 	r.grpcResponse = resp
-	return resp, nil
+	return resp, nil, nil
 }
 
 func (r *SetRemoveElementsRequest) interpretGrpcResponse() error {

--- a/momento/sorted_set_fetch_by_rank.go
+++ b/momento/sorted_set_fetch_by_rank.go
@@ -4,6 +4,8 @@ import (
 	"context"
 
 	"github.com/momentohq/client-sdk-go/responses"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
 
 	pb "github.com/momentohq/client-sdk-go/internal/protos"
 )
@@ -71,15 +73,17 @@ func (r *SortedSetFetchByRankRequest) initGrpcRequest(scsDataClient) error {
 	return nil
 }
 
-func (r *SortedSetFetchByRankRequest) makeGrpcRequest(metadata context.Context, client scsDataClient) (grpcResponse, error) {
-	resp, err := client.grpcClient.SortedSetFetch(metadata, r.grpcRequest)
+func (r *SortedSetFetchByRankRequest) makeGrpcRequest(requestMetadata context.Context, client scsDataClient) (grpcResponse, []metadata.MD, error) {
+	var header, trailer metadata.MD
+	resp, err := client.grpcClient.SortedSetFetch(requestMetadata, r.grpcRequest, grpc.Header(&header), grpc.Trailer(&trailer))
+	responseMetadata := []metadata.MD{header, trailer}
 	if err != nil {
-		return nil, err
+		return nil, responseMetadata, err
 	}
 
 	r.grpcResponse = resp
 
-	return resp, nil
+	return resp, nil, nil
 }
 
 func (r *SortedSetFetchByRankRequest) interpretGrpcResponse() error {

--- a/momento/sorted_set_fetch_by_score.go
+++ b/momento/sorted_set_fetch_by_score.go
@@ -4,6 +4,8 @@ import (
 	"context"
 
 	"github.com/momentohq/client-sdk-go/responses"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
 
 	pb "github.com/momentohq/client-sdk-go/internal/protos"
 )
@@ -81,15 +83,17 @@ func (r *SortedSetFetchByScoreRequest) initGrpcRequest(scsDataClient) error {
 	return nil
 }
 
-func (r *SortedSetFetchByScoreRequest) makeGrpcRequest(metadata context.Context, client scsDataClient) (grpcResponse, error) {
-	resp, err := client.grpcClient.SortedSetFetch(metadata, r.grpcRequest)
+func (r *SortedSetFetchByScoreRequest) makeGrpcRequest(requestMetadata context.Context, client scsDataClient) (grpcResponse, []metadata.MD, error) {
+	var header, trailer metadata.MD
+	resp, err := client.grpcClient.SortedSetFetch(requestMetadata, r.grpcRequest, grpc.Header(&header), grpc.Trailer(&trailer))
+	responseMetadata := []metadata.MD{header, trailer}
 	if err != nil {
-		return nil, err
+		return nil, responseMetadata, err
 	}
 
 	r.grpcResponse = resp
 
-	return resp, nil
+	return resp, nil, nil
 }
 
 func (r *SortedSetFetchByScoreRequest) interpretGrpcResponse() error {

--- a/momento/sorted_set_get_rank.go
+++ b/momento/sorted_set_get_rank.go
@@ -4,6 +4,8 @@ import (
 	"context"
 
 	"github.com/momentohq/client-sdk-go/responses"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
 
 	pb "github.com/momentohq/client-sdk-go/internal/protos"
 )
@@ -48,15 +50,17 @@ func (r *SortedSetGetRankRequest) initGrpcRequest(scsDataClient) error {
 	return nil
 }
 
-func (r *SortedSetGetRankRequest) makeGrpcRequest(metadata context.Context, client scsDataClient) (grpcResponse, error) {
-	resp, err := client.grpcClient.SortedSetGetRank(metadata, r.grpcRequest)
+func (r *SortedSetGetRankRequest) makeGrpcRequest(requestMetadata context.Context, client scsDataClient) (grpcResponse, []metadata.MD, error) {
+	var header, trailer metadata.MD
+	resp, err := client.grpcClient.SortedSetGetRank(requestMetadata, r.grpcRequest, grpc.Header(&header), grpc.Trailer(&trailer))
+	responseMetadata := []metadata.MD{header, trailer}
 	if err != nil {
-		return nil, err
+		return nil, responseMetadata, err
 	}
 
 	r.grpcResponse = resp
 
-	return resp, nil
+	return resp, nil, nil
 }
 
 func (r *SortedSetGetRankRequest) interpretGrpcResponse() error {

--- a/momento/sorted_set_get_scores.go
+++ b/momento/sorted_set_get_scores.go
@@ -4,6 +4,8 @@ import (
 	"context"
 
 	"github.com/momentohq/client-sdk-go/responses"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
 
 	pb "github.com/momentohq/client-sdk-go/internal/protos"
 )
@@ -44,15 +46,17 @@ func (r *SortedSetGetScoresRequest) initGrpcRequest(scsDataClient) error {
 	return nil
 }
 
-func (r *SortedSetGetScoresRequest) makeGrpcRequest(metadata context.Context, client scsDataClient) (grpcResponse, error) {
-	resp, err := client.grpcClient.SortedSetGetScore(metadata, r.grpcRequest)
+func (r *SortedSetGetScoresRequest) makeGrpcRequest(requestMetadata context.Context, client scsDataClient) (grpcResponse, []metadata.MD, error) {
+	var header, trailer metadata.MD
+	resp, err := client.grpcClient.SortedSetGetScore(requestMetadata, r.grpcRequest, grpc.Header(&header), grpc.Trailer(&trailer))
+	responseMetadata := []metadata.MD{header, trailer}
 	if err != nil {
-		return nil, err
+		return nil, responseMetadata, err
 	}
 
 	r.grpcResponse = resp
 
-	return resp, nil
+	return resp, nil, nil
 }
 
 func (r *SortedSetGetScoresRequest) interpretGrpcResponse() error {

--- a/momento/sorted_set_increment_score.go
+++ b/momento/sorted_set_increment_score.go
@@ -6,6 +6,8 @@ import (
 	"time"
 
 	"github.com/momentohq/client-sdk-go/responses"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
 
 	"github.com/momentohq/client-sdk-go/internal/momentoerrors"
 	pb "github.com/momentohq/client-sdk-go/internal/protos"
@@ -71,13 +73,15 @@ func (r *SortedSetIncrementScoreRequest) initGrpcRequest(client scsDataClient) e
 	return nil
 }
 
-func (r *SortedSetIncrementScoreRequest) makeGrpcRequest(metadata context.Context, client scsDataClient) (grpcResponse, error) {
-	resp, err := client.grpcClient.SortedSetIncrement(metadata, r.grpcRequest)
+func (r *SortedSetIncrementScoreRequest) makeGrpcRequest(requestMetadata context.Context, client scsDataClient) (grpcResponse, []metadata.MD, error) {
+	var header, trailer metadata.MD
+	resp, err := client.grpcClient.SortedSetIncrement(requestMetadata, r.grpcRequest, grpc.Header(&header), grpc.Trailer(&trailer))
+	responseMetadata := []metadata.MD{header, trailer}
 	if err != nil {
-		return nil, err
+		return nil, responseMetadata, err
 	}
 	r.grpcResponse = resp
-	return resp, nil
+	return resp, nil, nil
 }
 
 func (r *SortedSetIncrementScoreRequest) interpretGrpcResponse() error {

--- a/momento/sorted_set_length.go
+++ b/momento/sorted_set_length.go
@@ -4,6 +4,8 @@ import (
 	"context"
 
 	"github.com/momentohq/client-sdk-go/responses"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
 
 	pb "github.com/momentohq/client-sdk-go/internal/protos"
 )
@@ -33,13 +35,15 @@ func (r *SortedSetLengthRequest) initGrpcRequest(scsDataClient) error {
 	return nil
 }
 
-func (r *SortedSetLengthRequest) makeGrpcRequest(metadata context.Context, client scsDataClient) (grpcResponse, error) {
-	resp, err := client.grpcClient.SortedSetLength(metadata, r.grpcRequest)
+func (r *SortedSetLengthRequest) makeGrpcRequest(requestMetadata context.Context, client scsDataClient) (grpcResponse, []metadata.MD, error) {
+	var header, trailer metadata.MD
+	resp, err := client.grpcClient.SortedSetLength(requestMetadata, r.grpcRequest, grpc.Header(&header), grpc.Trailer(&trailer))
+	responseMetadata := []metadata.MD{header, trailer}
 	if err != nil {
-		return nil, err
+		return nil, responseMetadata, err
 	}
 	r.grpcResponse = resp
-	return resp, nil
+	return resp, nil, nil
 }
 
 func (r *SortedSetLengthRequest) interpretGrpcResponse() error {

--- a/momento/sorted_set_length_by_score.go
+++ b/momento/sorted_set_length_by_score.go
@@ -4,6 +4,8 @@ import (
 	"context"
 
 	"github.com/momentohq/client-sdk-go/responses"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
 
 	pb "github.com/momentohq/client-sdk-go/internal/protos"
 )
@@ -59,13 +61,15 @@ func (r *SortedSetLengthByScoreRequest) initGrpcRequest(scsDataClient) error {
 	return nil
 }
 
-func (r *SortedSetLengthByScoreRequest) makeGrpcRequest(metadata context.Context, client scsDataClient) (grpcResponse, error) {
-	resp, err := client.grpcClient.SortedSetLengthByScore(metadata, r.grpcRequest)
+func (r *SortedSetLengthByScoreRequest) makeGrpcRequest(requestMetadata context.Context, client scsDataClient) (grpcResponse, []metadata.MD, error) {
+	var header, trailer metadata.MD
+	resp, err := client.grpcClient.SortedSetLengthByScore(requestMetadata, r.grpcRequest, grpc.Header(&header), grpc.Trailer(&trailer))
+	responseMetadata := []metadata.MD{header, trailer}
 	if err != nil {
-		return nil, err
+		return nil, responseMetadata, err
 	}
 	r.grpcResponse = resp
-	return resp, nil
+	return resp, nil, nil
 }
 
 func (r *SortedSetLengthByScoreRequest) interpretGrpcResponse() error {

--- a/momento/sorted_set_put_elements.go
+++ b/momento/sorted_set_put_elements.go
@@ -7,6 +7,8 @@ import (
 	"github.com/momentohq/client-sdk-go/internal/momentoerrors"
 	"github.com/momentohq/client-sdk-go/responses"
 	"github.com/momentohq/client-sdk-go/utils"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
 
 	pb "github.com/momentohq/client-sdk-go/internal/protos"
 )
@@ -57,13 +59,15 @@ func (r *SortedSetPutElementsRequest) initGrpcRequest(client scsDataClient) erro
 	return nil
 }
 
-func (r *SortedSetPutElementsRequest) makeGrpcRequest(metadata context.Context, client scsDataClient) (grpcResponse, error) {
-	resp, err := client.grpcClient.SortedSetPut(metadata, r.grpcRequest)
+func (r *SortedSetPutElementsRequest) makeGrpcRequest(requestMetadata context.Context, client scsDataClient) (grpcResponse, []metadata.MD, error) {
+	var header, trailer metadata.MD
+	resp, err := client.grpcClient.SortedSetPut(requestMetadata, r.grpcRequest, grpc.Header(&header), grpc.Trailer(&trailer))
+	responseMetadata := []metadata.MD{header, trailer}
 	if err != nil {
-		return nil, err
+		return nil, responseMetadata, err
 	}
 	r.grpcResponse = resp
-	return resp, nil
+	return resp, nil, nil
 }
 
 func (r *SortedSetPutElementsRequest) interpretGrpcResponse() error {

--- a/momento/sorted_set_remove_elements.go
+++ b/momento/sorted_set_remove_elements.go
@@ -4,6 +4,8 @@ import (
 	"context"
 
 	"github.com/momentohq/client-sdk-go/responses"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
 
 	pb "github.com/momentohq/client-sdk-go/internal/protos"
 )
@@ -49,15 +51,17 @@ func (r *SortedSetRemoveElementsRequest) initGrpcRequest(scsDataClient) error {
 	return nil
 }
 
-func (r *SortedSetRemoveElementsRequest) makeGrpcRequest(metadata context.Context, client scsDataClient) (grpcResponse, error) {
-	resp, err := client.grpcClient.SortedSetRemove(metadata, r.grpcRequest)
+func (r *SortedSetRemoveElementsRequest) makeGrpcRequest(requestMetadata context.Context, client scsDataClient) (grpcResponse, []metadata.MD, error) {
+	var header, trailer metadata.MD
+	resp, err := client.grpcClient.SortedSetRemove(requestMetadata, r.grpcRequest, grpc.Header(&header), grpc.Trailer(&trailer))
+	responseMetadata := []metadata.MD{header, trailer}
 	if err != nil {
-		return nil, err
+		return nil, responseMetadata, err
 	}
 
 	r.grpcResponse = resp
 
-	return resp, nil
+	return resp, nil, nil
 }
 
 func (r *SortedSetRemoveElementsRequest) interpretGrpcResponse() error {

--- a/momento/token_client.go
+++ b/momento/token_client.go
@@ -12,6 +12,8 @@ import (
 	pb "github.com/momentohq/client-sdk-go/internal/protos"
 	auth_responses "github.com/momentohq/client-sdk-go/responses/auth"
 	"github.com/momentohq/client-sdk-go/utils"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
 )
 
 type tokenClient struct {
@@ -265,6 +267,7 @@ func (client *tokenClient) GenerateDisposableToken(ctx context.Context, request 
 		tokenId = *request.Props.TokenId
 	}
 
+	var header, trailer metadata.MD
 	resp, err := client.grpcClient.GenerateDisposableToken(ctx, &pb.XGenerateDisposableTokenRequest{
 		AuthToken: client.grpcManager.AuthToken,
 		Expires: &pb.XGenerateDisposableTokenRequest_Expires{
@@ -278,9 +281,9 @@ func (client *tokenClient) GenerateDisposableToken(ctx context.Context, request 
 			},
 		},
 		TokenId: tokenId,
-	})
+	}, grpc.Header(&header), grpc.Trailer(&trailer))
 	if err != nil {
-		return nil, momentoerrors.ConvertSvcErr(err)
+		return nil, momentoerrors.ConvertSvcErr(err, header, trailer)
 	}
 
 	jsonObject := map[string]string{

--- a/momento/topic_client.go
+++ b/momento/topic_client.go
@@ -160,7 +160,7 @@ func (c defaultTopicClient) Publish(ctx context.Context, request *TopicPublishRe
 
 	if err != nil {
 		c.log.Debug("failed to topic publish...")
-		return nil, momentoerrors.ConvertSvcErr(err)
+		return nil, err
 	}
 
 	return &responses.TopicPublishSuccess{}, err

--- a/momento/update_ttl.go
+++ b/momento/update_ttl.go
@@ -6,6 +6,8 @@ import (
 
 	pb "github.com/momentohq/client-sdk-go/internal/protos"
 	"github.com/momentohq/client-sdk-go/responses"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
 )
 
 type UpdateTtlRequest struct {
@@ -46,15 +48,17 @@ func (r *UpdateTtlRequest) initGrpcRequest(client scsDataClient) error {
 	return nil
 }
 
-func (r *UpdateTtlRequest) makeGrpcRequest(metadata context.Context, client scsDataClient) (grpcResponse, error) {
-	resp, err := client.grpcClient.UpdateTtl(metadata, r.grpcRequest)
+func (r *UpdateTtlRequest) makeGrpcRequest(requestMetadata context.Context, client scsDataClient) (grpcResponse, []metadata.MD, error) {
+	var header, trailer metadata.MD
+	resp, err := client.grpcClient.UpdateTtl(requestMetadata, r.grpcRequest, grpc.Header(&header), grpc.Trailer(&trailer))
+	responseMetadata := []metadata.MD{header, trailer}
 	if err != nil {
-		return nil, err
+		return nil, responseMetadata, err
 	}
 
 	r.grpcResponse = resp
 
-	return resp, nil
+	return resp, nil, nil
 }
 
 func (r *UpdateTtlRequest) interpretGrpcResponse() error {


### PR DESCRIPTION
Closes https://github.com/momentohq/dev-eco-issue-tracker/issues/1038

- When a RESOURCE_EXHAUSTED error is received, we now parse the `err` metadata in order to report the cause in the message wrapper. If the metadata is not available, we try to use string matching on the error details.
- Adds the missing message wrapper component for consistency with the other SDKs.
- Adds ability to get header and trailer metadata (as per the [docs](https://github.com/grpc/grpc-go/blob/master/Documentation/grpc-metadata.md#unary-call)) from each RPC call across the various clients. Otherwise, metadata is not available for parsing.
- Deprecates `AlreadyExistsError` in favor of `CacheAlreadyExistsError` and `StoreAlreadyExistsError` for consistency with the other SDKs.