### PR TITLE
fix: add nil check before getting header and trailer for GetBatch and SetBatch

### DIFF
--- a/momento/get_batch.go
+++ b/momento/get_batch.go
@@ -52,10 +52,15 @@ func (r *GetBatchRequest) initGrpcRequest(scsDataClient) error {
 
 func (r *GetBatchRequest) makeGrpcRequest(requestMetadata context.Context, client scsDataClient) (grpcResponse, []metadata.MD, error) {
 	var header, trailer metadata.MD
+	var responseMetadata []metadata.MD
 	resp, err := client.grpcClient.GetBatch(requestMetadata, r.grpcRequest)
-	header, _ = resp.Header()
-	trailer = resp.Trailer()
-	responseMetadata := []metadata.MD{header, trailer}
+	// If there is an error, it's possible resp is nil and we should avoid
+	// calling Header() and Trailer() on it to avoid a panic
+	if resp != nil {
+		header, _ = resp.Header()
+		trailer = resp.Trailer()
+		responseMetadata = []metadata.MD{header, trailer}
+	}
 	if err != nil {
 		return nil, responseMetadata, err
 	}

--- a/momento/set_batch.go
+++ b/momento/set_batch.go
@@ -57,10 +57,15 @@ func (r *SetBatchRequest) initGrpcRequest(client scsDataClient) error {
 
 func (r *SetBatchRequest) makeGrpcRequest(requestMetadata context.Context, client scsDataClient) (grpcResponse, []metadata.MD, error) {
 	var header, trailer metadata.MD
+	var responseMetadata []metadata.MD
 	resp, err := client.grpcClient.SetBatch(requestMetadata, r.grpcRequest)
-	header, _ = resp.Header()
-	trailer = resp.Trailer()
-	responseMetadata := []metadata.MD{header, trailer}
+	// If there is an error, it's possible resp is nil and we should avoid
+	// calling Header() and Trailer() on it to avoid a panic
+	if resp != nil {
+		header, _ = resp.Header()
+		trailer = resp.Trailer()
+		responseMetadata = []metadata.MD{header, trailer}
+	}
 	if err != nil {
 		return nil, responseMetadata, err
 	}


### PR DESCRIPTION
Verified that the other streaming method, topic subscribe, already does the nil check before accessing headers and trailers.

Any future server-streaming methods will need to implement this nil check as well