### PR TITLE
fix: use atomic reads when using atomic writes

### DIFF
--- a/momento/cache_client.go
+++ b/momento/cache_client.go
@@ -18,7 +18,7 @@ import (
 	"github.com/momentohq/client-sdk-go/responses"
 )
 
-var dataClientCount uint64
+var dataClientCount atomic.Uint64
 
 type CacheClient interface {
 	Logger() logger.MomentoLogger
@@ -312,8 +312,8 @@ func (c defaultScsClient) getCacheNameForRequest(request hasCacheName) string {
 }
 
 func (c defaultScsClient) getNextDataClient() *scsDataClient {
-	nextClientIndex := atomic.AddUint64(&dataClientCount, 1)
-	dataClient := c.dataClients[atomic.LoadUint64(&nextClientIndex)%uint64(len(c.dataClients))]
+	nextClientIndex := dataClientCount.Add(1)
+	dataClient := c.dataClients[nextClientIndex%uint64(len(c.dataClients))]
 	return dataClient
 }
 

--- a/momento/cache_client.go
+++ b/momento/cache_client.go
@@ -313,7 +313,7 @@ func (c defaultScsClient) getCacheNameForRequest(request hasCacheName) string {
 
 func (c defaultScsClient) getNextDataClient() *scsDataClient {
 	nextClientIndex := atomic.AddUint64(&dataClientCount, 1)
-	dataClient := c.dataClients[nextClientIndex%uint64(len(c.dataClients))]
+	dataClient := c.dataClients[atomic.LoadUint64(&nextClientIndex)%uint64(len(c.dataClients))]
 	return dataClient
 }
 

--- a/momento/pubsub_client.go
+++ b/momento/pubsub_client.go
@@ -23,8 +23,8 @@ type pubSubClient struct {
 	log                 logger.MomentoLogger
 }
 
-var streamTopicManagerCount uint64
-var numGrpcStreams int64
+var streamTopicManagerCount atomic.Uint64
+var numGrpcStreams atomic.Int64
 var numChannels uint32
 
 func newPubSubClient(request *models.PubSubClientRequest) (*pubSubClient, momentoerrors.MomentoSvcErr) {
@@ -71,8 +71,8 @@ func newPubSubClient(request *models.PubSubClientRequest) (*pubSubClient, moment
 }
 
 func (client *pubSubClient) getNextStreamTopicManager() *grpcmanagers.TopicGrpcManager {
-	nextManagerIndex := atomic.AddUint64(&streamTopicManagerCount, 1)
-	topicManager := client.streamTopicManagers[atomic.LoadUint64(&nextManagerIndex)%uint64(len(client.streamTopicManagers))]
+	nextManagerIndex := streamTopicManagerCount.Add(1)
+	topicManager := client.streamTopicManagers[nextManagerIndex%uint64(len(client.streamTopicManagers))]
 	return topicManager
 }
 
@@ -87,7 +87,7 @@ func (client *pubSubClient) topicSubscribe(ctx context.Context, request *TopicSu
 	cancelContext, cancelFunction := context.WithCancel(requestMetadata)
 
 	var header, trailer metadata.MD
-	atomic.AddInt64(&numGrpcStreams, 1)
+	numGrpcStreams.Add(1)
 	topicManager := client.getNextStreamTopicManager()
 	clientStream, err := topicManager.StreamClient.Subscribe(cancelContext, &pb.XSubscriptionRequest{
 		CacheName:                   request.CacheName,
@@ -97,7 +97,7 @@ func (client *pubSubClient) topicSubscribe(ctx context.Context, request *TopicSu
 	})
 
 	if err != nil {
-		atomic.AddInt64(&numGrpcStreams, -1)
+		numGrpcStreams.Add(-1)
 		cancelFunction()
 		if clientStream != nil {
 			header, _ = clientStream.Header()
@@ -106,8 +106,8 @@ func (client *pubSubClient) topicSubscribe(ctx context.Context, request *TopicSu
 		return nil, nil, nil, nil, momentoerrors.ConvertSvcErr(err, header, trailer)
 	}
 
-	if atomic.LoadInt64(&numGrpcStreams) > 0 && (int64(numChannels*100)-atomic.LoadInt64(&numGrpcStreams) < 10) {
-		client.log.Warn("WARNING: approaching grpc maximum concurrent stream limit, %d remaining of total %d streams\n", int64(numChannels*100)-atomic.LoadInt64(&numGrpcStreams), numChannels*100)
+	if numGrpcStreams.Load() > 0 && (int64(numChannels*100)-numGrpcStreams.Load() < 10) {
+		client.log.Warn("WARNING: approaching grpc maximum concurrent stream limit, %d remaining of total %d streams\n", int64(numChannels*100)-numGrpcStreams.Load(), numChannels*100)
 	}
 
 	return topicManager, clientStream, cancelContext, cancelFunction, err
@@ -121,7 +121,7 @@ func (client *pubSubClient) topicPublish(ctx context.Context, request *TopicPubl
 	var header, trailer metadata.MD
 	switch value := request.Value.(type) {
 	case String:
-		atomic.AddInt64(&numGrpcStreams, 1)
+		numGrpcStreams.Add(1)
 		_, err := topicManager.StreamClient.Publish(requestMetadata, &pb.XPublishRequest{
 			CacheName: request.CacheName,
 			Topic:     request.TopicName,
@@ -131,13 +131,13 @@ func (client *pubSubClient) topicPublish(ctx context.Context, request *TopicPubl
 				},
 			},
 		}, grpc.Header(&header), grpc.Trailer(&trailer))
-		atomic.AddInt64(&numGrpcStreams, -1)
+		numGrpcStreams.Add(-1)
 		if err != nil {
 			return momentoerrors.ConvertSvcErr(err, header, trailer)
 		}
 		return err
 	case Bytes:
-		atomic.AddInt64(&numGrpcStreams, 1)
+		numGrpcStreams.Add(1)
 		_, err := topicManager.StreamClient.Publish(requestMetadata, &pb.XPublishRequest{
 			CacheName: request.CacheName,
 			Topic:     request.TopicName,
@@ -147,7 +147,7 @@ func (client *pubSubClient) topicPublish(ctx context.Context, request *TopicPubl
 				},
 			},
 		}, grpc.Header(&header), grpc.Trailer(&trailer))
-		atomic.AddInt64(&numGrpcStreams, -1)
+		numGrpcStreams.Add(-1)
 		if err != nil {
 			return momentoerrors.ConvertSvcErr(err, header, trailer)
 		}
@@ -161,16 +161,16 @@ func (client *pubSubClient) topicPublish(ctx context.Context, request *TopicPubl
 }
 
 func (client *pubSubClient) close() {
-	atomic.AddInt64(&numGrpcStreams, -numGrpcStreams)
+	numGrpcStreams.Add(-numGrpcStreams.Load())
 	for clientIndex := range client.streamTopicManagers {
 		defer client.streamTopicManagers[clientIndex].Close()
 	}
 }
 
 func checkNumConcurrentStreams(log logger.MomentoLogger) {
-	if atomic.LoadInt64(&numGrpcStreams) > 0 && atomic.LoadInt64(&numGrpcStreams) >= int64(numChannels*100) {
+	if numGrpcStreams.Load() > 0 && numGrpcStreams.Load() >= int64(numChannels*100) {
 		log.Warn("Number of grpc streams: %d; number of channels: %d; max concurrent streams: %d; Already at maximum number of concurrent grpc streams, cannot make new publish or subscribe requests",
-			atomic.LoadInt64(&numGrpcStreams), numChannels, numChannels*100,
+			numGrpcStreams.Load(), numChannels, numChannels*100,
 		)
 	}
 }

--- a/momento/storage_client.go
+++ b/momento/storage_client.go
@@ -14,7 +14,7 @@ import (
 	"github.com/momentohq/client-sdk-go/responses"
 )
 
-var storageDataClientCount uint64
+var storageDataClientCount atomic.Uint64
 
 // PreviewStorageClient PREVIEW Momento Storage Client
 //
@@ -95,8 +95,8 @@ func NewPreviewStorageClient(storageConfiguration config.StorageConfiguration, c
 }
 
 func (c defaultPreviewStorageClient) getNextStorageDataClient() *storageDataClient {
-	nextClientIndex := atomic.AddUint64(&storageDataClientCount, 1)
-	dataClient := c.storageDataClients[atomic.LoadUint64(&nextClientIndex)%uint64(len(c.storageDataClients))]
+	nextClientIndex := storageDataClientCount.Add(1)
+	dataClient := c.storageDataClients[nextClientIndex%uint64(len(c.storageDataClients))]
 	return dataClient
 }
 

--- a/momento/storage_client.go
+++ b/momento/storage_client.go
@@ -96,7 +96,7 @@ func NewPreviewStorageClient(storageConfiguration config.StorageConfiguration, c
 
 func (c defaultPreviewStorageClient) getNextStorageDataClient() *storageDataClient {
 	nextClientIndex := atomic.AddUint64(&storageDataClientCount, 1)
-	dataClient := c.storageDataClients[nextClientIndex%uint64(len(c.storageDataClients))]
+	dataClient := c.storageDataClients[atomic.LoadUint64(&nextClientIndex)%uint64(len(c.storageDataClients))]
 	return dataClient
 }
 

--- a/momento/topic_subscription.go
+++ b/momento/topic_subscription.go
@@ -3,7 +3,6 @@ package momento
 import (
 	"context"
 	"fmt"
-	"sync/atomic"
 	"time"
 
 	"github.com/momentohq/client-sdk-go/config/logger"
@@ -186,6 +185,6 @@ func (s *topicSubscription) attemptReconnect(ctx context.Context) {
 }
 
 func (s *topicSubscription) Close() {
-	atomic.AddInt64(&numGrpcStreams, -1)
+	numGrpcStreams.Add(-1)
 	s.cancelFunction()
 }


### PR DESCRIPTION
We use atomic writes on several variables in our clients, but did not use atomic reads on them, potentially leading to data race conditions.

This PR updates the variables reads to be atomic variables, such as [`atomic.Uint64`](https://pkg.go.dev/sync/atomic#Uint64), and using first-class atomic methods such as [`Uint64.Load()`](https://pkg.go.dev/sync/atomic#Uint64.Load) and [`Uint64.Add()`](https://pkg.go.dev/sync/atomic#Uint64.Add).

Note: this is different from creating a regular `uint64` variable and then using the [`LoadUint64()`](https://pkg.go.dev/sync/atomic#LoadUint64) method that the godocs say is more error-prone than `atomic.LoadUint64()`.