### PR TITLE
feat: add CredentialProvider constructor for momento-local connections

### DIFF
--- a/auth/credential_provider_test.go
+++ b/auth/credential_provider_test.go
@@ -51,32 +51,32 @@ var _ = Describe("auth credential-provider", func() {
 			credentialProvider, err := auth.NewEnvMomentoTokenProvider(envVar)
 			Expect(err).To(BeNil())
 			Expect(credentialProvider.GetAuthToken()).To(Equal(testV1ApiKey))
-			Expect(credentialProvider.GetCacheEndpoint()).To(Equal("cache.test.momentohq.com"))
-			Expect(credentialProvider.GetControlEndpoint()).To(Equal("control.test.momentohq.com"))
+			Expect(credentialProvider.GetCacheEndpoint()).To(Equal("cache.test.momentohq.com:443"))
+			Expect(credentialProvider.GetControlEndpoint()).To(Equal("control.test.momentohq.com:443"))
 		})
 
 		It("returns a credential provider from a string via constructor", func() {
 			credentialProvider, err := auth.NewStringMomentoTokenProvider(os.Getenv(envVar))
 			Expect(err).To(BeNil())
 			Expect(credentialProvider.GetAuthToken()).To(Equal(testV1ApiKey))
-			Expect(credentialProvider.GetCacheEndpoint()).To(Equal("cache.test.momentohq.com"))
-			Expect(credentialProvider.GetControlEndpoint()).To(Equal("control.test.momentohq.com"))
+			Expect(credentialProvider.GetCacheEndpoint()).To(Equal("cache.test.momentohq.com:443"))
+			Expect(credentialProvider.GetControlEndpoint()).To(Equal("control.test.momentohq.com:443"))
 		})
 
 		It("returns a credential provider from an environment variable via method", func() {
 			credentialProvider, err := auth.FromEnvironmentVariable(envVar)
 			Expect(err).To(BeNil())
 			Expect(credentialProvider.GetAuthToken()).To(Equal(testV1ApiKey))
-			Expect(credentialProvider.GetCacheEndpoint()).To(Equal("cache.test.momentohq.com"))
-			Expect(credentialProvider.GetControlEndpoint()).To(Equal("control.test.momentohq.com"))
+			Expect(credentialProvider.GetCacheEndpoint()).To(Equal("cache.test.momentohq.com:443"))
+			Expect(credentialProvider.GetControlEndpoint()).To(Equal("control.test.momentohq.com:443"))
 		})
 
 		It("returns a credential provider from a string via method", func() {
 			credentialProvider, err := auth.FromString(os.Getenv(envVar))
 			Expect(err).To(BeNil())
 			Expect(credentialProvider.GetAuthToken()).To(Equal(testV1ApiKey))
-			Expect(credentialProvider.GetCacheEndpoint()).To(Equal("cache.test.momentohq.com"))
-			Expect(credentialProvider.GetControlEndpoint()).To(Equal("control.test.momentohq.com"))
+			Expect(credentialProvider.GetCacheEndpoint()).To(Equal("cache.test.momentohq.com:443"))
+			Expect(credentialProvider.GetControlEndpoint()).To(Equal("control.test.momentohq.com:443"))
 		})
 
 		It("overrides endpoints", func() {

--- a/auth/credential_provider_test.go
+++ b/auth/credential_provider_test.go
@@ -86,18 +86,22 @@ var _ = Describe("auth credential-provider", func() {
 			cacheEndpoint := credentialProvider.GetCacheEndpoint()
 			Expect(controlEndpoint).ToNot(BeEmpty())
 			Expect(cacheEndpoint).ToNot(BeEmpty())
+			Expect(credentialProvider.IsControlEndpointSecure()).To(BeTrue())
+			Expect(credentialProvider.IsCacheEndpointSecure()).To(BeTrue())
 
 			controlEndpoint = fmt.Sprintf("%s-overridden", controlEndpoint)
 			cacheEndpoint = fmt.Sprintf("%s-overridden", cacheEndpoint)
 			credentialProvider, err = credentialProvider.WithEndpoints(
-				auth.Endpoints{
-					ControlEndpoint: controlEndpoint,
-					CacheEndpoint:   cacheEndpoint,
+				auth.AllEndpoints{
+					ControlEndpoint: auth.Endpoint{Endpoint: controlEndpoint},
+					CacheEndpoint:   auth.Endpoint{Endpoint: cacheEndpoint},
 				},
 			)
 			Expect(err).To(BeNil())
 			Expect(credentialProvider.GetControlEndpoint()).To(Equal(controlEndpoint))
 			Expect(credentialProvider.GetCacheEndpoint()).To(Equal(cacheEndpoint))
+			Expect(credentialProvider.IsControlEndpointSecure()).To(BeTrue())
+			Expect(credentialProvider.IsCacheEndpointSecure()).To(BeTrue())
 		})
 
 		DescribeTable("errors when v1 token is missing data",
@@ -115,6 +119,39 @@ var _ = Describe("auth credential-provider", func() {
 			Entry("missing endpoint", testV1MissingEndpoint),
 			Entry("missing api key", testV1MissingApiKey),
 		)
+
+		It("correctly sets Momento Local endpoints", func() {
+			// Using default config
+			credentialProvider, err := auth.NewMomentoLocalProvider(nil)
+			defaultEndpoint := "127.0.0.1:8080"
+			Expect(err).To(BeNil())
+			Expect(credentialProvider.GetAuthToken()).To(Equal(""))
+			Expect(credentialProvider.GetCacheEndpoint()).To(Equal(defaultEndpoint))
+			Expect(credentialProvider.IsCacheEndpointSecure()).To(BeFalse())
+			Expect(credentialProvider.GetControlEndpoint()).To(Equal(defaultEndpoint))
+			Expect(credentialProvider.IsControlEndpointSecure()).To(BeFalse())
+			Expect(credentialProvider.GetStorageEndpoint()).To(Equal(defaultEndpoint))
+			Expect(credentialProvider.IsStorageEndpointSecure()).To(BeFalse())
+			Expect(credentialProvider.GetTokenEndpoint()).To(Equal(defaultEndpoint))
+			Expect(credentialProvider.IsTokenEndpointSecure()).To(BeFalse())
+
+			// Using provided config
+			credentialProvider, err = auth.NewMomentoLocalProvider(&auth.MomentoLocalConfig{
+				Hostname: "localhost",
+				Port:     9090,
+			})
+			nonDefaultEndpoint := "localhost:9090"
+			Expect(err).To(BeNil())
+			Expect(credentialProvider.GetAuthToken()).To(Equal(""))
+			Expect(credentialProvider.GetCacheEndpoint()).To(Equal(nonDefaultEndpoint))
+			Expect(credentialProvider.IsCacheEndpointSecure()).To(BeFalse())
+			Expect(credentialProvider.GetControlEndpoint()).To(Equal(nonDefaultEndpoint))
+			Expect(credentialProvider.IsControlEndpointSecure()).To(BeFalse())
+			Expect(credentialProvider.GetStorageEndpoint()).To(Equal(nonDefaultEndpoint))
+			Expect(credentialProvider.IsStorageEndpointSecure()).To(BeFalse())
+			Expect(credentialProvider.GetTokenEndpoint()).To(Equal(nonDefaultEndpoint))
+			Expect(credentialProvider.IsTokenEndpointSecure()).To(BeFalse())
+		})
 	})
 
 })

--- a/internal/grpcmanagers/auth_manager.go
+++ b/internal/grpcmanagers/auth_manager.go
@@ -1,8 +1,6 @@
 package grpcmanagers
 
 import (
-	"fmt"
-
 	"github.com/momentohq/client-sdk-go/internal/interceptor"
 	"github.com/momentohq/client-sdk-go/internal/models"
 	"github.com/momentohq/client-sdk-go/internal/momentoerrors"
@@ -14,10 +12,8 @@ type AuthGrpcManager struct {
 	AuthToken string
 }
 
-const AuthPort = ":443"
-
 func NewAuthGrpcManager(request *models.AuthGrpcManagerRequest) (*AuthGrpcManager, momentoerrors.MomentoSvcErr) {
-	endpoint := fmt.Sprint(request.CredentialProvider.GetControlEndpoint(), AuthPort)
+	endpoint := request.CredentialProvider.GetControlEndpoint()
 	authToken := request.CredentialProvider.GetAuthToken()
 
 	headerInterceptors := []grpc.UnaryClientInterceptor{
@@ -28,6 +24,7 @@ func NewAuthGrpcManager(request *models.AuthGrpcManagerRequest) (*AuthGrpcManage
 		endpoint,
 		AllDialOptions(
 			request.GrpcConfiguration,
+			request.CredentialProvider.IsControlEndpointSecure(),
 			grpc.WithChainUnaryInterceptor(headerInterceptors...),
 		)...,
 	)

--- a/internal/grpcmanagers/control_manager.go
+++ b/internal/grpcmanagers/control_manager.go
@@ -1,8 +1,6 @@
 package grpcmanagers
 
 import (
-	"fmt"
-
 	"github.com/momentohq/client-sdk-go/config"
 	"github.com/momentohq/client-sdk-go/internal/interceptor"
 	"github.com/momentohq/client-sdk-go/internal/models"
@@ -15,11 +13,9 @@ type ScsControlGrpcManager struct {
 	Conn *grpc.ClientConn
 }
 
-const ControlPort = ":443"
-
 func NewScsControlGrpcManager(request *models.ControlGrpcManagerRequest) (*ScsControlGrpcManager, momentoerrors.MomentoSvcErr) {
 	authToken := request.CredentialProvider.GetAuthToken()
-	endpoint := fmt.Sprint(request.CredentialProvider.GetControlEndpoint(), ControlPort)
+	endpoint := request.CredentialProvider.GetControlEndpoint()
 
 	// Override grpc config to disable keepalives
 	controlConfig := config.NewStaticGrpcConfiguration(&config.GrpcConfigurationProps{}).WithKeepAliveDisabled()
@@ -32,6 +28,7 @@ func NewScsControlGrpcManager(request *models.ControlGrpcManagerRequest) (*ScsCo
 		endpoint,
 		AllDialOptions(
 			controlConfig,
+			request.CredentialProvider.IsControlEndpointSecure(),
 			grpc.WithChainUnaryInterceptor(headerInterceptors...),
 		)...,
 	)

--- a/internal/grpcmanagers/data_manager.go
+++ b/internal/grpcmanagers/data_manager.go
@@ -3,7 +3,6 @@ package grpcmanagers
 import (
 	"context"
 	"errors"
-	"fmt"
 
 	"github.com/momentohq/client-sdk-go/internal/interceptor"
 	"github.com/momentohq/client-sdk-go/internal/models"
@@ -16,10 +15,8 @@ type DataGrpcManager struct {
 	Conn *grpc.ClientConn
 }
 
-const CachePort = ":443"
-
 func NewUnaryDataGrpcManager(request *models.DataGrpcManagerRequest) (*DataGrpcManager, momentoerrors.MomentoSvcErr) {
-	endpoint := fmt.Sprint(request.CredentialProvider.GetCacheEndpoint(), CachePort)
+	endpoint := request.CredentialProvider.GetCacheEndpoint()
 	authToken := request.CredentialProvider.GetAuthToken()
 
 	headerInterceptors := []grpc.UnaryClientInterceptor{
@@ -35,6 +32,7 @@ func NewUnaryDataGrpcManager(request *models.DataGrpcManagerRequest) (*DataGrpcM
 			endpoint,
 			AllDialOptions(
 				request.GrpcConfiguration,
+				request.CredentialProvider.IsCacheEndpointSecure(),
 				grpc.WithChainUnaryInterceptor(headerInterceptors...),
 				grpc.WithChainStreamInterceptor(interceptor.AddStreamHeaderInterceptor(authToken)),
 			)...,
@@ -44,6 +42,7 @@ func NewUnaryDataGrpcManager(request *models.DataGrpcManagerRequest) (*DataGrpcM
 			endpoint,
 			AllDialOptions(
 				request.GrpcConfiguration,
+				request.CredentialProvider.IsCacheEndpointSecure(),
 				grpc.WithChainUnaryInterceptor(headerInterceptors...),
 				grpc.WithChainStreamInterceptor(interceptor.AddStreamHeaderInterceptor(authToken)),
 			)...,

--- a/internal/grpcmanagers/data_manager.go
+++ b/internal/grpcmanagers/data_manager.go
@@ -27,27 +27,15 @@ func NewUnaryDataGrpcManager(request *models.DataGrpcManagerRequest) (*DataGrpcM
 
 	var conn *grpc.ClientConn
 	var err error
-	if request.EagerConnect {
-		conn, err = grpc.NewClient(
-			endpoint,
-			AllDialOptions(
-				request.GrpcConfiguration,
-				request.CredentialProvider.IsCacheEndpointSecure(),
-				grpc.WithChainUnaryInterceptor(headerInterceptors...),
-				grpc.WithChainStreamInterceptor(interceptor.AddStreamHeaderInterceptor(authToken)),
-			)...,
-		)
-	} else {
-		conn, err = grpc.NewClient(
-			endpoint,
-			AllDialOptions(
-				request.GrpcConfiguration,
-				request.CredentialProvider.IsCacheEndpointSecure(),
-				grpc.WithChainUnaryInterceptor(headerInterceptors...),
-				grpc.WithChainStreamInterceptor(interceptor.AddStreamHeaderInterceptor(authToken)),
-			)...,
-		)
-	}
+	conn, err = grpc.NewClient(
+		endpoint,
+		AllDialOptions(
+			request.GrpcConfiguration,
+			request.CredentialProvider.IsCacheEndpointSecure(),
+			grpc.WithChainUnaryInterceptor(headerInterceptors...),
+			grpc.WithChainStreamInterceptor(interceptor.AddStreamHeaderInterceptor(authToken)),
+		)...,
+	)
 
 	if err != nil {
 		return nil, momentoerrors.ConvertSvcErr(err)
@@ -60,8 +48,8 @@ func (dataManager *DataGrpcManager) Close() momentoerrors.MomentoSvcErr {
 }
 
 func (gm *DataGrpcManager) Connect(ctx context.Context) error {
-	// Dial would connect in the background, but NewClient remains in IDLE until first RPC
-	// or until we actually call Connect here
+	// grpc.NewClient remains in IDLE until first RPC, but we force
+	// an eager connection when we call Connect here
 	gm.Conn.Connect()
 
 	for {

--- a/internal/grpcmanagers/grpc-channel-options.go
+++ b/internal/grpcmanagers/grpc-channel-options.go
@@ -5,6 +5,7 @@ import (
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/keepalive"
 
 	"github.com/momentohq/client-sdk-go/config"
@@ -27,15 +28,18 @@ func GrpcChannelOptionsFromGrpcConfig(grpcConfig config.GrpcConfiguration) []grp
 	}
 }
 
-func TransportCredentialsChannelOption() grpc.DialOption {
+func TransportCredentialsChannelOption(secureEndpoint bool) grpc.DialOption {
+	if !secureEndpoint {
+		return grpc.WithTransportCredentials(insecure.NewCredentials())
+	}
 	config := &tls.Config{
 		InsecureSkipVerify: false,
 	}
 	return grpc.WithTransportCredentials(credentials.NewTLS(config))
 }
 
-func AllDialOptions(grpcConfig config.GrpcConfiguration, options ...grpc.DialOption) []grpc.DialOption {
-	options = append(options, TransportCredentialsChannelOption())
+func AllDialOptions(grpcConfig config.GrpcConfiguration, secureEndpoint bool, options ...grpc.DialOption) []grpc.DialOption {
+	options = append(options, TransportCredentialsChannelOption(secureEndpoint))
 	options = append(options, GrpcChannelOptionsFromGrpcConfig(grpcConfig)...)
 	return options
 }

--- a/internal/grpcmanagers/leaderboard_manager.go
+++ b/internal/grpcmanagers/leaderboard_manager.go
@@ -1,8 +1,6 @@
 package grpcmanagers
 
 import (
-	"fmt"
-
 	"github.com/momentohq/client-sdk-go/internal/interceptor"
 	"github.com/momentohq/client-sdk-go/internal/models"
 	"github.com/momentohq/client-sdk-go/internal/momentoerrors"
@@ -14,10 +12,8 @@ type LeaderboardGrpcManager struct {
 	Conn *grpc.ClientConn
 }
 
-const LeaderboardPort = ":443"
-
 func NewLeaderboardGrpcManager(request *models.LeaderboardGrpcManagerRequest) (*LeaderboardGrpcManager, momentoerrors.MomentoSvcErr) {
-	endpoint := fmt.Sprint(request.CredentialProvider.GetCacheEndpoint(), LeaderboardPort)
+	endpoint := request.CredentialProvider.GetCacheEndpoint()
 	authToken := request.CredentialProvider.GetAuthToken()
 
 	headerInterceptors := []grpc.UnaryClientInterceptor{
@@ -28,6 +24,7 @@ func NewLeaderboardGrpcManager(request *models.LeaderboardGrpcManagerRequest) (*
 		endpoint,
 		AllDialOptions(
 			request.GrpcConfiguration,
+			request.CredentialProvider.IsCacheEndpointSecure(),
 			grpc.WithChainUnaryInterceptor(headerInterceptors...),
 		)...,
 	)

--- a/internal/grpcmanagers/ping_manager.go
+++ b/internal/grpcmanagers/ping_manager.go
@@ -1,8 +1,6 @@
 package grpcmanagers
 
 import (
-	"fmt"
-
 	"github.com/momentohq/client-sdk-go/internal/interceptor"
 	"github.com/momentohq/client-sdk-go/internal/models"
 	"github.com/momentohq/client-sdk-go/internal/momentoerrors"
@@ -14,10 +12,8 @@ type PingGrpcManager struct {
 	Conn *grpc.ClientConn
 }
 
-const PingPort = ":443"
-
 func NewPingGrpcManager(request *models.PingGrpcManagerRequest) (*PingGrpcManager, momentoerrors.MomentoSvcErr) {
-	endpoint := fmt.Sprint(request.CredentialProvider.GetCacheEndpoint(), PingPort)
+	endpoint := request.CredentialProvider.GetCacheEndpoint()
 	authToken := request.CredentialProvider.GetAuthToken()
 
 	headerInterceptors := []grpc.UnaryClientInterceptor{
@@ -28,6 +24,7 @@ func NewPingGrpcManager(request *models.PingGrpcManagerRequest) (*PingGrpcManage
 		endpoint,
 		AllDialOptions(
 			request.GrpcConfiguration,
+			request.CredentialProvider.IsCacheEndpointSecure(),
 			grpc.WithChainUnaryInterceptor(headerInterceptors...),
 		)...,
 	)

--- a/internal/grpcmanagers/store_manager.go
+++ b/internal/grpcmanagers/store_manager.go
@@ -1,8 +1,6 @@
 package grpcmanagers
 
 import (
-	"fmt"
-
 	"github.com/momentohq/client-sdk-go/internal/interceptor"
 	"github.com/momentohq/client-sdk-go/internal/models"
 	"github.com/momentohq/client-sdk-go/internal/momentoerrors"
@@ -13,10 +11,8 @@ type StoreGrpcManager struct {
 	Conn *grpc.ClientConn
 }
 
-const StoragePort = ":443"
-
 func NewStoreGrpcManager(request *models.StoreGrpcManagerRequest) (*StoreGrpcManager, momentoerrors.MomentoSvcErr) {
-	endpoint := fmt.Sprint(request.CredentialProvider.GetStorageEndpoint(), StoragePort)
+	endpoint := request.CredentialProvider.GetStorageEndpoint()
 	authToken := request.CredentialProvider.GetAuthToken()
 
 	headerInterceptors := []grpc.UnaryClientInterceptor{
@@ -27,6 +23,7 @@ func NewStoreGrpcManager(request *models.StoreGrpcManagerRequest) (*StoreGrpcMan
 		endpoint,
 		AllDialOptions(
 			request.GrpcConfiguration,
+			request.CredentialProvider.IsStorageEndpointSecure(),
 			grpc.WithChainUnaryInterceptor(headerInterceptors...),
 		)...,
 	)

--- a/internal/grpcmanagers/token_manager.go
+++ b/internal/grpcmanagers/token_manager.go
@@ -1,8 +1,6 @@
 package grpcmanagers
 
 import (
-	"fmt"
-
 	"github.com/momentohq/client-sdk-go/internal/interceptor"
 	"github.com/momentohq/client-sdk-go/internal/models"
 	"github.com/momentohq/client-sdk-go/internal/momentoerrors"
@@ -15,10 +13,8 @@ type TokenGrpcManager struct {
 	AuthToken string
 }
 
-const TokenPort = ":443"
-
 func NewTokenGrpcManager(request *models.TokenGrpcManagerRequest) (*TokenGrpcManager, momentoerrors.MomentoSvcErr) {
-	endpoint := fmt.Sprint(request.CredentialProvider.GetTokenEndpoint(), TokenPort)
+	endpoint := request.CredentialProvider.GetTokenEndpoint()
 	authToken := request.CredentialProvider.GetAuthToken()
 
 	headerInterceptors := []grpc.UnaryClientInterceptor{
@@ -29,6 +25,7 @@ func NewTokenGrpcManager(request *models.TokenGrpcManagerRequest) (*TokenGrpcMan
 		endpoint,
 		AllDialOptions(
 			request.GrpcConfiguration,
+			request.CredentialProvider.IsTokenEndpointSecure(),
 			grpc.WithChainUnaryInterceptor(headerInterceptors...),
 		)...,
 	)

--- a/internal/grpcmanagers/topic_manager.go
+++ b/internal/grpcmanagers/topic_manager.go
@@ -1,8 +1,6 @@
 package grpcmanagers
 
 import (
-	"fmt"
-
 	"github.com/momentohq/client-sdk-go/internal/interceptor"
 	"github.com/momentohq/client-sdk-go/internal/models"
 	"github.com/momentohq/client-sdk-go/internal/momentoerrors"
@@ -16,7 +14,7 @@ type TopicGrpcManager struct {
 }
 
 func NewStreamTopicGrpcManager(request *models.TopicStreamGrpcManagerRequest) (*TopicGrpcManager, momentoerrors.MomentoSvcErr) {
-	endpoint := fmt.Sprint(request.CredentialProvider.GetCacheEndpoint(), CachePort)
+	endpoint := request.CredentialProvider.GetCacheEndpoint()
 	authToken := request.CredentialProvider.GetAuthToken()
 
 	headerInterceptors := []grpc.StreamClientInterceptor{
@@ -27,6 +25,7 @@ func NewStreamTopicGrpcManager(request *models.TopicStreamGrpcManagerRequest) (*
 		endpoint,
 		AllDialOptions(
 			request.GrpcConfiguration,
+			request.CredentialProvider.IsCacheEndpointSecure(),
 			grpc.WithChainStreamInterceptor(headerInterceptors...),
 			grpc.WithChainUnaryInterceptor(interceptor.AddAuthHeadersInterceptor(authToken)),
 		)...,

--- a/internal/models/requests.go
+++ b/internal/models/requests.go
@@ -21,7 +21,6 @@ type DataGrpcManagerRequest struct {
 	RetryStrategy      retry.Strategy
 	ReadConcern        config.ReadConcern
 	GrpcConfiguration  config.GrpcConfiguration
-	EagerConnect       bool
 }
 
 type TokenGrpcManagerRequest struct {

--- a/momento/scs_data_client.go
+++ b/momento/scs_data_client.go
@@ -29,7 +29,6 @@ func newScsDataClient(request *models.DataClientRequest, eagerConnectTimeout tim
 		RetryStrategy:      request.Configuration.GetRetryStrategy(),
 		ReadConcern:        request.Configuration.GetReadConcern(),
 		GrpcConfiguration:  request.Configuration.GetTransportStrategy().GetGrpcConfig(),
-		EagerConnect:       eagerConnectTimeout > 0,
 	})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Closes https://github.com/momentohq/dev-eco-issue-tracker/issues/1105

Adds `NewMomentoLocalProvider()` method to construct a `CredentialProvider` that allows cache clients to connect to momento-local. To support this, we needed to add a config for allowing insecure connections as momento-local does not use TLS. 
Referenced the structure used in JS sdk (References: [credential provider](https://github.com/momentohq/client-sdk-javascript/blob/main/packages/core/src/auth/credential-provider.ts) and [auth utils](https://github.com/momentohq/client-sdk-javascript/blob/main/packages/core/src/internal/utils/auth.ts)).