### PR TITLE
feat: document all rpc's and if they are idempotent or not

### DIFF
--- a/internal/retry/eligibility_strategy.go
+++ b/internal/retry/eligibility_strategy.go
@@ -15,9 +15,9 @@ var retryableStatusCodes = map[codes.Code]bool{
 }
 
 var retryableRequestMethods = map[string]bool{
-	"/cache_client.Scs/Get":    true,
+	"/cache_client.Scs/Get": true,
 	// NEW and idempotent "/cache_client.Scs/GetBatch"
-	"/cache_client.Scs/Set":    true,
+	"/cache_client.Scs/Set": true,
 	// NEW and idempotent "/cache_client.Scs/SetBatch"
 	// NEW and _NOT_ idempotent "/cache_client.Scs/SetIf"
 
@@ -29,17 +29,17 @@ var retryableRequestMethods = map[string]bool{
 	// NEW and idempotent "/cache_client.Scs/ItemGetTtl"
 	// NEW and idempotent "/cache_client.Scs/ItemGetType"
 
-	"/cache_client.Scs/DictionaryGet":    true,
-	"/cache_client.Scs/DictionaryFetch":  true,
-	"/cache_client.Scs/DictionarySet": true,
+	"/cache_client.Scs/DictionaryGet":   true,
+	"/cache_client.Scs/DictionaryFetch": true,
+	"/cache_client.Scs/DictionarySet":   true,
 	// not idempotent: "/cache_client.Scs/DictionaryIncrement",
 	"/cache_client.Scs/DictionaryDelete": true,
 	// NEW and idempotent "/cache_client.Scs/DictionaryLength"
 
-	"/cache_client.Scs/SetFetch":         true,
+	"/cache_client.Scs/SetFetch": true,
 	// NEW and idempotent "/cache_client.Scs/SetSample"
-	"/cache_client.Scs/SetUnion":         true,
-	"/cache_client.Scs/SetDifference":    true,
+	"/cache_client.Scs/SetUnion":      true,
+	"/cache_client.Scs/SetDifference": true,
 	// NEW and idempotent "/cache_client.Scs/SetContains"
 	// NEW and idempotent "/cache_client.Scs/SetLength"
 	// NEW and _NOT_ idempotent "/cache_client.Scs/SetPop"
@@ -54,7 +54,7 @@ var retryableRequestMethods = map[string]bool{
 	// In the future, we may also add "the first/last N occurrences of a value".
 	// In the latter case it is not idempotent.
 	"/cache_client.Scs/ListRemove": true,
-	"/cache_client.Scs/ListFetch": true,
+	"/cache_client.Scs/ListFetch":  true,
 	"/cache_client.Scs/ListLength": true,
 	// not idempotent: "/cache_client.Scs/ListConcatenateFront",
 	// not idempotent: "/cache_client.Scs/ListConcatenateBack"

--- a/internal/retry/eligibility_strategy.go
+++ b/internal/retry/eligibility_strategy.go
@@ -25,10 +25,9 @@ var retryableRequestMethods = map[string]bool{
 	"/cache_client.Scs/Delete":         true,
 	"/cache_client.Scs/KeysExist":      true,
 	"/cache_client.Scs/Increment":      false,
-	// UpdateTtl is idempotent on the server but return values can be different if the first call is successful.
-	"/cache_client.Scs/UpdateTtl":   true,
-	"/cache_client.Scs/ItemGetTtl":  true,
-	"/cache_client.Scs/ItemGetType": true,
+	"/cache_client.Scs/UpdateTtl":      false,
+	"/cache_client.Scs/ItemGetTtl":     true,
+	"/cache_client.Scs/ItemGetType":    true,
 
 	"/cache_client.Scs/DictionaryGet":       true,
 	"/cache_client.Scs/DictionaryFetch":     true,
@@ -50,11 +49,7 @@ var retryableRequestMethods = map[string]bool{
 	"/cache_client.Scs/ListPopFront":  false,
 	"/cache_client.Scs/ListPopBack":   false,
 	// Not used, and unknown "/cache_client.Scs/ListErase",
-	// Warning: in the future, ListRemove may not be idempotent
-	// Currently it supports removing all occurrences of a value.
-	// In the future, we may also add "the first/last N occurrences of a value".
-	// In the latter case it is not idempotent.
-	"/cache_client.Scs/ListRemove":           true,
+	"/cache_client.Scs/ListRemove":           false,
 	"/cache_client.Scs/ListFetch":            true,
 	"/cache_client.Scs/ListLength":           true,
 	"/cache_client.Scs/ListConcatenateFront": false,

--- a/internal/retry/eligibility_strategy.go
+++ b/internal/retry/eligibility_strategy.go
@@ -15,59 +15,60 @@ var retryableStatusCodes = map[codes.Code]bool{
 }
 
 var retryableRequestMethods = map[string]bool{
-	"/cache_client.Scs/Get": true,
-	// NEW and idempotent "/cache_client.Scs/GetBatch"
-	"/cache_client.Scs/Set": true,
-	// NEW and idempotent "/cache_client.Scs/SetBatch"
-	// NEW and _NOT_ idempotent "/cache_client.Scs/SetIf"
+	"/cache_client.Scs/Get":      true,
+	"/cache_client.Scs/GetBatch": true,
+	"/cache_client.Scs/Set":      true,
+	"/cache_client.Scs/SetBatch": true,
+	"/cache_client.Scs/SetIf":    false,
+	// SetIfNotExists is deprecated
+	"/cache_client.Scs/SetIfNotExists": false,
+	"/cache_client.Scs/Delete":         true,
+	"/cache_client.Scs/KeysExist":      true,
+	"/cache_client.Scs/Increment":      false,
+	// Idempotent on the server but return values can be different if the first call is successful.
+	"/cache_client.Scs/UpdateTtl":   true,
+	"/cache_client.Scs/ItemGetTtl":  true,
+	"/cache_client.Scs/ItemGetType": true,
 
-	// deprecated and not idempotent "/cache_client.Scs/SetIfNotExists"
-	"/cache_client.Scs/Delete": true,
-	// NEW and idempotent "/cache_client.Scs/KeysExist"
-	// not idempotent "/cache_client.Scs/Increment"
-	// NEW and server-idempotent but return values can be different "/cache_client.Scs/UpdateTtl"
-	// NEW and idempotent "/cache_client.Scs/ItemGetTtl"
-	// NEW and idempotent "/cache_client.Scs/ItemGetType"
+	"/cache_client.Scs/DictionaryGet":       true,
+	"/cache_client.Scs/DictionaryFetch":     true,
+	"/cache_client.Scs/DictionarySet":       true,
+	"/cache_client.Scs/DictionaryIncrement": false,
+	"/cache_client.Scs/DictionaryDelete":    true,
+	"/cache_client.Scs/DictionaryLength":    true,
 
-	"/cache_client.Scs/DictionaryGet":   true,
-	"/cache_client.Scs/DictionaryFetch": true,
-	"/cache_client.Scs/DictionarySet":   true,
-	// not idempotent: "/cache_client.Scs/DictionaryIncrement",
-	"/cache_client.Scs/DictionaryDelete": true,
-	// NEW and idempotent "/cache_client.Scs/DictionaryLength"
-
-	"/cache_client.Scs/SetFetch": true,
-	// NEW and idempotent "/cache_client.Scs/SetSample"
+	"/cache_client.Scs/SetFetch":      true,
+	"/cache_client.Scs/SetSample":     true,
 	"/cache_client.Scs/SetUnion":      true,
 	"/cache_client.Scs/SetDifference": true,
-	// NEW and idempotent "/cache_client.Scs/SetContains"
-	// NEW and idempotent "/cache_client.Scs/SetLength"
-	// NEW and _NOT_ idempotent "/cache_client.Scs/SetPop"
+	"/cache_client.Scs/SetContains":   true,
+	"/cache_client.Scs/SetLength":     true,
+	"/cache_client.Scs/SetPop":        false,
 
-	// not idempotent: "/cache_client.Scs/ListPushFront",
-	// not idempotent: "/cache_client.Scs/ListPushBack",
-	// not idempotent: "/cache_client.Scs/ListPopFront",
-	// not idempotent: "/cache_client.Scs/ListPopBack",
-	// NEW, not used, and unknown "/cache_client.Scs/ListErase",
-	// Warning: in the future, this may not be idempotent
+	"/cache_client.Scs/ListPushFront": false,
+	"/cache_client.Scs/ListPushBack":  false,
+	"/cache_client.Scs/ListPopFront":  false,
+	"/cache_client.Scs/ListPopBack":   false,
+	// Not used, and unknown "/cache_client.Scs/ListErase",
+	// Warning: in the future, ListRemove may not be idempotent
 	// Currently it supports removing all occurrences of a value.
 	// In the future, we may also add "the first/last N occurrences of a value".
 	// In the latter case it is not idempotent.
-	"/cache_client.Scs/ListRemove": true,
-	"/cache_client.Scs/ListFetch":  true,
-	"/cache_client.Scs/ListLength": true,
-	// not idempotent: "/cache_client.Scs/ListConcatenateFront",
-	// not idempotent: "/cache_client.Scs/ListConcatenateBack"
-	// NEW and _NOT_ idempotent "/cache_client.Scs/ListRetain"
+	"/cache_client.Scs/ListRemove":           true,
+	"/cache_client.Scs/ListFetch":            true,
+	"/cache_client.Scs/ListLength":           true,
+	"/cache_client.Scs/ListConcatenateFront": false,
+	"/cache_client.Scs/ListConcatenateBack":  false,
+	"/cache_client.Scs/ListRetain":           false,
 
-	// NEW and idempotent "/cache_client.Scs/SortedSetPut"
-	// NEW and idempotent "/cache_client.Scs/SortedSetFetch"
-	// NEW and idempotent "/cache_client.Scs/SortedSetGetScore"
-	// NEW and idempotent "/cache_client.Scs/SortedSetRemove"
-	// NEW and _NOT_ idempotent "/cache_client.Scs/SortedSetIncrement"
-	// NEW and idempotent "/cache_client.Scs/SortedSetGetRank"
-	// NEW and idempotent "/cache_client.Scs/SortedSetLength"
-	// NEW and idempotent "/cache_client.Scs/SortedSetLengthByScore"
+	"/cache_client.Scs/SortedSetPut":           true,
+	"/cache_client.Scs/SortedSetFetch":         true,
+	"/cache_client.Scs/SortedSetGetScore":      true,
+	"/cache_client.Scs/SortedSetRemove":        true,
+	"/cache_client.Scs/SortedSetIncrement":     false,
+	"/cache_client.Scs/SortedSetGetRank":       true,
+	"/cache_client.Scs/SortedSetLength":        true,
+	"/cache_client.Scs/SortedSetLengthByScore": true,
 
 	"/cache_client.pubsub.Pubsub/Subscribe": true,
 }

--- a/internal/retry/eligibility_strategy.go
+++ b/internal/retry/eligibility_strategy.go
@@ -15,32 +15,60 @@ var retryableStatusCodes = map[codes.Code]bool{
 }
 
 var retryableRequestMethods = map[string]bool{
-	"/cache_client.Scs/Set":    true,
 	"/cache_client.Scs/Get":    true,
+	// NEW and idempotent "/cache_client.Scs/GetBatch"
+	"/cache_client.Scs/Set":    true,
+	// NEW and idempotent "/cache_client.Scs/SetBatch"
+	// NEW and _NOT_ idempotent "/cache_client.Scs/SetIf"
+
+	// deprecated and not idempotent "/cache_client.Scs/SetIfNotExists"
 	"/cache_client.Scs/Delete": true,
+	// NEW and idempotent "/cache_client.Scs/KeysExist"
 	// not idempotent "/cache_client.Scs/Increment"
-	"/cache_client.Scs/DictionarySet": true,
-	// not idempotent: "/cache_client.Scs/DictionaryIncrement",
+	// NEW and server-idempotent but return values can be different "/cache_client.Scs/UpdateTtl"
+	// NEW and idempotent "/cache_client.Scs/ItemGetTtl"
+	// NEW and idempotent "/cache_client.Scs/ItemGetType"
+
 	"/cache_client.Scs/DictionaryGet":    true,
 	"/cache_client.Scs/DictionaryFetch":  true,
+	"/cache_client.Scs/DictionarySet": true,
+	// not idempotent: "/cache_client.Scs/DictionaryIncrement",
 	"/cache_client.Scs/DictionaryDelete": true,
+	// NEW and idempotent "/cache_client.Scs/DictionaryLength"
+
+	"/cache_client.Scs/SetFetch":         true,
+	// NEW and idempotent "/cache_client.Scs/SetSample"
 	"/cache_client.Scs/SetUnion":         true,
 	"/cache_client.Scs/SetDifference":    true,
-	"/cache_client.Scs/SetFetch":         true,
-	// not idempotent: "/cache_client.Scs/SetIfNotExists"
+	// NEW and idempotent "/cache_client.Scs/SetContains"
+	// NEW and idempotent "/cache_client.Scs/SetLength"
+	// NEW and _NOT_ idempotent "/cache_client.Scs/SetPop"
+
 	// not idempotent: "/cache_client.Scs/ListPushFront",
 	// not idempotent: "/cache_client.Scs/ListPushBack",
 	// not idempotent: "/cache_client.Scs/ListPopFront",
 	// not idempotent: "/cache_client.Scs/ListPopBack",
-	"/cache_client.Scs/ListFetch": true,
+	// NEW, not used, and unknown "/cache_client.Scs/ListErase",
 	// Warning: in the future, this may not be idempotent
 	// Currently it supports removing all occurrences of a value.
 	// In the future, we may also add "the first/last N occurrences of a value".
 	// In the latter case it is not idempotent.
 	"/cache_client.Scs/ListRemove": true,
+	"/cache_client.Scs/ListFetch": true,
 	"/cache_client.Scs/ListLength": true,
 	// not idempotent: "/cache_client.Scs/ListConcatenateFront",
 	// not idempotent: "/cache_client.Scs/ListConcatenateBack"
+	// NEW and _NOT_ idempotent "/cache_client.Scs/ListRetain"
+
+	// NEW and idempotent "/cache_client.Scs/SortedSetPut"
+	// NEW and idempotent "/cache_client.Scs/SortedSetFetch"
+	// NEW and idempotent "/cache_client.Scs/SortedSetGetScore"
+	// NEW and idempotent "/cache_client.Scs/SortedSetRemove"
+	// NEW and _NOT_ idempotent "/cache_client.Scs/SortedSetIncrement"
+	// NEW and idempotent "/cache_client.Scs/SortedSetGetRank"
+	// NEW and idempotent "/cache_client.Scs/SortedSetLength"
+	// NEW and idempotent "/cache_client.Scs/SortedSetLengthByScore"
+
 	"/cache_client.pubsub.Pubsub/Subscribe": true,
 }
 

--- a/internal/retry/eligibility_strategy.go
+++ b/internal/retry/eligibility_strategy.go
@@ -49,7 +49,7 @@ var retryableRequestMethods = map[string]bool{
 	"/cache_client.Scs/ListPopFront":  false,
 	"/cache_client.Scs/ListPopBack":   false,
 	// Not used, and unknown "/cache_client.Scs/ListErase",
-	"/cache_client.Scs/ListRemove":           false,
+	"/cache_client.Scs/ListRemove":           true,
 	"/cache_client.Scs/ListFetch":            true,
 	"/cache_client.Scs/ListLength":           true,
 	"/cache_client.Scs/ListConcatenateFront": false,

--- a/internal/retry/eligibility_strategy.go
+++ b/internal/retry/eligibility_strategy.go
@@ -25,7 +25,7 @@ var retryableRequestMethods = map[string]bool{
 	"/cache_client.Scs/Delete":         true,
 	"/cache_client.Scs/KeysExist":      true,
 	"/cache_client.Scs/Increment":      false,
-	// Idempotent on the server but return values can be different if the first call is successful.
+	// UpdateTtl is idempotent on the server but return values can be different if the first call is successful.
 	"/cache_client.Scs/UpdateTtl":   true,
 	"/cache_client.Scs/ItemGetTtl":  true,
 	"/cache_client.Scs/ItemGetType": true,


### PR DESCRIPTION
Based on the current cache service proto, we add in all RPCs. For
maintainability, we arrange them in the same order as in the proto
file. For the RPCs that are new relative to when this was last
updated, add a comment and mark whether they are retryable or not.
