### PR TITLE
chore: log pretty print cache config on instantiation

### DIFF
--- a/auth/credential_provider.go
+++ b/auth/credential_provider.go
@@ -19,6 +19,13 @@ type Endpoint struct {
 	InsecureConnection bool
 }
 
+func (endpoint Endpoint) String() string {
+	return fmt.Sprintf(
+		"Endpoint{Endpoint=%s, InsecureConnection=%t}",
+		endpoint.Endpoint,
+		endpoint.InsecureConnection)
+}
+
 type AllEndpoints struct {
 	// ControlEndpoint is the host which the Momento client will connect to the Momento control plane
 	ControlEndpoint Endpoint
@@ -99,6 +106,24 @@ func (credentialProvider defaultCredentialProvider) GetStorageEndpoint() string 
 // IsStorageEndpointSecure returns true if the storage endpoint is secure.
 func (credentialProvider defaultCredentialProvider) IsStorageEndpointSecure() bool {
 	return !credentialProvider.storageEndpoint.InsecureConnection
+}
+
+func (credentialProvider defaultCredentialProvider) String() string {
+	authToken := credentialProvider.authToken
+	if len(authToken) > 4 {
+		authToken = fmt.Sprintf("%s***%s", authToken[:2], authToken[len(authToken)-2:])
+	} else {
+		authToken = "***"
+	}
+
+	return fmt.Sprintf(
+		"CredentialProvider{authToken=%s, controlEndpoint=%s, cacheEndpoint=%s, tokenEndpoint=%s, storageEndpoint=%s}",
+		authToken,
+		credentialProvider.controlEndpoint,
+		credentialProvider.cacheEndpoint,
+		credentialProvider.tokenEndpoint,
+		credentialProvider.storageEndpoint,
+	)
 }
 
 // FromEnvironmentVariable returns a new CredentialProvider using an auth token stored in the provided environment variable.

--- a/config/config.go
+++ b/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/momentohq/client-sdk-go/internal/retry"
@@ -160,4 +161,15 @@ func (s *cacheConfiguration) WithReadConcern(readConcern ReadConcern) Configurat
 		numGrpcChannels:   s.numGrpcChannels,
 		readConcern:       readConcern,
 	}
+}
+
+func (s *cacheConfiguration) String() string {
+	return fmt.Sprintf(
+		"Configuration{loggerFactory=%v, transportStrategy=%v, retryStrategy=%v, numGrpcChannels=%v, readConcern=%v}",
+		s.loggerFactory,
+		s.transportStrategy,
+		s.retryStrategy,
+		s.numGrpcChannels,
+		s.readConcern,
+	)
 }

--- a/config/logger/momento_default_logger/momento-default-logger.go
+++ b/config/logger/momento_default_logger/momento-default-logger.go
@@ -53,6 +53,10 @@ func (l *DefaultMomentoLogger) Error(message string, args ...any) {
 	}
 }
 
+func (l *DefaultMomentoLogger) String() string {
+	return fmt.Sprintf("DefaultMomentoLogger{loggerName=%s, level=%v}", l.loggerName, l.level)
+}
+
 func momentoLog(level string, loggerName string, message string, args ...any) {
 	finalMessage := fmt.Sprintf(message, args...)
 	log.Printf("[%s] %s (%s): %s\n", time.Now().UTC().Format(time.RFC3339), level, loggerName, finalMessage)
@@ -71,4 +75,8 @@ func NewDefaultMomentoLoggerFactory(level LogLevel) logger.MomentoLoggerFactory 
 func (lf DefaultMomentoLoggerFactory) GetLogger(loggerName string) logger.MomentoLogger {
 	log.SetFlags(0)
 	return &DefaultMomentoLogger{loggerName: loggerName, level: lf.level}
+}
+
+func (lf DefaultMomentoLoggerFactory) String() string {
+	return fmt.Sprintf("DefaultMomentoLoggerFactory{level=%v}", lf.level)
 }

--- a/config/logger/noop-momento-logger.go
+++ b/config/logger/noop-momento-logger.go
@@ -33,3 +33,7 @@ func NewNoopMomentoLoggerFactory() MomentoLoggerFactory {
 func (*NoopMomentoLoggerFactory) GetLogger(loggerName string) MomentoLogger {
 	return &NoopMomentoLogger{}
 }
+
+func (*NoopMomentoLoggerFactory) String() string {
+	return "NoopMomentoLoggerFactory{}"
+}

--- a/config/transport_strategy.go
+++ b/config/transport_strategy.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"fmt"
 	"time"
 )
 
@@ -150,6 +151,11 @@ func (s *StaticGrpcConfiguration) WithKeepAliveDisabled() GrpcConfiguration {
 	}
 }
 
