### PR TITLE
fix: add topic subscribe timeout

### DIFF
--- a/momento/topic_client.go
+++ b/momento/topic_client.go
@@ -4,8 +4,8 @@ package momento
 import (
 	"context"
 	"fmt"
+	"time"
 
-	"github.com/momentohq/client-sdk-go/internal/grpcmanagers"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
@@ -31,16 +31,25 @@ type defaultTopicClient struct {
 	numChannels        uint32
 	pubSubClient       *pubSubClient
 	log                logger.MomentoLogger
+	requestTimeout     time.Duration
 }
 
 // NewTopicClient returns a new TopicClient with provided configuration and credential provider arguments.
 func NewTopicClient(topicsConfiguration config.TopicsConfiguration, credentialProvider auth.CredentialProvider) (TopicClient, error) {
 	numChannels := topicsConfiguration.GetNumGrpcChannels()
 
+	var timeout time.Duration
+	if topicsConfiguration.GetClientSideTimeout() < 1 {
+		timeout = defaultRequestTimeout
+	} else {
+		timeout = topicsConfiguration.GetClientSideTimeout()
+	}
+
 	client := &defaultTopicClient{
 		credentialProvider: credentialProvider,
 		numChannels:        numChannels,
 		log:                topicsConfiguration.GetLoggerFactory().GetLogger("topic-client"),
+		requestTimeout:     timeout,
 	}
 
 	pubSubClient, err := newPubSubClient(&models.PubSubClientRequest{
@@ -57,6 +66,76 @@ func NewTopicClient(topicsConfiguration config.TopicsConfiguration, credentialPr
 	return client, nil
 }
 
+func (c defaultTopicClient) sendSubscribe(firstMessageCtx context.Context, requestCtx context.Context, request *TopicSubscribeRequest) (TopicSubscription, error) {
+	// This loop should exit after the first iteration either due to a timeout or a successful subscription.
+	for {
+		select {
+		case <-firstMessageCtx.Done():
+			return nil, momentoerrors.NewMomentoSvcErr(
+				momentoerrors.TimeoutError,
+				"subscription did not receive first message within the expected time",
+				nil,
+			)
+		default:
+			var firstMsg *pb.XSubscriptionItem
+			topicManager, subscribeClient, cancelContext, cancelFunction, err := c.pubSubClient.topicSubscribe(requestCtx, &TopicSubscribeRequest{
+				CacheName:                   request.CacheName,
+				TopicName:                   request.TopicName,
+				ResumeAtTopicSequenceNumber: request.ResumeAtTopicSequenceNumber,
+				SequencePage:                request.SequencePage,
+			})
+			if err != nil {
+				return nil, err
+			}
+
+			if request.ResumeAtTopicSequenceNumber == 0 && request.SequencePage == 0 {
+				c.log.Debug("Starting new subscription with new sequence number and sequence page.")
+			} else {
+				c.log.Debug("Resuming subscription from sequence number %d and sequence page %d.", request.ResumeAtTopicSequenceNumber, request.SequencePage)
+			}
+
+			// Ping the stream to provide a nice error message if the cache does not exist.
+			firstMsg, err = subscribeClient.Recv()
+			if err != nil {
+				c.log.Debug("failed to receive first message from subscription: %s", err.Error())
+
+				// We now count number of active subscriptions per grpc channel, so if we did not return
+				// an error earlier when calling c.pubSubClient.topicSubscribe, we know that the error
+				// here is due to a service-side subscription limit.
+				rpcError, _ := status.FromError(err)
+				if rpcError != nil {
+					if rpcError.Code() == codes.ResourceExhausted {
+						c.log.Warn("Topic subscription limit reached for this account; please contact us at support@momentohq.com")
+					}
+				}
+				return nil, momentoerrors.ConvertSvcErr(err)
+			}
+
+			switch firstMsg.Kind.(type) {
+			case *pb.XSubscriptionItem_Heartbeat:
+				// The first message to a new subscription will always be a heartbeat.
+			default:
+				return nil, momentoerrors.NewMomentoSvcErr(
+					momentoerrors.InternalServerError,
+					fmt.Sprintf("expected a heartbeat message, got: %T", firstMsg.Kind),
+					err,
+				)
+			}
+
+			return &topicSubscription{
+				topicManager:       topicManager,
+				subscribeClient:    subscribeClient,
+				momentoTopicClient: c.pubSubClient,
+				cacheName:          request.CacheName,
+				topicName:          request.TopicName,
+				log:                c.log,
+				cancelContext:      cancelContext,
+				cancelFunction:     cancelFunction,
+			}, nil
+		}
+	}
+}
+
 func (c defaultTopicClient) Subscribe(ctx context.Context, request *TopicSubscribeRequest) (TopicSubscription, error) {
 	if err := isCacheNameValid(request.CacheName); err != nil {
 		return nil, err
@@ -66,67 +145,11 @@ func (c defaultTopicClient) Subscribe(ctx context.Context, request *TopicSubscri
 		return nil, err
 	}
 
-	var topicManager *grpcmanagers.TopicGrpcManager
-	var subscribeClient pb.Pubsub_SubscribeClient
-	var cancelContext context.Context
-	var cancelFunction context.CancelFunc
-	var err error
-
-	var firstMsg *pb.XSubscriptionItem
-	topicManager, subscribeClient, cancelContext, cancelFunction, err = c.pubSubClient.topicSubscribe(ctx, &TopicSubscribeRequest{
-		CacheName:                   request.CacheName,
-		TopicName:                   request.TopicName,
-		ResumeAtTopicSequenceNumber: request.ResumeAtTopicSequenceNumber,
-		SequencePage:                request.SequencePage,
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	if request.ResumeAtTopicSequenceNumber == 0 && request.SequencePage == 0 {
-		c.log.Debug("Starting new subscription with new sequence number and sequence page.")
-	} else {
-		c.log.Debug("Resuming subscription from sequence number %d and sequence page %d.", request.ResumeAtTopicSequenceNumber, request.SequencePage)
-	}
-
-	// Ping the stream to provide a nice error message if the cache does not exist.
-	firstMsg, err = subscribeClient.Recv()
-	if err != nil {
-		c.log.Debug("failed to receive first message from subscription: %s", err.Error())
-
-		// We now count number of active subscriptions per grpc channel, so if we did not return
-		// an error earlier when calling c.pubSubClient.topicSubscribe, we know that the error
-		// here is due to a service-side subscription limit.
-		rpcError, _ := status.FromError(err)
-		if rpcError != nil {
-			if rpcError.Code() == codes.ResourceExhausted {
-				c.log.Warn("Topic subscription limit reached for this account; please contact us at support@momentohq.com")
-			}
-		}
-		return nil, momentoerrors.ConvertSvcErr(err)
-	}
-
-	switch firstMsg.Kind.(type) {
-	case *pb.XSubscriptionItem_Heartbeat:
-		// The first message to a new subscription will always be a heartbeat.
-	default:
-		return nil, momentoerrors.NewMomentoSvcErr(
-			momentoerrors.InternalServerError,
-			fmt.Sprintf("expected a heartbeat message, got: %T", firstMsg.Kind),
-			err,
-		)
-	}
-
-	return &topicSubscription{
-		topicManager:       topicManager,
-		subscribeClient:    subscribeClient,
-		momentoTopicClient: c.pubSubClient,
-		cacheName:          request.CacheName,
-		topicName:          request.TopicName,
-		log:                c.log,
-		cancelContext:      cancelContext,
-		cancelFunction:     cancelFunction,
-	}, nil
+	// Set a timeout by which the first heartbeat message should be received.
+	// If the first message is not received within this time, we will cancel the subscription.
+	firstMessageCtx, cancel := context.WithTimeout(context.Background(), c.requestTimeout)
+	defer cancel()
+	return c.sendSubscribe(firstMessageCtx, ctx, request)
 }
 
 func (c defaultTopicClient) Publish(ctx context.Context, request *TopicPublishRequest) (responses.TopicPublishResponse, error) {

--- a/momento/topic_client.go
+++ b/momento/topic_client.go
@@ -114,7 +114,6 @@ func (c defaultTopicClient) sendSubscribe(requestCtx context.Context, request *T
 		SequencePage:                request.SequencePage,
 	})
 	if err != nil {
-		cancelFunction()
 		errChan <- err
 		return
 	}


### PR DESCRIPTION
Closes https://github.com/momentohq/dev-eco-issue-tracker/issues/1146
Subscribe request should return DeadlineExceeded error if first heartbeat not received within the client timeout duration.

Tested locally (allowed queueing up of subscribe requests again in pubsub client, disabled checks) and received the timeout error as expected when attempting to make 101 subscriptions on 1 grpc channel:

```
[2025-03-12T23:35:07Z] WARN (topic-client): WARNING: approaching grpc maximum concurrent stream limit, 1 remaining of total 100 streams

[2025-03-12T23:35:07Z] WARN (topic-client): WARNING: approaching grpc maximum concurrent stream limit, 0 remaining of total 100 streams

panic: TimeoutError: subscription did not receive first message within the expected time

goroutine 1 [running]:
main.main()
        /Users/anita/client-sdk-go/examples/topic-example/main.go:44 +0x274
exit status 2
```