### PR TITLE
chore: fix request names in several requester objects

### DIFF
--- a/momento/item_get_ttl.go
+++ b/momento/item_get_ttl.go
@@ -22,7 +22,7 @@ func (r *ItemGetTtlRequest) cacheName() string { return r.CacheName }
 
 func (r *ItemGetTtlRequest) key() Key { return r.Key }
 
-func (r *ItemGetTtlRequest) requestName() string { return "ItemGetTypeTL" }
+func (r *ItemGetTtlRequest) requestName() string { return "ItemGetTtl" }
 
 func (r *ItemGetTtlRequest) initGrpcRequest(scsDataClient) error {
 	var err error

--- a/momento/set_if_absent.go
+++ b/momento/set_if_absent.go
@@ -37,7 +37,7 @@ func (r *SetIfAbsentRequest) value() Value { return r.Value }
 
 func (r *SetIfAbsentRequest) ttl() time.Duration { return r.Ttl }
 
-func (r *SetIfAbsentRequest) requestName() string { return "SetIfNotExists" }
+func (r *SetIfAbsentRequest) requestName() string { return "SetIfAbsent" }
 
 func (r *SetIfAbsentRequest) initGrpcRequest(client scsDataClient) error {
 	var err error

--- a/momento/set_if_absent_or_equal.go
+++ b/momento/set_if_absent_or_equal.go
@@ -39,7 +39,7 @@ func (r *SetIfAbsentOrEqualRequest) equal() Value { return r.Equal }
 
 func (r *SetIfAbsentOrEqualRequest) ttl() time.Duration { return r.Ttl }
 
-func (r *SetIfAbsentOrEqualRequest) requestName() string { return "SetIfNotExists" }
+func (r *SetIfAbsentOrEqualRequest) requestName() string { return "SetIfAbsentOrEqual" }
 
 func (r *SetIfAbsentOrEqualRequest) initGrpcRequest(client scsDataClient) error {
 	var err error

--- a/momento/set_if_equal.go
+++ b/momento/set_if_equal.go
@@ -39,7 +39,7 @@ func (r *SetIfEqualRequest) equal() Value { return r.Equal }
 
 func (r *SetIfEqualRequest) ttl() time.Duration { return r.Ttl }
 
-func (r *SetIfEqualRequest) requestName() string { return "SetIfNotExists" }
+func (r *SetIfEqualRequest) requestName() string { return "SetIfEqual" }
 
 func (r *SetIfEqualRequest) initGrpcRequest(client scsDataClient) error {
 	var err error

--- a/momento/set_if_not_equal.go
+++ b/momento/set_if_not_equal.go
@@ -39,7 +39,7 @@ func (r *SetIfNotEqualRequest) notEqual() Value { return r.NotEqual }
 
 func (r *SetIfNotEqualRequest) ttl() time.Duration { return r.Ttl }
 
-func (r *SetIfNotEqualRequest) requestName() string { return "SetIfNotExists" }
+func (r *SetIfNotEqualRequest) requestName() string { return "SetIfNotEqual" }
 
 func (r *SetIfNotEqualRequest) initGrpcRequest(client scsDataClient) error {
 	var err error

--- a/momento/set_if_present.go
+++ b/momento/set_if_present.go
@@ -35,7 +35,7 @@ func (r *SetIfPresentRequest) value() Value { return r.Value }
 
 func (r *SetIfPresentRequest) ttl() time.Duration { return r.Ttl }
 
-func (r *SetIfPresentRequest) requestName() string { return "SetIfNotExists" }
+func (r *SetIfPresentRequest) requestName() string { return "SetIfPresent" }
 
 func (r *SetIfPresentRequest) initGrpcRequest(client scsDataClient) error {
 	var err error

--- a/momento/set_if_present_and_not_equal.go
+++ b/momento/set_if_present_and_not_equal.go
@@ -39,7 +39,7 @@ func (r *SetIfPresentAndNotEqualRequest) notEqual() Value { return r.NotEqual }
 
 func (r *SetIfPresentAndNotEqualRequest) ttl() time.Duration { return r.Ttl }
 
-func (r *SetIfPresentAndNotEqualRequest) requestName() string { return "SetIfNotExists" }
+func (r *SetIfPresentAndNotEqualRequest) requestName() string { return "SetIfPresentAndNotEqual" }
 
 func (r *SetIfPresentAndNotEqualRequest) initGrpcRequest(client scsDataClient) error {
 	var err error

--- a/momento/sorted_set_fetch_by_rank.go
+++ b/momento/sorted_set_fetch_by_rank.go
@@ -24,7 +24,7 @@ type SortedSetFetchByRankRequest struct {
 
 func (r *SortedSetFetchByRankRequest) cacheName() string { return r.CacheName }
 
-func (r *SortedSetFetchByRankRequest) requestName() string { return "Sorted set fetch" }
+func (r *SortedSetFetchByRankRequest) requestName() string { return "SortedSetFetchByRank" }
 
 func (r *SortedSetFetchByRankRequest) initGrpcRequest(scsDataClient) error {
 	var err error

--- a/momento/sorted_set_fetch_by_score.go
+++ b/momento/sorted_set_fetch_by_score.go
@@ -26,7 +26,7 @@ type SortedSetFetchByScoreRequest struct {
 
 func (r *SortedSetFetchByScoreRequest) cacheName() string { return r.CacheName }
 
-func (r *SortedSetFetchByScoreRequest) requestName() string { return "Sorted set fetch" }
+func (r *SortedSetFetchByScoreRequest) requestName() string { return "SortedSetFetchByScore" }
 
 func (r *SortedSetFetchByScoreRequest) initGrpcRequest(scsDataClient) error {
 	var err error

--- a/momento/sorted_set_get_rank.go
+++ b/momento/sorted_set_get_rank.go
@@ -23,7 +23,7 @@ type SortedSetGetRankRequest struct {
 
 func (r *SortedSetGetRankRequest) cacheName() string { return r.CacheName }
 
-func (r *SortedSetGetRankRequest) requestName() string { return "Sorted set get rank" }
+func (r *SortedSetGetRankRequest) requestName() string { return "SortedSetGetRank" }
 
 func (r *SortedSetGetRankRequest) value() Value { return r.Value }
 

--- a/momento/sorted_set_get_scores.go
+++ b/momento/sorted_set_get_scores.go
@@ -22,7 +22,7 @@ type SortedSetGetScoresRequest struct {
 
 func (r *SortedSetGetScoresRequest) cacheName() string { return r.CacheName }
 
-func (r *SortedSetGetScoresRequest) requestName() string { return "Sorted set get score" }
+func (r *SortedSetGetScoresRequest) requestName() string { return "SortedSetGetScores" }
 
 func (r *SortedSetGetScoresRequest) initGrpcRequest(scsDataClient) error {
 	var err error

--- a/momento/sorted_set_increment_score.go
+++ b/momento/sorted_set_increment_score.go
@@ -29,7 +29,7 @@ type SortedSetIncrementScoreRequest struct {
 
 func (r *SortedSetIncrementScoreRequest) cacheName() string { return r.CacheName }
 
-func (r *SortedSetIncrementScoreRequest) requestName() string { return "Sorted set increment score" }
+func (r *SortedSetIncrementScoreRequest) requestName() string { return "SortedSetIncrementScore" }
 
 func (r *SortedSetIncrementScoreRequest) value() Value { return r.Value }
 

--- a/momento/sorted_set_put_elements.go
+++ b/momento/sorted_set_put_elements.go
@@ -26,7 +26,7 @@ type SortedSetPutElementsRequest struct {
 
 func (r *SortedSetPutElementsRequest) cacheName() string { return r.CacheName }
 
-func (r *SortedSetPutElementsRequest) requestName() string { return "Sorted set put elements" }
+func (r *SortedSetPutElementsRequest) requestName() string { return "SortedSetPutElements" }
 
 func (r *SortedSetPutElementsRequest) ttl() time.Duration { return r.Ttl.Ttl }
 

--- a/momento/sorted_set_remove_elements.go
+++ b/momento/sorted_set_remove_elements.go
@@ -22,7 +22,7 @@ type SortedSetRemoveElementsRequest struct {
 
 func (r *SortedSetRemoveElementsRequest) cacheName() string { return r.CacheName }
 
-func (r *SortedSetRemoveElementsRequest) requestName() string { return "Sorted set remove elements" }
+func (r *SortedSetRemoveElementsRequest) requestName() string { return "SortedSetRemoveElements" }
 
 func (r *SortedSetRemoveElementsRequest) values() []Value { return r.Values }
 


### PR DESCRIPTION
Noticed some inconsistent / incorrect request names on several requester objects. Fixed them so errors will show the correct RPC name