+func (s *StaticGrpcConfiguration) String() string {
+	return fmt.Sprintf("GrpcConfiguration{deadline=%v, keepAlivePermitWithoutCalls=%v, keepAliveTimeout=%v, keepAliveTime=%v, maxSendMessageLength=%v, maxReceiveMessageLength=%v}",
+		s.deadline, s.keepAlivePermitWithoutCalls, s.keepAliveTimeout, s.keepAliveTime, s.maxSendMessageLength, s.maxReceiveMessageLength)
+}
+
 type StaticTransportStrategy struct {
 	grpcConfig GrpcConfiguration
 	maxIdle    time.Duration
@@ -192,4 +198,8 @@ func (s *StaticTransportStrategy) WithMaxIdle(maxIdle time.Duration) TransportSt
 		grpcConfig: s.grpcConfig,
 		maxIdle:    maxIdle,
 	}
+}
+
+func (s *StaticTransportStrategy) String() string {
+	return fmt.Sprintf("TransportStrategy{grpcConfig=%v, maxIdle=%v}", s.grpcConfig, s.maxIdle)
 }

--- a/internal/retry/retry.go
+++ b/internal/retry/retry.go
@@ -1,6 +1,7 @@
 package retry
 
 import (
+	"fmt"
 	"strconv"
 
 	"github.com/momentohq/client-sdk-go/config/logger"
@@ -26,6 +27,10 @@ type neverRetryStrategy struct{}
 
 func (r neverRetryStrategy) DetermineWhenToRetry(props StrategyProps) *int {
 	return nil
+}
+
+func (r neverRetryStrategy) String() string {
+	return "neverRetryStrategy{}"
 }
 
 // NewNeverRetryStrategy is a retry strategy that never retries any request
@@ -87,4 +92,12 @@ func (r fixedCountRetryStrategy) DetermineWhenToRetry(props StrategyProps) *int 
 	)
 	timeTilNextRetry := 0
 	return &timeTilNextRetry
+}
+
+func (r fixedCountRetryStrategy) String() string {
+	return fmt.Sprintf(
+		"fixedCountRetryStrategy{eligibilityStrategy=%v, maxAttempts=%v, log=%v}",
+		r.eligibilityStrategy,
+		r.maxAttempts,
+		r.log)
 }


### PR DESCRIPTION
Logs a pretty printed version of the cache configuration in the cache
client factory function.

When printing the cache configuration before, we would see something like this:
```
 &{loggerFactory:0x1400000ee80 transportStrategy:0x1400000ca50 retryStrategy:{eligibilityStrategy:{} maxAttempts:3 log:0x1400000ca68} numGrpcChannels:1 readConcern:balanced}
```

This contains pointers to parts of the configuration that should be dereferenced and recursively represented. We override the `String` function on the appropriate structs to get this. Now we will see:

```
Configuration{loggerFactory=DefaultMomentoLoggerFactory{level=20}, transportStrategy=TransportStrategy{grpcConfig=GrpcConfiguration{deadline=5s, keepAlivePermitWithoutCalls=true, keepAliveTimeout=1s, keepAliveTime=5s, maxSendMessageLength=5243000, maxReceiveMessageLength=5243000}, maxIdle=0s}, retryStrategy=fixedCountRetryStrategy{eligibilityStrategy={}, maxAttempts=3, log=DefaultMomentoLogger{loggerName=fixed-count-retry-strategy, level=20}}, numGrpcChannels=1, readConcern=balanced}
```

We further log the properties from the cache client constructors to log all relevant settings. We provide a `String` function for `CredentialProvider` where we censor the auth token. Here is what the log statement looks like:

```
[2025-01-17T00:50:18Z] INFO (CacheClient): Creating cache client with settings: CacheClientProps{CacheName: , Configuration: Configuration{loggerFactory=DefaultMomentoLoggerFactory{level=20}, transportStrategy=TransportStrategy{grpcConfig=GrpcConfiguration{deadline=5s, keepAlivePermitWithoutCalls=true, keepAliveTimeout=1s, keepAliveTime=5s, maxSendMessageLength=5243000, maxReceiveMessageLength=5243000}, maxIdle=0s}, retryStrategy=fixedCountRetryStrategy{eligibilityStrategy={}, maxAttempts=3, log=DefaultMomentoLogger{loggerName=fixed-count-retry-strategy, level=20}}, numGrpcChannels=1, readConcern=balanced}, CredentialProvider: CredentialProvider{authToken=ey***uM, controlEndpoint=Endpoint{Endpoint=control.cell-4-us-west-2-1.prod.a.momentohq.com:443, InsecureConnection=false}, cacheEndpoint=Endpoint{Endpoint=cache.cell-4-us-west-2-1.prod.a.momentohq.com:443, InsecureConnection=false}, tokenEndpoint=Endpoint{Endpoint=token.cell-4-us-west-2-1.prod.a.momentohq.com:443, InsecureConnection=false}, storageEndpoint=Endpoint{Endpoint=storage.cell-4-us-west-2-1.prod.a.momentohq.com:443, InsecureConnection=false}}, DefaultTtl: 1m0s, EagerConnectTimeout: 30s}
```

I considered adding a `String` method to relevant configuration interface types. Since that would be a breaking change for existing users that have made their own implementation, I have foregone that.