### PR TITLE
feat: do not retry on cancelled codes

### DIFF
--- a/internal/retry/eligibility_strategy.go
+++ b/internal/retry/eligibility_strategy.go
@@ -9,7 +9,6 @@ type EligibilityStrategy interface {
 }
 
 var retryableStatusCodes = map[codes.Code]bool{
-	codes.Canceled:    true,
 	codes.Internal:    true,
 	codes.Unavailable: true,
 }


### PR DESCRIPTION
Since the client may cancel the context, we do not retry on cancelled
errors. This reverts d62e27d.
