### PR TITLE
fix: add nil check before grabbing metadata when retrying subscribe

### DIFF
--- a/momento/pubsub_client.go
+++ b/momento/pubsub_client.go
@@ -99,8 +99,10 @@ func (client *pubSubClient) topicSubscribe(ctx context.Context, request *TopicSu
 	if err != nil {
 		atomic.AddInt64(&numGrpcStreams, -1)
 		cancelFunction()
-		header, _ = clientStream.Header()
-		trailer = clientStream.Trailer()
+		if clientStream != nil {
+			header, _ = clientStream.Header()
+			trailer = clientStream.Trailer()
+		}
 		return nil, nil, nil, nil, momentoerrors.ConvertSvcErr(err, header, trailer)
 	}
 


### PR DESCRIPTION
When testing locally, ran into a segfault error when entering the topic resubscribe loop, causing it to panic and not attempt to resubscribe.

This PR adds a nil check that avoids the segfault error:
```
[2024-11-06T22:37:04Z] ERROR (topic-client): stream disconnected YO, attempting to reconnect err:%!(EXTRA string=rpc error: code = Unavailable desc = keepalive ping failed to receive ACK within timeout)
[2024-11-06T22:37:04Z] INFO (topic-client): Attempting reconnecting to client stream
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x28 pc=0x10337a988]
```