### PR TITLE
feat: configure topic client to use separate publish and subscribe grpc channels

### DIFF
--- a/config/grpc-configuration.go
+++ b/config/grpc-configuration.go
@@ -2,6 +2,16 @@ package config
 
 import "time"
 
+// Used by `AllDialOptions()` and `GrpcChannelOptionsFromGrpcConfig()` in
+// grpc managers to translate these configurations into grpc.DialOptions.
+type IGrpcConfiguration interface {
+	GetKeepAlivePermitWithoutCalls() bool
+	GetKeepAliveTimeout() time.Duration
+	GetKeepAliveTime() time.Duration
+	GetMaxSendMessageLength() int
+	GetMaxReceiveMessageLength() int
+}
+
 type GrpcConfigurationProps struct {
 	// number of milliseconds the client is willing to wait for an RPC to complete before it is terminated
 	// with a DeadlineExceeded error.

--- a/config/topics-grpc-configuration.go
+++ b/config/topics-grpc-configuration.go
@@ -3,9 +3,9 @@ package config
 import "time"
 
 type TopicsGrpcConfigurationProps struct {
-	// number of milliseconds the client is willing to wait for an RPC to complete before it is terminated
+	// The number of milliseconds the client is willing to wait for an RPC to complete before it is terminated
 	// with a DeadlineExceeded error.
-	deadline time.Duration
+	client_timeout time.Duration
 
 	// The maximum message length the client can send to the server.  If the client attempts to send a message
 	// larger than this size, it will result in a RESOURCE_EXHAUSTED error.
@@ -26,13 +26,13 @@ type TopicsGrpcConfigurationProps struct {
 
 // GrpcConfiguration Encapsulates gRPC configuration tunables.
 type TopicsGrpcConfiguration interface {
-	// GetDeadline Returns number of milliseconds the client is willing to wait for an RPC to complete before
+	// GetClientTimeout Returns number of milliseconds the client is willing to wait for an RPC to complete before
 	// it is terminated with a DeadlineExceeded error.
-	GetDeadline() time.Duration
+	GetClientTimeout() time.Duration
 
-	// WithDeadline Copy constructor for overriding the client-side deadline. Returns a new GrpcConfiguration
+	// WithClientTimeout Copy constructor for overriding the client-side deadline. Returns a new GrpcConfiguration
 	// with the specified client-side deadline
-	WithDeadline(deadline time.Duration) TopicsGrpcConfiguration
+	WithClientTimeout(deadline time.Duration) TopicsGrpcConfiguration
 
 	// GetKeepAlivePermitWithoutCalls returns bool indicating if it is permissible to send keepalive pings from the client without any outstanding calls.
 	GetKeepAlivePermitWithoutCalls() bool

--- a/config/topics-grpc-configuration.go
+++ b/config/topics-grpc-configuration.go
@@ -1,0 +1,105 @@
+package config
+
+import "time"
+
+type TopicsGrpcConfigurationProps struct {
+	// number of milliseconds the client is willing to wait for an RPC to complete before it is terminated
+	// with a DeadlineExceeded error.
+	deadline time.Duration
+
+	// The maximum message length the client can send to the server.  If the client attempts to send a message
+	// larger than this size, it will result in a RESOURCE_EXHAUSTED error.
+	maxSendMessageLength int
+
+	// The maximum message length the client can receive from the server.  If the server attempts to send a message
+	// larger than this size, it will result in a RESOURCE_EXHAUSTED error.
+	maxReceiveMessageLength int
+
+	// NumStreamGrpcChannels represents the number of GRPC channels the topic client
+	// should open and work with for stream operations (i.e. topic subscriptions).
+	numStreamGrpcChannels uint32
+
+	// NumUnaryGrpcChannels represents the number of GRPC channels the topic client
+	// should open and work with for unary operations (i.e. topic publishes).
+	numUnaryGrpcChannels uint32
+}
+
+// GrpcConfiguration Encapsulates gRPC configuration tunables.
+type TopicsGrpcConfiguration interface {
+	// GetDeadline Returns number of milliseconds the client is willing to wait for an RPC to complete before
+	// it is terminated with a DeadlineExceeded error.
+	GetDeadline() time.Duration
+
+	// WithDeadline Copy constructor for overriding the client-side deadline. Returns a new GrpcConfiguration
+	// with the specified client-side deadline
+	WithDeadline(deadline time.Duration) TopicsGrpcConfiguration
+
+	// GetKeepAlivePermitWithoutCalls returns bool indicating if it is permissible to send keepalive pings from the client without any outstanding calls.
+	GetKeepAlivePermitWithoutCalls() bool
+
+	// WithKeepAlivePermitWithoutCalls Copy constructor for overriding the keepalive permit without calls.
+	// Indicates if it permissible to send keepalive pings from the client without any outstanding streams.
+	//
+	// NOTE: keep-alives are very important for long-lived server environments where there may be periods of time
+	// when the connection is idle. However, they are very problematic for lambda environments where the lambda
+	// runtime is continuously frozen and unfrozen, because the lambda may be frozen before the "ACK" is received
+	// from the server. This can cause the keep-alive to timeout even though the connection is completely healthy.
+	// Therefore, keep-alives should be disabled in lambda and similar environments.
+	WithKeepAlivePermitWithoutCalls(keepAlivePermitWithoutCalls bool) TopicsGrpcConfiguration
+
+	// GetKeepAliveTimeout returns number of milliseconds the client will wait for a response from a keepalive or ping.
+	GetKeepAliveTimeout() time.Duration
+
+	// WithKeepAliveTimeout Copy constructor for overriding the keepalive timeout. After waiting for a duration of this time,
+	// if the keepalive ping sender does not receive the ping ack, it will close the transport.
+	//
+	// NOTE: keep-alives are very important for long-lived server environments where there may be periods of time
+	// when the connection is idle. However, they are very problematic for lambda environments where the lambda
+	// runtime is continuously frozen and unfrozen, because the lambda may be frozen before the "ACK" is received
+	// from the server. This can cause the keep-alive to timeout even though the connection is completely healthy.
+	// Therefore, keep-alives should be disabled in lambda and similar environments.
+	WithKeepAliveTimeout(keepAliveTimeout time.Duration) TopicsGrpcConfiguration
+
+	// GetKeepAliveTime returns the interval at which to send the keepalive or ping.
+	GetKeepAliveTime() time.Duration
+
+	// WithKeepAliveTime Copy constructor for overriding the keepalive time.
+	// After a duration of this time the client/server pings its peer to see if the transport is still alive.
+	//
+	// NOTE: keep-alives are very important for long-lived server environments where there may be periods of time
+	// when the connection is idle. However, they are very problematic for lambda environments where the lambda
+	// runtime is continuously frozen and unfrozen, because the lambda may be frozen before the "ACK" is received
+	// from the server. This can cause the keep-alive to timeout even though the connection is completely healthy.
+	// Therefore, keep-alives should be disabled in lambda and similar environments.
+	WithKeepAliveTime(keepAliveTime time.Duration) TopicsGrpcConfiguration
+
+	// WithKeepAliveDisabled disables grpc keepalives```
+	// Returns a new GrpcConfiguration with keepalive settings disabled (they're enabled by default)
+	WithKeepAliveDisabled() TopicsGrpcConfiguration
+
+	// GetMaxSendMessageLength is the maximum message length the client can send to the server.  If the client attempts to send a message
+	// larger than this size, it will result in a RESOURCE_EXHAUSTED error.
+	GetMaxSendMessageLength() int
+
+	// GetMaxReceiveMessageLength is the maximum message length the client can receive from the server.  If the server attempts to send a message
+	// larger than this size, it will result in a RESOURCE_EXHAUSTED error.
+	GetMaxReceiveMessageLength() int
+
+	// GetNumStreamGrpcChannels Returns the configuration option for the number of GRPC channels
+	// the topic client should open and work with for stream operations (i.e. topic subscriptions).
+	GetNumStreamGrpcChannels() uint32
+
+	// WithNumStreamGrpcChannels is currently implemented to create the specified number of GRPC connections
+	// for stream operations. Each GRPC connection can multiplex 100 concurrent subscriptions.
+	// Defaults to 4.
+	WithNumStreamGrpcChannels(numStreamGrpcChannels uint32) TopicsGrpcConfiguration
+
+	// GetNumUnaryGrpcChannels Returns the configuration option for the number of GRPC channels
+	// the topic client should open and work with for unary operations (i.e. topic publishes).
+	GetNumUnaryGrpcChannels() uint32
+
+	// WithNumUnaryGrpcChannels is currently implemented to create the specified number of GRPC connections
+	// for unary operations. Each GRPC connection can multiplex 100 concurrent publish requests.
+	// Defaults to 4.
+	WithNumUnaryGrpcChannels(numUnaryGrpcChannels uint32) TopicsGrpcConfiguration
+}

--- a/config/topics_config.go
+++ b/config/topics_config.go
@@ -1,6 +1,8 @@
 package config
 
 import (
+	"math"
+
 	"github.com/momentohq/client-sdk-go/config/logger"
 )
 
@@ -101,11 +103,12 @@ func (s *topicsConfiguration) GetMaxSubscriptions() uint32 {
 
 func (s *topicsConfiguration) WithMaxSubscriptions(maxSubscriptions uint32) TopicsConfiguration {
 	s.loggerFactory.GetLogger("TopicsConfiguration").Warn("WithMaxSubscriptions is deprecated, please use WithNumStreamGrpcChannels and WithNumUnaryGrpcChannels instead")
-	// numGrpcChannels is mutually exclusive with maxSubscriptions, not included in the override
+	// If this deprecated method is used, we'll use the default 4 unary channels and set
+	// the number of stream channels to accommodate the specified number of subscriptions.
+	numStreamChannels := uint32(math.Ceil(float64(maxSubscriptions) / 100.0))
 	return &topicsConfiguration{
 		loggerFactory:     s.loggerFactory,
-		maxSubscriptions:  maxSubscriptions,
-		transportStrategy: s.transportStrategy,
+		transportStrategy: s.transportStrategy.WithNumStreamGrpcChannels(numStreamChannels),
 	}
 }
 
@@ -115,11 +118,11 @@ func (s *topicsConfiguration) GetNumGrpcChannels() uint32 {
 
 func (s *topicsConfiguration) WithNumGrpcChannels(numGrpcChannels uint32) TopicsConfiguration {
 	s.loggerFactory.GetLogger("TopicsConfiguration").Warn("WithNumGrpcChannels is deprecated, please use WithNumStreamGrpcChannels and WithNumUnaryGrpcChannels instead")
-	// maxSubscriptions is mutually exclusive with numGrpcChannels, not included in the override
+	// If this deprecated method is used, we'll use the default 4 unary channels
+	// and set the number of stream channels to the specified number.
 	return &topicsConfiguration{
 		loggerFactory:     s.loggerFactory,
-		numGrpcChannels:   numGrpcChannels,
-		transportStrategy: s.transportStrategy,
+		transportStrategy: s.transportStrategy.WithNumStreamGrpcChannels(numGrpcChannels),
 	}
 }
 

--- a/config/topics_config.go
+++ b/config/topics_config.go
@@ -37,10 +37,11 @@ type TopicsConfiguration interface {
 
 	// Deprecated: please use the WithNumStreamGrpcChannels and WithNumUnaryGrpcChannels overrides
 	// instead to tune the number of GRPC channels for stream and unary operations, respectively.
-	// Defaults to 4 stream channels and 4 unary channels otherwise.
+	// Using WithMaxSubscriptions now will default to creating 4 unary channels and as many stream
+	// channels as needed to accommodate the maximum number of subscriptions.
 	//
-	// WithMaxSubscriptions is currently implemented to create one GRPC connection for every
-	// 100 subscribers. Can result in edge cases where subscribers and publishers are in contention
+	// WithMaxSubscriptions creates one GRPC connection for every 100 subscribers.
+	// Can result in edge cases where subscribers and publishers are in contention
 	// and may bottleneck a large volume of publish requests.
 	// One GRPC connection can multiplex 100 subscribers/publishers.
 	WithMaxSubscriptions(maxSubscriptions uint32) TopicsConfiguration
@@ -51,9 +52,10 @@ type TopicsConfiguration interface {
 
 	// Deprecated: please use the WithNumStreamGrpcChannels and WithNumUnaryGrpcChannels overrides
 	// instead to tune the number of GRPC channels for stream and unary operations, respectively.
-	// Defaults to 4 stream channels and 4 unary channels otherwise.
+	// Using WithNumGrpcChannels now will default creating 4 unary channels and `numGrpcChannels`
+	// number of stream channels.
 	//
-	// WithNumGrpcChannels is currently implemented to create the specified number of GRPC connections
+	// WithNumGrpcChannels creates the specified number of GRPC connections
 	// (each GRPC connection can multiplex 100 subscribers/publishers). Defaults to 1.
 	WithNumGrpcChannels(numGrpcChannels uint32) TopicsConfiguration
 
@@ -98,6 +100,7 @@ func (s *topicsConfiguration) GetMaxSubscriptions() uint32 {
 }
 
 func (s *topicsConfiguration) WithMaxSubscriptions(maxSubscriptions uint32) TopicsConfiguration {
+	s.loggerFactory.GetLogger("TopicsConfiguration").Warn("WithMaxSubscriptions is deprecated, please use WithNumStreamGrpcChannels and WithNumUnaryGrpcChannels instead")
 	// numGrpcChannels is mutually exclusive with maxSubscriptions, not included in the override
 	return &topicsConfiguration{
 		loggerFactory:     s.loggerFactory,
@@ -111,6 +114,7 @@ func (s *topicsConfiguration) GetNumGrpcChannels() uint32 {
 }
 
 func (s *topicsConfiguration) WithNumGrpcChannels(numGrpcChannels uint32) TopicsConfiguration {
+	s.loggerFactory.GetLogger("TopicsConfiguration").Warn("WithNumGrpcChannels is deprecated, please use WithNumStreamGrpcChannels and WithNumUnaryGrpcChannels instead")
 	// maxSubscriptions is mutually exclusive with numGrpcChannels, not included in the override
 	return &topicsConfiguration{
 		loggerFactory:     s.loggerFactory,

--- a/config/topics_config.go
+++ b/config/topics_config.go
@@ -5,18 +5,30 @@ import (
 )
 
 type topicsConfiguration struct {
-	loggerFactory    logger.MomentoLoggerFactory
-	maxSubscriptions uint32
-	numGrpcChannels  uint32
+	loggerFactory     logger.MomentoLoggerFactory
+	maxSubscriptions  uint32 // DEPRECATED
+	numGrpcChannels   uint32 // DEPRECATED
+	numStreamChannels uint32
+	numUnaryChannels  uint32
 }
 
 type TopicsConfigurationProps struct {
 	// LoggerFactory represents a type used to configure the Momento logging system.
 	LoggerFactory logger.MomentoLoggerFactory
 
+	// Deprecated: use NumStreamGrpcChannels and NumUnaryGrpcChannels instead.
 	MaxSubscriptions uint32
 
+	// Deprecated: use NumStreamGrpcChannels and NumUnaryGrpcChannels instead.
 	NumGrpcChannels uint32
+
+	// NumStreamGrpcChannels represents the number of GRPC channels the topic client
+	// should open and work with for stream operations (i.e. topic subscriptions).
+	NumStreamGrpcChannels uint32
+
+	// NumUnaryGrpcChannels represents the number of GRPC channels the topic client
+	// should open and work with for unary operations (i.e. topic publishes).
+	NumUnaryGrpcChannels uint32
 }
 
 type TopicsConfiguration interface {
@@ -28,11 +40,13 @@ type TopicsConfiguration interface {
 	// Deprecated: Use GetNumGrpcChannels instead.
 	GetMaxSubscriptions() uint32
 
-	// Deprecated: maxSubscriptions is currently implemented to create one GRPC connection for every
+	// Deprecated: please use the WithNumStreamGrpcChannels and WithNumUnaryGrpcChannels overrides
+	// instead to tune the number of GRPC channels for stream and unary operations, respectively.
+	// Defaults to 4 stream channels and 4 unary channels otherwise.
+	//
+	// WithMaxSubscriptions is currently implemented to create one GRPC connection for every
 	// 100 subscribers. Can result in edge cases where subscribers and publishers are in contention
 	// and may bottleneck a large volume of publish requests.
-	//
-	// Please use WithNumGrpcChannels instead as per your use case.
 	// One GRPC connection can multiplex 100 subscribers/publishers.
 	WithMaxSubscriptions(maxSubscriptions uint32) TopicsConfiguration
 
@@ -40,14 +54,40 @@ type TopicsConfiguration interface {
 	// the topic client should open and work with.
 	GetNumGrpcChannels() uint32
 
+	// Deprecated: please use the WithNumStreamGrpcChannels and WithNumUnaryGrpcChannels overrides
+	// instead to tune the number of GRPC channels for stream and unary operations, respectively.
+	// Defaults to 4 stream channels and 4 unary channels otherwise.
+	//
+	// WithNumGrpcChannels is currently implemented to create the specified number of GRPC connections
+	// (each GRPC connection can multiplex 100 subscribers/publishers). Defaults to 1.
 	WithNumGrpcChannels(numGrpcChannels uint32) TopicsConfiguration
+
+	// GetNumStreamGrpcChannels Returns the configuration option for the number of GRPC channels
+	// the topic client should open and work with for stream operations (i.e. topic subscriptions).
+	GetNumStreamGrpcChannels() uint32
+
+	// WithNumStreamGrpcChannels is currently implemented to create the specified number of GRPC connections
+	// for stream operations. Each GRPC connection can multiplex 100 concurrent subscriptions.
+	// Defaults to 4.
+	WithNumStreamGrpcChannels(numStreamGrpcChannels uint32) TopicsConfiguration
+
+	// GetNumUnaryGrpcChannels Returns the configuration option for the number of GRPC channels
+	// the topic client should open and work with for unary operations (i.e. topic publishes).
+	GetNumUnaryGrpcChannels() uint32
+
+	// WithNumUnaryGrpcChannels is currently implemented to create the specified number of GRPC connections
+	// for unary operations. Each GRPC connection can multiplex 100 concurrent publish requests.
+	// Defaults to 4.
+	WithNumUnaryGrpcChannels(numUnaryGrpcChannels uint32) TopicsConfiguration
 }
 
 func NewTopicConfiguration(props *TopicsConfigurationProps) TopicsConfiguration {
 	return &topicsConfiguration{
-		loggerFactory:    props.LoggerFactory,
-		maxSubscriptions: props.MaxSubscriptions,
-		numGrpcChannels:  props.NumGrpcChannels,
+		loggerFactory:     props.LoggerFactory,
+		maxSubscriptions:  props.MaxSubscriptions,
+		numGrpcChannels:   props.NumGrpcChannels,
+		numStreamChannels: props.NumStreamGrpcChannels,
+		numUnaryChannels:  props.NumUnaryGrpcChannels,
 	}
 }
 
@@ -60,9 +100,12 @@ func (s *topicsConfiguration) GetMaxSubscriptions() uint32 {
 }
 
 func (s *topicsConfiguration) WithMaxSubscriptions(maxSubscriptions uint32) TopicsConfiguration {
+	// numGrpcChannels is mutually exclusive with maxSubscriptions, not included in the override
 	return &topicsConfiguration{
-		loggerFactory:    s.loggerFactory,
-		maxSubscriptions: maxSubscriptions,
+		loggerFactory:     s.loggerFactory,
+		maxSubscriptions:  maxSubscriptions,
+		numStreamChannels: s.numStreamChannels,
+		numUnaryChannels:  s.numUnaryChannels,
 	}
 }
 
@@ -71,8 +114,37 @@ func (s *topicsConfiguration) GetNumGrpcChannels() uint32 {
 }
 
 func (s *topicsConfiguration) WithNumGrpcChannels(numGrpcChannels uint32) TopicsConfiguration {
+	// maxSubscriptions is mutually exclusive with numGrpcChannels, not included in the override
 	return &topicsConfiguration{
-		loggerFactory:   s.loggerFactory,
-		numGrpcChannels: numGrpcChannels,
+		loggerFactory:     s.loggerFactory,
+		numGrpcChannels:   numGrpcChannels,
+		numStreamChannels: s.numStreamChannels,
+		numUnaryChannels:  s.numUnaryChannels,
+	}
+}
+
+func (s *topicsConfiguration) GetNumStreamGrpcChannels() uint32 {
+	return s.numStreamChannels
+}
+
+func (s *topicsConfiguration) WithNumStreamGrpcChannels(numStreamGrpcChannels uint32) TopicsConfiguration {
+	// maxSubscriptions and numGrpcChannels are deprecated, not included in the override
+	return &topicsConfiguration{
+		loggerFactory:     s.loggerFactory,
+		numStreamChannels: numStreamGrpcChannels,
+		numUnaryChannels:  s.numUnaryChannels,
+	}
+}
+
+func (s *topicsConfiguration) GetNumUnaryGrpcChannels() uint32 {
+	return s.numUnaryChannels
+}
+
+func (s *topicsConfiguration) WithNumUnaryGrpcChannels(numUnaryGrpcChannels uint32) TopicsConfiguration {
+	// maxSubscriptions and numGrpcChannels are deprecated, not included in the override
+	return &topicsConfiguration{
+		loggerFactory:     s.loggerFactory,
+		numStreamChannels: s.numStreamChannels,
+		numUnaryChannels:  numUnaryGrpcChannels,
 	}
 }

--- a/config/topics_configurations.go
+++ b/config/topics_configurations.go
@@ -2,6 +2,8 @@
 package config
 
 import (
+	"time"
+
 	"github.com/momentohq/client-sdk-go/config/logger/momento_default_logger"
 
 	"github.com/momentohq/client-sdk-go/config/logger"
@@ -15,5 +17,10 @@ func TopicsDefault() TopicsConfiguration {
 func TopicsDefaultWithLogger(loggerFactory logger.MomentoLoggerFactory) TopicsConfiguration {
 	return NewTopicConfiguration(&TopicsConfigurationProps{
 		LoggerFactory: loggerFactory,
+		TransportStrategy: NewTopicsStaticTransportStrategy(&TopicsTransportStrategyProps{
+			GrpcConfiguration: NewTopicsStaticGrpcConfiguration(&TopicsGrpcConfigurationProps{
+				deadline: 5 * time.Second,
+			}),
+		}),
 	})
 }

--- a/config/topics_configurations.go
+++ b/config/topics_configurations.go
@@ -19,7 +19,7 @@ func TopicsDefaultWithLogger(loggerFactory logger.MomentoLoggerFactory) TopicsCo
 		LoggerFactory: loggerFactory,
 		TransportStrategy: NewTopicsStaticTransportStrategy(&TopicsTransportStrategyProps{
 			GrpcConfiguration: NewTopicsStaticGrpcConfiguration(&TopicsGrpcConfigurationProps{
-				deadline: 5 * time.Second,
+				client_timeout: 5 * time.Second,
 			}),
 		}),
 	})

--- a/config/topics_transport_strategy.go
+++ b/config/topics_transport_strategy.go
@@ -1,0 +1,278 @@
+package config
+
+import (
+	"fmt"
+	"time"
+)
+
+type TopicsTransportStrategyProps struct {
+	// low-level gRPC settings for communication with the Momento server
+	GrpcConfiguration TopicsGrpcConfiguration
+}
+
+type TopicsTransportStrategy interface {
+
+	// GetGrpcConfig Configures the low-level gRPC settings for the Momento client's communication
+	// with the Momento server.
+	GetGrpcConfig() GrpcConfiguration
+
+	// WithGrpcConfig Copy constructor for overriding the gRPC configuration. Returns  a new
+	// TransportStrategy with the specified gRPC config.
+	WithGrpcConfig(grpcConfig TopicsGrpcConfiguration) TopicsTransportStrategy
+
+	// GetClientSideTimeout Gets configuration for client side timeout from transport strategy
+	GetClientSideTimeout() time.Duration
+
+	// WithClientTimeout Copy constructor for overriding the client sie timeout. Returns a new
+	// TransportStrategy with the specified client side timeout.
+	WithClientTimeout(clientTimeout time.Duration) TopicsTransportStrategy
+
+	// GetNumStreamGrpcChannels Returns the configuration option for the number of GRPC channels
+	// the topic client should open and work with for stream operations (i.e. topic subscriptions).
+	GetNumStreamGrpcChannels() uint32
+
+	// WithNumStreamGrpcChannels is currently implemented to create the specified number of GRPC connections
+	// for stream operations. Each GRPC connection can multiplex 100 concurrent subscriptions.
+	// Defaults to 4.
+	WithNumStreamGrpcChannels(numStreamGrpcChannels uint32) TopicsTransportStrategy
+
+	// GetNumUnaryGrpcChannels Returns the configuration option for the number of GRPC channels
+	// the topic client should open and work with for unary operations (i.e. topic publishes).
+	GetNumUnaryGrpcChannels() uint32
+
+	// WithNumUnaryGrpcChannels is currently implemented to create the specified number of GRPC connections
+	// for unary operations. Each GRPC connection can multiplex 100 concurrent publish requests.
+	// Defaults to 4.
+	WithNumUnaryGrpcChannels(numUnaryGrpcChannels uint32) TopicsTransportStrategy
+}
+
+type TopicsStaticGrpcConfiguration struct {
+	deadline                    time.Duration
+	keepAlivePermitWithoutCalls bool
+	keepAliveTimeout            time.Duration
+	keepAliveTime               time.Duration
+	maxSendMessageLength        int
+	maxReceiveMessageLength     int
+	numStreamGrpcChannels       uint32
+	numUnaryGrpcChannels        uint32
+}
+
+// NewStaticGrpcConfiguration constructs a new TopicsGrpcConfiguration to tune lower-level grpc settings.
+// Note: keepalive settings are enabled by default, use WithKeepAliveDisabled() to disable all of them,
+// or use the appropriate copy constructor to override individual settings.
+func NewTopicsStaticGrpcConfiguration(grpcConfiguration *TopicsGrpcConfigurationProps) *TopicsStaticGrpcConfiguration {
+	// We set keepalive values to defaults because we can't tell if users set them to zero values
+	// or if the settings were just omitted from the props struct, thus defaulting them to zero values.
+
+	maxSendLength := DEFAULT_MAX_MESSAGE_SIZE
+	if grpcConfiguration.maxSendMessageLength > 0 {
+		maxSendLength = grpcConfiguration.maxSendMessageLength
+	}
+
+	maxReceiveLength := DEFAULT_MAX_MESSAGE_SIZE
+	if grpcConfiguration.maxReceiveMessageLength > 0 {
+		maxReceiveLength = grpcConfiguration.maxReceiveMessageLength
+	}
+
+	return &TopicsStaticGrpcConfiguration{
+		deadline:                    grpcConfiguration.deadline,
+		keepAlivePermitWithoutCalls: DEFAULT_KEEPALIVE_WITHOUT_STREAM,
+		keepAliveTimeout:            DEFAULT_KEEPALIVE_TIMEOUT,
+		keepAliveTime:               DEFAULT_KEEPALIVE_TIME,
+		maxSendMessageLength:        maxSendLength,
+		maxReceiveMessageLength:     maxReceiveLength,
+		numStreamGrpcChannels:       grpcConfiguration.numStreamGrpcChannels,
+		numUnaryGrpcChannels:        grpcConfiguration.numUnaryGrpcChannels,
+	}
+}
+
+func (s *TopicsStaticGrpcConfiguration) GetDeadline() time.Duration {
+	return s.deadline
+}
+
+func (s *TopicsStaticGrpcConfiguration) GetKeepAlivePermitWithoutCalls() bool {
+	return s.keepAlivePermitWithoutCalls
+}
+
+func (s *TopicsStaticGrpcConfiguration) GetKeepAliveTimeout() time.Duration {
+	return s.keepAliveTimeout
+}
+
+func (s *TopicsStaticGrpcConfiguration) GetKeepAliveTime() time.Duration {
+	return s.keepAliveTime
+}
+
+func (s *TopicsStaticGrpcConfiguration) GetMaxSendMessageLength() int {
+	return s.maxSendMessageLength
+}
+
+func (s *TopicsStaticGrpcConfiguration) GetMaxReceiveMessageLength() int {
+	return s.maxReceiveMessageLength
+}
+
+func (s *TopicsStaticGrpcConfiguration) GetNumStreamGrpcChannels() uint32 {
+	return s.numStreamGrpcChannels
+}
+
+func (s *TopicsStaticGrpcConfiguration) GetNumUnaryGrpcChannels() uint32 {
+	return s.numUnaryGrpcChannels
+}
+
+func (s *TopicsStaticGrpcConfiguration) WithDeadline(deadline time.Duration) TopicsGrpcConfiguration {
+	return &TopicsStaticGrpcConfiguration{
+		deadline:                    deadline,
+		keepAlivePermitWithoutCalls: s.keepAlivePermitWithoutCalls,
+		keepAliveTimeout:            s.keepAliveTimeout,
+		keepAliveTime:               s.keepAliveTime,
+		maxSendMessageLength:        s.maxSendMessageLength,
+		maxReceiveMessageLength:     s.maxReceiveMessageLength,
+		numStreamGrpcChannels:       s.numStreamGrpcChannels,
+		numUnaryGrpcChannels:        s.numUnaryGrpcChannels,
+	}
+}
+
+func (s *TopicsStaticGrpcConfiguration) WithKeepAlivePermitWithoutCalls(keepAlivePermitWithoutCalls bool) TopicsGrpcConfiguration {
+	return &TopicsStaticGrpcConfiguration{
+		deadline:                    s.deadline,
+		keepAlivePermitWithoutCalls: keepAlivePermitWithoutCalls,
+		keepAliveTimeout:            s.keepAliveTimeout,
+		keepAliveTime:               s.keepAliveTime,
+		maxSendMessageLength:        s.maxSendMessageLength,
+		maxReceiveMessageLength:     s.maxReceiveMessageLength,
+		numStreamGrpcChannels:       s.numStreamGrpcChannels,
+		numUnaryGrpcChannels:        s.numUnaryGrpcChannels,
+	}
+}
+
+func (s *TopicsStaticGrpcConfiguration) WithKeepAliveTimeout(keepAliveTimeout time.Duration) TopicsGrpcConfiguration {
+	return &TopicsStaticGrpcConfiguration{
+		deadline:                    s.deadline,
+		keepAlivePermitWithoutCalls: s.keepAlivePermitWithoutCalls,
+		keepAliveTimeout:            keepAliveTimeout,
+		keepAliveTime:               s.keepAliveTime,
+		maxSendMessageLength:        s.maxSendMessageLength,
+		maxReceiveMessageLength:     s.maxReceiveMessageLength,
+		numStreamGrpcChannels:       s.numStreamGrpcChannels,
+		numUnaryGrpcChannels:        s.numUnaryGrpcChannels,
+	}
+}
+
+func (s *TopicsStaticGrpcConfiguration) WithKeepAliveTime(keepAliveTime time.Duration) TopicsGrpcConfiguration {
+	return &TopicsStaticGrpcConfiguration{
+		deadline:                    s.deadline,
+		keepAlivePermitWithoutCalls: s.keepAlivePermitWithoutCalls,
+		keepAliveTimeout:            s.keepAliveTimeout,
+		keepAliveTime:               keepAliveTime,
+		maxSendMessageLength:        s.maxSendMessageLength,
+		maxReceiveMessageLength:     s.maxReceiveMessageLength,
+		numStreamGrpcChannels:       s.numStreamGrpcChannels,
+		numUnaryGrpcChannels:        s.numUnaryGrpcChannels,
+	}
+}
+
+func (s *TopicsStaticGrpcConfiguration) WithKeepAliveDisabled() TopicsGrpcConfiguration {
+	return &TopicsStaticGrpcConfiguration{
+		deadline:                    s.deadline,
+		keepAlivePermitWithoutCalls: false,
+		keepAliveTimeout:            0,
+		keepAliveTime:               0,
+		maxSendMessageLength:        s.maxSendMessageLength,
+		maxReceiveMessageLength:     s.maxReceiveMessageLength,
+		numStreamGrpcChannels:       s.numStreamGrpcChannels,
+		numUnaryGrpcChannels:        s.numUnaryGrpcChannels,
+	}
+}
+
+func (s *TopicsStaticGrpcConfiguration) WithNumStreamGrpcChannels(numStreamGrpcChannels uint32) TopicsGrpcConfiguration {
+	return &TopicsStaticGrpcConfiguration{
+		deadline:                    s.deadline,
+		keepAlivePermitWithoutCalls: s.keepAlivePermitWithoutCalls,
+		keepAliveTimeout:            s.keepAliveTimeout,
+		keepAliveTime:               s.keepAliveTime,
+		maxSendMessageLength:        s.maxSendMessageLength,
+		maxReceiveMessageLength:     s.maxReceiveMessageLength,
+		numStreamGrpcChannels:       numStreamGrpcChannels,
+		numUnaryGrpcChannels:        s.numUnaryGrpcChannels,
+	}
+}
+
+func (s *TopicsStaticGrpcConfiguration) WithNumUnaryGrpcChannels(numUnaryGrpcChannels uint32) TopicsGrpcConfiguration {
+	return &TopicsStaticGrpcConfiguration{
+		deadline:                    s.deadline,
+		keepAlivePermitWithoutCalls: s.keepAlivePermitWithoutCalls,
+		keepAliveTimeout:            s.keepAliveTimeout,
+		keepAliveTime:               s.keepAliveTime,
+		maxSendMessageLength:        s.maxSendMessageLength,
+		maxReceiveMessageLength:     s.maxReceiveMessageLength,
+		numStreamGrpcChannels:       s.numStreamGrpcChannels,
+		numUnaryGrpcChannels:        numUnaryGrpcChannels,
+	}
+}
+
+func (s *TopicsStaticGrpcConfiguration) String() string {
+	return fmt.Sprintf(
+		"TopicsGrpcConfiguration{deadline=%v, keepAlivePermitWithoutCalls=%v, keepAliveTimeout=%v, keepAliveTime=%v, maxSendMessageLength=%v, maxReceiveMessageLength=%v, numStreamGrpcChannels=%v, numUnaryGrpcChannels=%v}",
+		s.deadline, s.keepAlivePermitWithoutCalls, s.keepAliveTimeout, s.keepAliveTime, s.maxSendMessageLength, s.maxReceiveMessageLength, s.numStreamGrpcChannels, s.numUnaryGrpcChannels,
+	)
+}
+
+type TopicsStaticTransportStrategy struct {
+	grpcConfig TopicsGrpcConfiguration
+}
+
+func (s *TopicsStaticTransportStrategy) GetClientSideTimeout() time.Duration {
+	return s.grpcConfig.GetDeadline()
+}
+
+func (s *TopicsStaticTransportStrategy) WithClientTimeout(clientTimeout time.Duration) TopicsTransportStrategy {
+	return &TopicsStaticTransportStrategy{
+		grpcConfig: s.grpcConfig.WithDeadline(clientTimeout),
+	}
+}
+
+func (s *TopicsStaticTransportStrategy) GetNumStreamGrpcChannels() uint32 {
+	return s.grpcConfig.GetNumStreamGrpcChannels()
+}
+
+func (s *TopicsStaticTransportStrategy) WithNumStreamGrpcChannels(numStreamGrpcChannels uint32) TopicsTransportStrategy {
+	return &TopicsStaticTransportStrategy{
+		grpcConfig: s.grpcConfig.WithNumStreamGrpcChannels(numStreamGrpcChannels),
+	}
+}
+
+func (s *TopicsStaticTransportStrategy) GetNumUnaryGrpcChannels() uint32 {
+	return s.grpcConfig.GetNumUnaryGrpcChannels()
+}
+
+func (s *TopicsStaticTransportStrategy) WithNumUnaryGrpcChannels(numUnaryGrpcChannels uint32) TopicsTransportStrategy {
+	return &TopicsStaticTransportStrategy{
+		grpcConfig: s.grpcConfig.WithNumUnaryGrpcChannels(numUnaryGrpcChannels),
+	}
+}
+
+func NewTopicsStaticTransportStrategy(props *TopicsTransportStrategyProps) TopicsTransportStrategy {
+	return &TopicsStaticTransportStrategy{
+		grpcConfig: props.GrpcConfiguration,
+	}
+}
+
+// Returns the more generic GrpcConfiguration interface instead of the more specific TopicsGrpcConfiguration.
+// Used by underlying grpc manager to set cross-cutting grpc settings.
+func (s *TopicsStaticTransportStrategy) GetGrpcConfig() GrpcConfiguration {
+	grpcConfig := NewStaticGrpcConfiguration(&GrpcConfigurationProps{
+		deadline:                s.grpcConfig.GetDeadline(),
+		maxSendMessageLength:    s.grpcConfig.GetMaxSendMessageLength(),
+		maxReceiveMessageLength: s.grpcConfig.GetMaxReceiveMessageLength(),
+	})
+	return grpcConfig
+}
+
+func (s *TopicsStaticTransportStrategy) WithGrpcConfig(grpcConfig TopicsGrpcConfiguration) TopicsTransportStrategy {
+	return &TopicsStaticTransportStrategy{
+		grpcConfig: grpcConfig,
+	}
+}
+
+func (s *TopicsStaticTransportStrategy) String() string {
+	return fmt.Sprintf("TransportStrategy{grpcConfig=%v}", s.grpcConfig)
+}

--- a/config/topics_transport_strategy.go
+++ b/config/topics_transport_strategy.go
@@ -47,7 +47,7 @@ type TopicsTransportStrategy interface {
 }
 
 type TopicsStaticGrpcConfiguration struct {
-	deadline                    time.Duration
+	client_timeout              time.Duration
 	keepAlivePermitWithoutCalls bool
 	keepAliveTimeout            time.Duration
 	keepAliveTime               time.Duration
@@ -75,7 +75,7 @@ func NewTopicsStaticGrpcConfiguration(grpcConfiguration *TopicsGrpcConfiguration
 	}
 
 	return &TopicsStaticGrpcConfiguration{
-		deadline:                    grpcConfiguration.deadline,
+		client_timeout:              grpcConfiguration.client_timeout,
 		keepAlivePermitWithoutCalls: DEFAULT_KEEPALIVE_WITHOUT_STREAM,
 		keepAliveTimeout:            DEFAULT_KEEPALIVE_TIMEOUT,
 		keepAliveTime:               DEFAULT_KEEPALIVE_TIME,
@@ -86,8 +86,8 @@ func NewTopicsStaticGrpcConfiguration(grpcConfiguration *TopicsGrpcConfiguration
 	}
 }
 
-func (s *TopicsStaticGrpcConfiguration) GetDeadline() time.Duration {
-	return s.deadline
+func (s *TopicsStaticGrpcConfiguration) GetClientTimeout() time.Duration {
+	return s.client_timeout
 }
 
 func (s *TopicsStaticGrpcConfiguration) GetKeepAlivePermitWithoutCalls() bool {
@@ -118,9 +118,9 @@ func (s *TopicsStaticGrpcConfiguration) GetNumUnaryGrpcChannels() uint32 {
 	return s.numUnaryGrpcChannels
 }
 
-func (s *TopicsStaticGrpcConfiguration) WithDeadline(deadline time.Duration) TopicsGrpcConfiguration {
+func (s *TopicsStaticGrpcConfiguration) WithClientTimeout(client_timeout time.Duration) TopicsGrpcConfiguration {
 	return &TopicsStaticGrpcConfiguration{
-		deadline:                    deadline,
+		client_timeout:              client_timeout,
 		keepAlivePermitWithoutCalls: s.keepAlivePermitWithoutCalls,
 		keepAliveTimeout:            s.keepAliveTimeout,
 		keepAliveTime:               s.keepAliveTime,
@@ -133,7 +133,7 @@ func (s *TopicsStaticGrpcConfiguration) WithDeadline(deadline time.Duration) Top
 
 func (s *TopicsStaticGrpcConfiguration) WithKeepAlivePermitWithoutCalls(keepAlivePermitWithoutCalls bool) TopicsGrpcConfiguration {
 	return &TopicsStaticGrpcConfiguration{
-		deadline:                    s.deadline,
+		client_timeout:              s.client_timeout,
 		keepAlivePermitWithoutCalls: keepAlivePermitWithoutCalls,
 		keepAliveTimeout:            s.keepAliveTimeout,
 		keepAliveTime:               s.keepAliveTime,
@@ -146,7 +146,7 @@ func (s *TopicsStaticGrpcConfiguration) WithKeepAlivePermitWithoutCalls(keepAliv
 
 func (s *TopicsStaticGrpcConfiguration) WithKeepAliveTimeout(keepAliveTimeout time.Duration) TopicsGrpcConfiguration {
 	return &TopicsStaticGrpcConfiguration{
-		deadline:                    s.deadline,
+		client_timeout:              s.client_timeout,
 		keepAlivePermitWithoutCalls: s.keepAlivePermitWithoutCalls,
 		keepAliveTimeout:            keepAliveTimeout,
 		keepAliveTime:               s.keepAliveTime,
@@ -159,7 +159,7 @@ func (s *TopicsStaticGrpcConfiguration) WithKeepAliveTimeout(keepAliveTimeout ti
 
 func (s *TopicsStaticGrpcConfiguration) WithKeepAliveTime(keepAliveTime time.Duration) TopicsGrpcConfiguration {
 	return &TopicsStaticGrpcConfiguration{
-		deadline:                    s.deadline,
+		client_timeout:              s.client_timeout,
 		keepAlivePermitWithoutCalls: s.keepAlivePermitWithoutCalls,
 		keepAliveTimeout:            s.keepAliveTimeout,
 		keepAliveTime:               keepAliveTime,
@@ -172,7 +172,7 @@ func (s *TopicsStaticGrpcConfiguration) WithKeepAliveTime(keepAliveTime time.Dur
 
 func (s *TopicsStaticGrpcConfiguration) WithKeepAliveDisabled() TopicsGrpcConfiguration {
 	return &TopicsStaticGrpcConfiguration{
-		deadline:                    s.deadline,
+		client_timeout:              s.client_timeout,
 		keepAlivePermitWithoutCalls: false,
 		keepAliveTimeout:            0,
 		keepAliveTime:               0,
@@ -185,7 +185,7 @@ func (s *TopicsStaticGrpcConfiguration) WithKeepAliveDisabled() TopicsGrpcConfig
 
 func (s *TopicsStaticGrpcConfiguration) WithNumStreamGrpcChannels(numStreamGrpcChannels uint32) TopicsGrpcConfiguration {
 	return &TopicsStaticGrpcConfiguration{
-		deadline:                    s.deadline,
+		client_timeout:              s.client_timeout,
 		keepAlivePermitWithoutCalls: s.keepAlivePermitWithoutCalls,
 		keepAliveTimeout:            s.keepAliveTimeout,
 		keepAliveTime:               s.keepAliveTime,
@@ -198,7 +198,7 @@ func (s *TopicsStaticGrpcConfiguration) WithNumStreamGrpcChannels(numStreamGrpcC
 
 func (s *TopicsStaticGrpcConfiguration) WithNumUnaryGrpcChannels(numUnaryGrpcChannels uint32) TopicsGrpcConfiguration {
 	return &TopicsStaticGrpcConfiguration{
-		deadline:                    s.deadline,
+		client_timeout:              s.client_timeout,
 		keepAlivePermitWithoutCalls: s.keepAlivePermitWithoutCalls,
 		keepAliveTimeout:            s.keepAliveTimeout,
 		keepAliveTime:               s.keepAliveTime,
@@ -211,8 +211,8 @@ func (s *TopicsStaticGrpcConfiguration) WithNumUnaryGrpcChannels(numUnaryGrpcCha
 
 func (s *TopicsStaticGrpcConfiguration) String() string {
 	return fmt.Sprintf(
-		"TopicsGrpcConfiguration{deadline=%v, keepAlivePermitWithoutCalls=%v, keepAliveTimeout=%v, keepAliveTime=%v, maxSendMessageLength=%v, maxReceiveMessageLength=%v, numStreamGrpcChannels=%v, numUnaryGrpcChannels=%v}",
-		s.deadline, s.keepAlivePermitWithoutCalls, s.keepAliveTimeout, s.keepAliveTime, s.maxSendMessageLength, s.maxReceiveMessageLength, s.numStreamGrpcChannels, s.numUnaryGrpcChannels,
+		"TopicsGrpcConfiguration{client_timeout=%v, keepAlivePermitWithoutCalls=%v, keepAliveTimeout=%v, keepAliveTime=%v, maxSendMessageLength=%v, maxReceiveMessageLength=%v, numStreamGrpcChannels=%v, numUnaryGrpcChannels=%v}",
+		s.client_timeout, s.keepAlivePermitWithoutCalls, s.keepAliveTimeout, s.keepAliveTime, s.maxSendMessageLength, s.maxReceiveMessageLength, s.numStreamGrpcChannels, s.numUnaryGrpcChannels,
 	)
 }
 
@@ -221,12 +221,12 @@ type TopicsStaticTransportStrategy struct {
 }
 
 func (s *TopicsStaticTransportStrategy) GetClientSideTimeout() time.Duration {
-	return s.grpcConfig.GetDeadline()
+	return s.grpcConfig.GetClientTimeout()
 }
 
 func (s *TopicsStaticTransportStrategy) WithClientTimeout(clientTimeout time.Duration) TopicsTransportStrategy {
 	return &TopicsStaticTransportStrategy{
-		grpcConfig: s.grpcConfig.WithDeadline(clientTimeout),
+		grpcConfig: s.grpcConfig.WithClientTimeout(clientTimeout),
 	}
 }
 

--- a/config/topics_transport_strategy.go
+++ b/config/topics_transport_strategy.go
@@ -14,7 +14,7 @@ type TopicsTransportStrategy interface {
 
 	// GetGrpcConfig Configures the low-level gRPC settings for the Momento client's communication
 	// with the Momento server.
-	GetGrpcConfig() GrpcConfiguration
+	GetGrpcConfig() TopicsGrpcConfiguration
 
 	// WithGrpcConfig Copy constructor for overriding the gRPC configuration. Returns  a new
 	// TransportStrategy with the specified gRPC config.
@@ -256,15 +256,8 @@ func NewTopicsStaticTransportStrategy(props *TopicsTransportStrategyProps) Topic
 	}
 }
 
-// Returns the more generic GrpcConfiguration interface instead of the more specific TopicsGrpcConfiguration.
-// Used by underlying grpc manager to set cross-cutting grpc settings.
-func (s *TopicsStaticTransportStrategy) GetGrpcConfig() GrpcConfiguration {
-	grpcConfig := NewStaticGrpcConfiguration(&GrpcConfigurationProps{
-		deadline:                s.grpcConfig.GetDeadline(),
-		maxSendMessageLength:    s.grpcConfig.GetMaxSendMessageLength(),
-		maxReceiveMessageLength: s.grpcConfig.GetMaxReceiveMessageLength(),
-	})
-	return grpcConfig
+func (s *TopicsStaticTransportStrategy) GetGrpcConfig() TopicsGrpcConfiguration {
+	return s.grpcConfig
 }
 
 func (s *TopicsStaticTransportStrategy) WithGrpcConfig(grpcConfig TopicsGrpcConfiguration) TopicsTransportStrategy {

--- a/internal/grpcmanagers/grpc-channel-options.go
+++ b/internal/grpcmanagers/grpc-channel-options.go
@@ -11,7 +11,7 @@ import (
 	"github.com/momentohq/client-sdk-go/config"
 )
 
-func GrpcChannelOptionsFromGrpcConfig(grpcConfig config.GrpcConfiguration) []grpc.DialOption {
+func GrpcChannelOptionsFromGrpcConfig(grpcConfig config.IGrpcConfiguration) []grpc.DialOption {
 	// Default to 5mb message sizes and keepalives turned on (defaults are set in NewStaticGrpcConfiguration)
 	return []grpc.DialOption{
 		grpc.WithDefaultCallOptions(
@@ -38,7 +38,7 @@ func TransportCredentialsChannelOption(secureEndpoint bool) grpc.DialOption {
 	return grpc.WithTransportCredentials(credentials.NewTLS(config))
 }
 
-func AllDialOptions(grpcConfig config.GrpcConfiguration, secureEndpoint bool, options ...grpc.DialOption) []grpc.DialOption {
+func AllDialOptions(grpcConfig config.IGrpcConfiguration, secureEndpoint bool, options ...grpc.DialOption) []grpc.DialOption {
 	options = append(options, TransportCredentialsChannelOption(secureEndpoint))
 	options = append(options, GrpcChannelOptionsFromGrpcConfig(grpcConfig)...)
 	return options

--- a/internal/models/requests.go
+++ b/internal/models/requests.go
@@ -40,7 +40,7 @@ type DataStreamGrpcManagerRequest struct {
 
 type TopicStreamGrpcManagerRequest struct {
 	CredentialProvider auth.CredentialProvider
-	GrpcConfiguration  config.GrpcConfiguration
+	GrpcConfiguration  config.TopicsGrpcConfiguration
 }
 
 type PingGrpcManagerRequest struct {

--- a/momento/pubsub_client.go
+++ b/momento/pubsub_client.go
@@ -16,6 +16,9 @@ import (
 	"google.golang.org/grpc/metadata"
 )
 
+const DEFAULT_NUM_STREAM_GRPC_CHANNELS uint32 = 4
+const DEFAULT_NUM_UNARY_GRPC_CHANNELS uint32 = 4
+
 type pubSubClient struct {
 	numUnaryChannels        uint32
 	unaryTopicManagers      []*grpcmanagers.TopicGrpcManager
@@ -31,8 +34,7 @@ type pubSubClient struct {
 func newPubSubClient(request *models.PubSubClientRequest) (*pubSubClient, momentoerrors.MomentoSvcErr) {
 	grpcConfig := request.TopicsConfiguration.GetTransportStrategy().GetGrpcConfig()
 
-	// Default to using 4 grpc channels for subscriptions.
-	numStreamChannels := uint32(4)
+	numStreamChannels := uint32(DEFAULT_NUM_STREAM_GRPC_CHANNELS)
 	if request.TopicsConfiguration.GetNumStreamGrpcChannels() > 0 {
 		numStreamChannels = request.TopicsConfiguration.GetNumStreamGrpcChannels()
 	}
@@ -48,8 +50,7 @@ func newPubSubClient(request *models.PubSubClientRequest) (*pubSubClient, moment
 		streamTopicManagers = append(streamTopicManagers, streamTopicManager)
 	}
 
-	// Default to using 4 grpc channels for publishes.
-	numUnaryChannels := uint32(4)
+	numUnaryChannels := uint32(DEFAULT_NUM_UNARY_GRPC_CHANNELS)
 	if request.TopicsConfiguration.GetNumUnaryGrpcChannels() > 0 {
 		numUnaryChannels = request.TopicsConfiguration.GetNumUnaryGrpcChannels()
 	}

--- a/momento/pubsub_client.go
+++ b/momento/pubsub_client.go
@@ -3,7 +3,6 @@ package momento
 import (
 	"context"
 	"fmt"
-	"math"
 	"sync/atomic"
 
 	"github.com/momentohq/client-sdk-go/config/logger"
@@ -36,14 +35,6 @@ func newPubSubClient(request *models.PubSubClientRequest) (*pubSubClient, moment
 	numStreamChannels := uint32(4)
 	if request.TopicsConfiguration.GetNumStreamGrpcChannels() > 0 {
 		numStreamChannels = request.TopicsConfiguration.GetNumStreamGrpcChannels()
-	} else if request.TopicsConfiguration.GetNumGrpcChannels() > 0 {
-		// numGrpcChannels is deprecated, but we'll use it to set numStreamChannels
-		// in case there are customers still using it.
-		numStreamChannels = request.TopicsConfiguration.GetNumGrpcChannels()
-	} else if request.TopicsConfiguration.GetMaxSubscriptions() > 0 {
-		// maxSubscriptions is deprecated, but we'll use it to set numStreamChannels
-		// in case there are customers still using it.
-		numStreamChannels = uint32(math.Ceil(float64(request.TopicsConfiguration.GetMaxSubscriptions()) / 100.0))
 	}
 	streamTopicManagers := make([]*grpcmanagers.TopicGrpcManager, 0)
 	for i := 0; uint32(i) < numStreamChannels; i++ {
@@ -58,7 +49,6 @@ func newPubSubClient(request *models.PubSubClientRequest) (*pubSubClient, moment
 	}
 
 	// Default to using 4 grpc channels for publishes.
-	// Note: 4 unary channels is also the default even if WithMaxSubscriptions and WithNumGrpcChannels is used.
 	numUnaryChannels := uint32(4)
 	if request.TopicsConfiguration.GetNumUnaryGrpcChannels() > 0 {
 		numUnaryChannels = request.TopicsConfiguration.GetNumUnaryGrpcChannels()

--- a/momento/pubsub_client.go
+++ b/momento/pubsub_client.go
@@ -32,12 +32,12 @@ type pubSubClient struct {
 func newPubSubClient(request *models.PubSubClientRequest) (*pubSubClient, momentoerrors.MomentoSvcErr) {
 	grpcConfig := request.TopicsConfiguration.GetTransportStrategy().GetGrpcConfig()
 
-	// Default to using 4 grpc channels for subscriptions
+	// Default to using 4 grpc channels for subscriptions.
 	numStreamChannels := uint32(4)
 	if request.TopicsConfiguration.GetNumStreamGrpcChannels() > 0 {
 		numStreamChannels = request.TopicsConfiguration.GetNumStreamGrpcChannels()
 	} else if request.TopicsConfiguration.GetNumGrpcChannels() > 0 {
-		// numGrpcChannels is deprecated, but we'll use it to set both numUnaryChannels and numStreamChannels
+		// numGrpcChannels is deprecated, but we'll use it to set numStreamChannels
 		// in case there are customers still using it.
 		numStreamChannels = request.TopicsConfiguration.GetNumGrpcChannels()
 	} else if request.TopicsConfiguration.GetMaxSubscriptions() > 0 {
@@ -57,14 +57,11 @@ func newPubSubClient(request *models.PubSubClientRequest) (*pubSubClient, moment
 		streamTopicManagers = append(streamTopicManagers, streamTopicManager)
 	}
 
-	// Default to using 4 grpc channels for publishes
+	// Default to using 4 grpc channels for publishes.
+	// Note: 4 unary channels is also the default even if WithMaxSubscriptions and WithNumGrpcChannels is used.
 	numUnaryChannels := uint32(4)
 	if request.TopicsConfiguration.GetNumUnaryGrpcChannels() > 0 {
 		numUnaryChannels = request.TopicsConfiguration.GetNumUnaryGrpcChannels()
-	} else if request.TopicsConfiguration.GetNumGrpcChannels() > 0 {
-		// numGrpcChannels is deprecated, but we'll use it to set both numUnaryChannels and numStreamChannels
-		// in case there are customers still using it.
-		numUnaryChannels = request.TopicsConfiguration.GetNumGrpcChannels()
 	}
 	unaryTopicManagers := make([]*grpcmanagers.TopicGrpcManager, 0)
 	for i := 0; uint32(i) < numUnaryChannels; i++ {

--- a/momento/pubsub_client.go
+++ b/momento/pubsub_client.go
@@ -2,7 +2,7 @@ package momento
 
 import (
 	"context"
-	"math"
+	"fmt"
 	"sync/atomic"
 
 	"github.com/momentohq/client-sdk-go/config"
@@ -18,41 +18,28 @@ import (
 )
 
 type pubSubClient struct {
-	streamTopicManagers []*grpcmanagers.TopicGrpcManager
-	endpoint            string
-	log                 logger.MomentoLogger
+	numUnaryChannels        uint32
+	unaryTopicManagers      []*grpcmanagers.TopicGrpcManager
+	unaryTopicManagerCount  atomic.Uint64
+	numStreamChannels       uint32
+	streamTopicManagers     []*grpcmanagers.TopicGrpcManager
+	streamTopicManagerCount atomic.Uint64
+	endpoint                string
+	log                     logger.MomentoLogger
+	numGrpcStreams          atomic.Int64 // TODO: encapsulate in grpc manager
 }
 
-var streamTopicManagerCount atomic.Uint64
-var numGrpcStreams atomic.Int64
-var numChannels uint32
-
 func newPubSubClient(request *models.PubSubClientRequest) (*pubSubClient, momentoerrors.MomentoSvcErr) {
-	numSubscriptions := float64(request.TopicsConfiguration.GetMaxSubscriptions())
-	numGrpcChannels := request.TopicsConfiguration.GetNumGrpcChannels()
-
-	// numSubscriptions is deprecated. Nevertheless, check that numGrpcChannels and numSubscriptions
-	// are not both set. They should be mutually exclusive configs.
-	if numGrpcChannels > 0 && numSubscriptions > 0 {
-		return nil, NewMomentoError(momentoerrors.InvalidArgumentError, "Cannot accept both maxSubscriptions and numGrpcChannels as arguments; please use numGrpcChannels as maxSubscriptions is deprecated", nil)
-	}
-
-	if numGrpcChannels > 0 {
-		numChannels = numGrpcChannels
-	} else if numSubscriptions > 0 {
-		// a single channel can support 100 streams, so we need to create enough
-		// channels to handle the maximum number of subscriptions
-		// plus one for the publishing channel
-		numChannels = uint32(math.Ceil((numSubscriptions + 1) / 100.0))
-	} else {
-		numChannels = 1
-	}
-	streamTopicManagers := make([]*grpcmanagers.TopicGrpcManager, 0)
-
 	// NOTE: This is hard-coded for now but we may want to expose it via TopicConfiguration in the future,
 	// as we do with some of the other clients. Defaults to keep-alive pings enabled.
 	grpcConfig := config.NewStaticGrpcConfiguration(&config.GrpcConfigurationProps{})
-	for i := 0; uint32(i) < numChannels; i++ {
+
+	numStreamChannels := uint32(4)
+	if request.TopicsConfiguration.GetNumStreamGrpcChannels() > 0 {
+		numStreamChannels = request.TopicsConfiguration.GetNumStreamGrpcChannels()
+	}
+	streamTopicManagers := make([]*grpcmanagers.TopicGrpcManager, 0)
+	for i := 0; uint32(i) < numStreamChannels; i++ {
 		streamTopicManager, err := grpcmanagers.NewStreamTopicGrpcManager(&models.TopicStreamGrpcManagerRequest{
 			CredentialProvider: request.CredentialProvider,
 			GrpcConfiguration:  grpcConfig,
@@ -63,7 +50,26 @@ func newPubSubClient(request *models.PubSubClientRequest) (*pubSubClient, moment
 		streamTopicManagers = append(streamTopicManagers, streamTopicManager)
 	}
 
+	numUnaryChannels := uint32(4)
+	if request.TopicsConfiguration.GetNumUnaryGrpcChannels() > 0 {
+		numUnaryChannels = request.TopicsConfiguration.GetNumUnaryGrpcChannels()
+	}
+	unaryTopicManagers := make([]*grpcmanagers.TopicGrpcManager, 0)
+	for i := 0; uint32(i) < numUnaryChannels; i++ {
+		unaryTopicManager, err := grpcmanagers.NewStreamTopicGrpcManager(&models.TopicStreamGrpcManagerRequest{
+			CredentialProvider: request.CredentialProvider,
+			GrpcConfiguration:  grpcConfig,
+		})
+		if err != nil {
+			return nil, err
+		}
+		unaryTopicManagers = append(unaryTopicManagers, unaryTopicManager)
+	}
+
 	return &pubSubClient{
+		numUnaryChannels:    numUnaryChannels,
+		unaryTopicManagers:  unaryTopicManagers,
+		numStreamChannels:   numStreamChannels,
 		streamTopicManagers: streamTopicManagers,
 		endpoint:            request.CredentialProvider.GetCacheEndpoint(),
 		log:                 request.Log,
@@ -71,14 +77,41 @@ func newPubSubClient(request *models.PubSubClientRequest) (*pubSubClient, moment
 }
 
 func (client *pubSubClient) getNextStreamTopicManager() *grpcmanagers.TopicGrpcManager {
-	nextManagerIndex := streamTopicManagerCount.Add(1)
-	topicManager := client.streamTopicManagers[nextManagerIndex%uint64(len(client.streamTopicManagers))]
+	nextManagerIndex := client.streamTopicManagerCount.Add(1)
+	topicManager := client.streamTopicManagers[nextManagerIndex%uint64(client.numStreamChannels)]
 	return topicManager
 }
 
-func (client *pubSubClient) topicSubscribe(ctx context.Context, request *TopicSubscribeRequest) (*grpcmanagers.TopicGrpcManager, grpc.ClientStream, context.Context, context.CancelFunc, error) {
+func (client *pubSubClient) getNextUnaryTopicManager() *grpcmanagers.TopicGrpcManager {
+	nextManagerIndex := client.unaryTopicManagerCount.Add(1)
+	topicManager := client.unaryTopicManagers[nextManagerIndex%uint64(client.numUnaryChannels)]
+	return topicManager
+}
 
-	checkNumConcurrentStreams(client.log)
+// Each grpc connection can multiplex 100 subscribe/publish requests.
+//
+// Publish requests will queue up on client while waiting for in-flight requests to complete if
+// the number of concurrent requests exceeds numUnaryChannels*100, but will eventually complete.
+//
+// We must prevent subscription requests from similarly queuing up if there are already numStreamChannels*100
+// concurrent streams as it causes the program to hang indefinitely with no error.
+func (client *pubSubClient) checkNumConcurrentStreams(log logger.MomentoLogger) error {
+	if client.numGrpcStreams.Load() >= int64(client.numStreamChannels*100) {
+		errorMessage := fmt.Sprintf(
+			"Number of grpc streams: %d; number of channels: %d; max concurrent streams: %d; Already at maximum number of concurrent grpc streams, cannot make new subscribe requests\n",
+			client.numGrpcStreams.Load(), client.numStreamChannels, client.numStreamChannels*100,
+		)
+		return momentoerrors.NewMomentoSvcErr(LimitExceededError, errorMessage, nil)
+	}
+	return nil
+}
+
+func (client *pubSubClient) topicSubscribe(ctx context.Context, request *TopicSubscribeRequest) (*grpcmanagers.TopicGrpcManager, grpc.ClientStream, context.Context, context.CancelFunc, error) {
+	// First check if there is enough grpc stream capabity to make a new subscription
+	err := client.checkNumConcurrentStreams(client.log)
+	if err != nil {
+		return nil, nil, nil, nil, err
+	}
 
 	// add metadata to context
 	requestMetadata := internal.CreateMetadata(ctx, internal.Topic)
@@ -87,7 +120,7 @@ func (client *pubSubClient) topicSubscribe(ctx context.Context, request *TopicSu
 	cancelContext, cancelFunction := context.WithCancel(requestMetadata)
 
 	var header, trailer metadata.MD
-	numGrpcStreams.Add(1)
+	client.numGrpcStreams.Add(1)
 	topicManager := client.getNextStreamTopicManager()
 	clientStream, err := topicManager.StreamClient.Subscribe(cancelContext, &pb.XSubscriptionRequest{
 		CacheName:                   request.CacheName,
@@ -97,7 +130,7 @@ func (client *pubSubClient) topicSubscribe(ctx context.Context, request *TopicSu
 	})
 
 	if err != nil {
-		numGrpcStreams.Add(-1)
+		client.numGrpcStreams.Add(-1)
 		cancelFunction()
 		if clientStream != nil {
 			header, _ = clientStream.Header()
@@ -106,22 +139,26 @@ func (client *pubSubClient) topicSubscribe(ctx context.Context, request *TopicSu
 		return nil, nil, nil, nil, momentoerrors.ConvertSvcErr(err, header, trailer)
 	}
 
-	if numGrpcStreams.Load() > 0 && (int64(numChannels*100)-numGrpcStreams.Load() < 10) {
-		client.log.Warn("WARNING: approaching grpc maximum concurrent stream limit, %d remaining of total %d streams\n", int64(numChannels*100)-numGrpcStreams.Load(), numChannels*100)
+	// If we are approaching the grpc maximum concurrent stream limit, log a warning
+	numStreamsLimit := int64(client.numStreamChannels * 100)
+	remainingStreams := numStreamsLimit - client.numGrpcStreams.Load()
+	if remainingStreams < 10 {
+		client.log.Warn(
+			"WARNING: approaching grpc maximum concurrent stream limit, %d remaining of total %d streams\n",
+			remainingStreams, numStreamsLimit,
+		)
 	}
 
+	client.log.Debug("Started new subscription, number of concurrent streams: %d", client.numGrpcStreams.Load())
 	return topicManager, clientStream, cancelContext, cancelFunction, err
 }
 
 func (client *pubSubClient) topicPublish(ctx context.Context, request *TopicPublishRequest) error {
-	checkNumConcurrentStreams(client.log)
-
 	requestMetadata := internal.CreateMetadata(ctx, internal.Topic)
-	topicManager := client.getNextStreamTopicManager()
+	topicManager := client.getNextUnaryTopicManager()
 	var header, trailer metadata.MD
 	switch value := request.Value.(type) {
 	case String:
-		numGrpcStreams.Add(1)
 		_, err := topicManager.StreamClient.Publish(requestMetadata, &pb.XPublishRequest{
 			CacheName: request.CacheName,
 			Topic:     request.TopicName,
@@ -131,13 +168,11 @@ func (client *pubSubClient) topicPublish(ctx context.Context, request *TopicPubl
 				},
 			},
 		}, grpc.Header(&header), grpc.Trailer(&trailer))
-		numGrpcStreams.Add(-1)
 		if err != nil {
 			return momentoerrors.ConvertSvcErr(err, header, trailer)
 		}
 		return err
 	case Bytes:
-		numGrpcStreams.Add(1)
 		_, err := topicManager.StreamClient.Publish(requestMetadata, &pb.XPublishRequest{
 			CacheName: request.CacheName,
 			Topic:     request.TopicName,
@@ -147,7 +182,6 @@ func (client *pubSubClient) topicPublish(ctx context.Context, request *TopicPubl
 				},
 			},
 		}, grpc.Header(&header), grpc.Trailer(&trailer))
-		numGrpcStreams.Add(-1)
 		if err != nil {
 			return momentoerrors.ConvertSvcErr(err, header, trailer)
 		}
@@ -161,16 +195,8 @@ func (client *pubSubClient) topicPublish(ctx context.Context, request *TopicPubl
 }
 
 func (client *pubSubClient) close() {
-	numGrpcStreams.Add(-numGrpcStreams.Load())
+	client.numStreamChannels = 0
 	for clientIndex := range client.streamTopicManagers {
 		defer client.streamTopicManagers[clientIndex].Close()
-	}
-}
-
-func checkNumConcurrentStreams(log logger.MomentoLogger) {
-	if numGrpcStreams.Load() > 0 && numGrpcStreams.Load() >= int64(numChannels*100) {
-		log.Warn("Number of grpc streams: %d; number of channels: %d; max concurrent streams: %d; Already at maximum number of concurrent grpc streams, cannot make new publish or subscribe requests",
-			numGrpcStreams.Load(), numChannels, numChannels*100,
-		)
 	}
 }

--- a/momento/pubsub_client.go
+++ b/momento/pubsub_client.go
@@ -94,7 +94,7 @@ func (client *pubSubClient) getNextUnaryTopicManager() *grpcmanagers.TopicGrpcMa
 //
 // We must prevent subscription requests from similarly queuing up if there are already numStreamChannels*100
 // concurrent streams as it causes the program to hang indefinitely with no error.
-func (client *pubSubClient) checkNumConcurrentStreams(log logger.MomentoLogger) error {
+func (client *pubSubClient) checkNumConcurrentStreams() error {
 	if client.numGrpcStreams.Load() >= int64(client.numStreamChannels*100) {
 		errorMessage := fmt.Sprintf(
 			"Number of grpc streams: %d; number of channels: %d; max concurrent streams: %d; Already at maximum number of concurrent grpc streams, cannot make new subscribe requests\n",
@@ -107,7 +107,7 @@ func (client *pubSubClient) checkNumConcurrentStreams(log logger.MomentoLogger) 
 
 func (client *pubSubClient) topicSubscribe(ctx context.Context, request *TopicSubscribeRequest) (*grpcmanagers.TopicGrpcManager, grpc.ClientStream, context.Context, context.CancelFunc, error) {
 	// First check if there is enough grpc stream capabity to make a new subscription
-	err := client.checkNumConcurrentStreams(client.log)
+	err := client.checkNumConcurrentStreams()
 	if err != nil {
 		return nil, nil, nil, nil, err
 	}

--- a/momento/pubsub_client.go
+++ b/momento/pubsub_client.go
@@ -6,7 +6,6 @@ import (
 	"math"
 	"sync/atomic"
 
-	"github.com/momentohq/client-sdk-go/config"
 	"github.com/momentohq/client-sdk-go/config/logger"
 	"github.com/momentohq/client-sdk-go/internal"
 	"github.com/momentohq/client-sdk-go/internal/grpcmanagers"
@@ -31,9 +30,7 @@ type pubSubClient struct {
 }
 
 func newPubSubClient(request *models.PubSubClientRequest) (*pubSubClient, momentoerrors.MomentoSvcErr) {
-	// NOTE: This is hard-coded for now but we may want to expose it via TopicConfiguration in the future,
-	// as we do with some of the other clients. Defaults to keep-alive pings enabled.
-	grpcConfig := config.NewStaticGrpcConfiguration(&config.GrpcConfigurationProps{})
+	grpcConfig := request.TopicsConfiguration.GetTransportStrategy().GetGrpcConfig()
 
 	// Default to using 4 grpc channels for subscriptions
 	numStreamChannels := uint32(4)

--- a/momento/topic_client.go
+++ b/momento/topic_client.go
@@ -106,7 +106,7 @@ func (c defaultTopicClient) Subscribe(ctx context.Context, request *TopicSubscri
 			rpcError, _ := status.FromError(err)
 			if rpcError != nil {
 				if rpcError.Code() == codes.ResourceExhausted {
-					c.log.Info("Topic subscription limit reached, checking to see if subscription is eligible for retry")
+					c.log.Warn("Topic subscription limit reached, checking to see if subscription is eligible for retry")
 					continue
 				}
 			}


### PR DESCRIPTION
Work towards https://github.com/momentohq/dev-eco-issue-tracker/issues/1124

Under high load, grpc channels that serve both publish and subscribe requests fail to recover when the service redeploys. Creating separate unary and stream grpc channels appears to fix this problem.

Creates separate unary and stream grpc channels within the topic client (defaults to 4 unary and 4 stream channels).
Adds topic config methods `WithNumStreamGrpcChannels()` and `WithNumUnaryGrpcChannels()` to allow overriding the default number. Also adds topics-specific grpc config and transport strategy to the topics config struct to allow setting these values.

Now returns an error if user attempts to start a new subscription when numStreamChannels*100 is exceeded:
```
panic: LimitExceededError: Number of grpc streams: 402; number of channels: 4; max concurrent streams: 400; Already at maximum number of concurrent grpc streams, cannot make new subscribe requests
```

Verified that these changes work with the loadgen setup I'd been using for testing. Survived two failovers, used 1 topic, 1500 users, default 4 unary channels, `WithNumStreamGrpcChannels(15)` for the 1500 subscribers.