### PR TITLE
feat: add new get/set if hash apis

### DIFF
--- a/momento/cache_client.go
+++ b/momento/cache_client.go
@@ -476,42 +476,47 @@ func (c defaultScsClient) SetIfNotEqual(ctx context.Context, r *SetIfNotEqualReq
 
 func (c defaultScsClient) SetIfPresentAndHashNotEqual(ctx context.Context, r *SetIfPresentAndHashNotEqualRequest) (responses.SetIfPresentAndHashNotEqualResponse, error) {
 	r.CacheName = c.getCacheNameForRequest(r)
-	if err := c.getNextDataClient().makeRequest(ctx, r); err != nil {
+	resp, err := c.getNextDataClient().makeRequest(ctx, r)
+	if err != nil {
 		return nil, err
 	}
-	return r.response, nil
+	return resp.(responses.SetIfPresentAndHashNotEqualResponse), nil
 }
 
 func (c defaultScsClient) SetIfPresentAndHashEqual(ctx context.Context, r *SetIfPresentAndHashEqualRequest) (responses.SetIfPresentAndHashEqualResponse, error) {
 	r.CacheName = c.getCacheNameForRequest(r)
-	if err := c.getNextDataClient().makeRequest(ctx, r); err != nil {
+	resp, err := c.getNextDataClient().makeRequest(ctx, r)
+	if err != nil {
 		return nil, err
 	}
-	return r.response, nil
+	return resp.(responses.SetIfPresentAndHashEqualResponse), nil
 }
 
 func (c defaultScsClient) SetIfAbsentOrHashEqual(ctx context.Context, r *SetIfAbsentOrHashEqualRequest) (responses.SetIfAbsentOrHashEqualResponse, error) {
 	r.CacheName = c.getCacheNameForRequest(r)
-	if err := c.getNextDataClient().makeRequest(ctx, r); err != nil {
+	resp, err := c.getNextDataClient().makeRequest(ctx, r)
+	if err != nil {
 		return nil, err
 	}
-	return r.response, nil
+	return resp.(responses.SetIfAbsentOrHashEqualResponse), nil
 }
 
 func (c defaultScsClient) SetIfAbsentOrHashNotEqual(ctx context.Context, r *SetIfAbsentOrHashNotEqualRequest) (responses.SetIfAbsentOrHashNotEqualResponse, error) {
 	r.CacheName = c.getCacheNameForRequest(r)
-	if err := c.getNextDataClient().makeRequest(ctx, r); err != nil {
+	resp, err := c.getNextDataClient().makeRequest(ctx, r)
+	if err != nil {
 		return nil, err
 	}
-	return r.response, nil
+	return resp.(responses.SetIfAbsentOrHashNotEqualResponse), nil
 }
 
 func (c defaultScsClient) SetWithHash(ctx context.Context, r *SetWithHashRequest) (responses.SetWithHashResponse, error) {
 	r.CacheName = c.getCacheNameForRequest(r)
-	if err := c.getNextDataClient().makeRequest(ctx, r); err != nil {
+	resp, err := c.getNextDataClient().makeRequest(ctx, r)
+	if err != nil {
 		return nil, err
 	}
-	return r.response, nil
+	return resp.(responses.SetWithHashResponse), nil
 }
 
 func (c defaultScsClient) SetBatch(ctx context.Context, r *SetBatchRequest) (responses.SetBatchResponse, error) {
@@ -534,10 +539,11 @@ func (c defaultScsClient) Get(ctx context.Context, r *GetRequest) (responses.Get
 
 func (c defaultScsClient) GetWithHash(ctx context.Context, r *GetWithHashRequest) (responses.GetWithHashResponse, error) {
 	r.CacheName = c.getCacheNameForRequest(r)
-	if err := c.getNextDataClient().makeRequest(ctx, r); err != nil {
+	resp, err := c.getNextDataClient().makeRequest(ctx, r)
+	if err != nil {
 		return nil, err
 	}
-	return r.response, nil
+	return resp.(responses.GetWithHashResponse), nil
 }
 
 func (c defaultScsClient) GetBatch(ctx context.Context, r *GetBatchRequest) (responses.GetBatchResponse, error) {

--- a/momento/cache_client.go
+++ b/momento/cache_client.go
@@ -51,10 +51,22 @@ type CacheClient interface {
 	SetIfAbsentOrEqual(ctx context.Context, r *SetIfAbsentOrEqualRequest) (responses.SetIfAbsentOrEqualResponse, error)
 	// SetIfNotEqual sets the value in cache with a given time to live (TTL) if key is present and its value is not equal to the given value
 	SetIfNotEqual(ctx context.Context, r *SetIfNotEqualRequest) (responses.SetIfNotEqualResponse, error)
+	// SetIfPresentAndHashNotEqual sets the value in the cache with a given time to live (TTL) if key is present and the hash of the current value is not equal to the given hash
+	SetIfPresentAndHashNotEqual(ctx context.Context, r *SetIfPresentAndHashNotEqualRequest) (responses.SetIfPresentAndHashNotEqualResponse, error)
+	// SetIfPresentAndHashEqual sets the value in the cache with a given time to live (TTL) if key is present and the hash of the current value is equal to the given hash
+	SetIfPresentAndHashEqual(ctx context.Context, r *SetIfPresentAndHashEqualRequest) (responses.SetIfPresentAndHashEqualResponse, error)
+	// SetIfAbsentOrHashEqual sets the value in the cache with a given time to live (TTL) if key is present and the hash of the current value is equal to the given hash, or creates the item if it does not exist
+	SetIfAbsentOrHashEqual(ctx context.Context, r *SetIfAbsentOrHashEqualRequest) (responses.SetIfAbsentOrHashEqualResponse, error)
+	// SetIfAbsentOrHashNotEqual sets the value in the cache with a given time to live (TTL) if key is present and the hash of the current value is not equal to the given hash, or creates the item if it does not exist
+	SetIfAbsentOrHashNotEqual(ctx context.Context, r *SetIfAbsentOrHashNotEqualRequest) (responses.SetIfAbsentOrHashNotEqualResponse, error)
+	// SetWithHash sets the value in the cache with a given time to live (TTL) unconditionally (may overwrite existing value) and returns the hash of the new value
+	SetWithHash(ctx context.Context, r *SetWithHashRequest) (responses.SetWithHashResponse, error)
 	// SetBatch sets multiple values in cache with a given time to live (TTL)
 	SetBatch(ctx context.Context, r *SetBatchRequest) (responses.SetBatchResponse, error)
 	// Get gets the cache value stored for the given key.
 	Get(ctx context.Context, r *GetRequest) (responses.GetResponse, error)
+	// GetWithHash gets the cache value stored for the given key and the hash of the value.
+	GetWithHash(ctx context.Context, r *GetWithHashRequest) (responses.GetWithHashResponse, error)
 	// GetBatch gets the cache values stored for the given keys.
 	GetBatch(ctx context.Context, r *GetBatchRequest) (responses.GetBatchResponse, error)
 	// Delete removes the key from the cache.
@@ -462,6 +474,46 @@ func (c defaultScsClient) SetIfNotEqual(ctx context.Context, r *SetIfNotEqualReq
 	return resp.(responses.SetIfNotEqualResponse), nil
 }
 
+func (c defaultScsClient) SetIfPresentAndHashNotEqual(ctx context.Context, r *SetIfPresentAndHashNotEqualRequest) (responses.SetIfPresentAndHashNotEqualResponse, error) {
+	r.CacheName = c.getCacheNameForRequest(r)
+	if err := c.getNextDataClient().makeRequest(ctx, r); err != nil {
+		return nil, err
+	}
+	return r.response, nil
+}
+
+func (c defaultScsClient) SetIfPresentAndHashEqual(ctx context.Context, r *SetIfPresentAndHashEqualRequest) (responses.SetIfPresentAndHashEqualResponse, error) {
+	r.CacheName = c.getCacheNameForRequest(r)
+	if err := c.getNextDataClient().makeRequest(ctx, r); err != nil {
+		return nil, err
+	}
+	return r.response, nil
+}
+
+func (c defaultScsClient) SetIfAbsentOrHashEqual(ctx context.Context, r *SetIfAbsentOrHashEqualRequest) (responses.SetIfAbsentOrHashEqualResponse, error) {
+	r.CacheName = c.getCacheNameForRequest(r)
+	if err := c.getNextDataClient().makeRequest(ctx, r); err != nil {
+		return nil, err
+	}
+	return r.response, nil
+}
+
+func (c defaultScsClient) SetIfAbsentOrHashNotEqual(ctx context.Context, r *SetIfAbsentOrHashNotEqualRequest) (responses.SetIfAbsentOrHashNotEqualResponse, error) {
+	r.CacheName = c.getCacheNameForRequest(r)
+	if err := c.getNextDataClient().makeRequest(ctx, r); err != nil {
+		return nil, err
+	}
+	return r.response, nil
+}
+
+func (c defaultScsClient) SetWithHash(ctx context.Context, r *SetWithHashRequest) (responses.SetWithHashResponse, error) {
+	r.CacheName = c.getCacheNameForRequest(r)
+	if err := c.getNextDataClient().makeRequest(ctx, r); err != nil {
+		return nil, err
+	}
+	return r.response, nil
+}
+
 func (c defaultScsClient) SetBatch(ctx context.Context, r *SetBatchRequest) (responses.SetBatchResponse, error) {
 	r.CacheName = c.getCacheNameForRequest(r)
 	resp, err := c.getNextDataClient().makeRequest(ctx, r)
@@ -478,6 +530,14 @@ func (c defaultScsClient) Get(ctx context.Context, r *GetRequest) (responses.Get
 		return nil, err
 	}
 	return resp.(responses.GetResponse), nil
+}
+
+func (c defaultScsClient) GetWithHash(ctx context.Context, r *GetWithHashRequest) (responses.GetWithHashResponse, error) {
+	r.CacheName = c.getCacheNameForRequest(r)
+	if err := c.getNextDataClient().makeRequest(ctx, r); err != nil {
+		return nil, err
+	}
+	return r.response, nil
 }
 
 func (c defaultScsClient) GetBatch(ctx context.Context, r *GetBatchRequest) (responses.GetBatchResponse, error) {

--- a/momento/get_with_hash.go
+++ b/momento/get_with_hash.go
@@ -1,0 +1,70 @@
+package momento
+
+import (
+	"context"
+
+	"github.com/momentohq/client-sdk-go/responses"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+
+	pb "github.com/momentohq/client-sdk-go/internal/protos"
+)
+
+type GetWithHashRequest struct {
+	// Name of the cache to get the item from
+	CacheName string
+	// string or byte key to be used to store item
+	Key Key
+
+	grpcRequest  *pb.XGetWithHashRequest
+	grpcResponse *pb.XGetWithHashResponse
+	response     responses.GetWithHashResponse
+}
+
+func (r *GetWithHashRequest) cacheName() string { return r.CacheName }
+
+func (r *GetWithHashRequest) key() Key { return r.Key }
+
+func (r *GetWithHashRequest) requestName() string { return "GetWithHash" }
+
+func (r *GetWithHashRequest) initGrpcRequest(scsDataClient) error {
+	var err error
+
+	var key []byte
+	if key, err = prepareKey(r); err != nil {
+		return err
+	}
+
+	r.grpcRequest = &pb.XGetWithHashRequest{
+		CacheKey: key,
+	}
+
+	return nil
+}
+
+func (r *GetWithHashRequest) makeGrpcRequest(requestMetadata context.Context, client scsDataClient) (grpcResponse, []metadata.MD, error) {
+	var header, trailer metadata.MD
+	resp, err := client.grpcClient.GetWithHash(requestMetadata, r.grpcRequest, grpc.Header(&header), grpc.Trailer(&trailer))
+	responseMetadata := []metadata.MD{header, trailer}
+	if err != nil {
+		return nil, responseMetadata, err
+	}
+
+	r.grpcResponse = resp
+
+	return resp, nil, nil
+}
+
+func (r *GetWithHashRequest) interpretGrpcResponse() error {
+	resp := r.grpcResponse
+
+	if resp.Result == pb.ECacheResult_Hit {
+		r.response = responses.NewGetWithHashHit(resp.CacheBody)
+		return nil
+	} else if resp.Result == pb.ECacheResult_Miss {
+		r.response = &responses.GetWithHashMiss{}
+		return nil
+	} else {
+		return errUnexpectedGrpcResponse(r, r.grpcResponse)
+	}
+}

--- a/momento/get_with_hash.go
+++ b/momento/get_with_hash.go
@@ -15,10 +15,6 @@ type GetWithHashRequest struct {
 	CacheName string
 	// string or byte key to be used to store item
 	Key Key
-
-	grpcRequest  *pb.XGetWithHashRequest
-	grpcResponse *pb.XGetWithHashResponse
-	response     responses.GetWithHashResponse
 }
 
 func (r *GetWithHashRequest) cacheName() string { return r.CacheName }
@@ -27,44 +23,44 @@ func (r *GetWithHashRequest) key() Key { return r.Key }
 
 func (r *GetWithHashRequest) requestName() string { return "GetWithHash" }
 
-func (r *GetWithHashRequest) initGrpcRequest(scsDataClient) error {
+func (r *GetWithHashRequest) initGrpcRequest(client scsDataClient) (interface{}, error) {
 	var err error
 
 	var key []byte
 	if key, err = prepareKey(r); err != nil {
-		return err
+		return nil, err
 	}
 
-	r.grpcRequest = &pb.XGetWithHashRequest{
+	grpcRequest := &pb.XGetWithHashRequest{
 		CacheKey: key,
 	}
 
-	return nil
+	return grpcRequest, nil
 }
 
-func (r *GetWithHashRequest) makeGrpcRequest(requestMetadata context.Context, client scsDataClient) (grpcResponse, []metadata.MD, error) {
+func (r *GetWithHashRequest) makeGrpcRequest(grpcRequest interface{}, requestMetadata context.Context, client scsDataClient) (grpcResponse, []metadata.MD, error) {
 	var header, trailer metadata.MD
-	resp, err := client.grpcClient.GetWithHash(requestMetadata, r.grpcRequest, grpc.Header(&header), grpc.Trailer(&trailer))
+	resp, err := client.grpcClient.GetWithHash(
+		requestMetadata,
+		grpcRequest.(*pb.XGetWithHashRequest),
+		grpc.Header(&header),
+		grpc.Trailer(&trailer),
+	)
 	responseMetadata := []metadata.MD{header, trailer}
 	if err != nil {
 		return nil, responseMetadata, err
 	}
-
-	r.grpcResponse = resp
-
 	return resp, nil, nil
 }
 
-func (r *GetWithHashRequest) interpretGrpcResponse() error {
-	resp := r.grpcResponse
-
-	if resp.Result == pb.ECacheResult_Hit {
-		r.response = responses.NewGetWithHashHit(resp.CacheBody)
-		return nil
-	} else if resp.Result == pb.ECacheResult_Miss {
-		r.response = &responses.GetWithHashMiss{}
-		return nil
-	} else {
-		return errUnexpectedGrpcResponse(r, r.grpcResponse)
+func (r *GetWithHashRequest) interpretGrpcResponse(resp interface{}) (interface{}, error) {
+	grpcResponse := resp.(*pb.XGetWithHashResponse)
+	switch response := grpcResponse.Result.(type) {
+	case *pb.XGetWithHashResponse_Found:
+		return responses.NewGetWithHashHit(response.Found.Value, response.Found.Hash), nil
+	case *pb.XGetWithHashResponse_Missing:
+		return &responses.GetWithHashMiss{}, nil
+	default:
+		return nil, errUnexpectedGrpcResponse(r, grpcResponse)
 	}
 }

--- a/momento/set_if_absent_or_hash_equal.go
+++ b/momento/set_if_absent_or_hash_equal.go
@@ -1,0 +1,108 @@
+package momento
+
+import (
+	"context"
+	"time"
+
+	"github.com/momentohq/client-sdk-go/responses"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+
+	pb "github.com/momentohq/client-sdk-go/internal/protos"
+)
+
+type SetIfAbsentOrHashEqualRequest struct {
+	// Name of the cache to store the item in.
+	CacheName string
+	// string or byte key to be used to store item.
+	Key Key
+	// string ot byte value to be stored.
+	Value Value
+	// string or byte value to compare with the existing value in the cache.
+	HashEqual Value
+	// Optional Time to live in cache in seconds.
+	// If not provided, then default TTL for the cache client instance is used.
+	Ttl time.Duration
+
+	grpcRequest  *pb.XSetIfHashRequest
+	grpcResponse *pb.XSetIfHashResponse
+	response     responses.SetIfAbsentOrHashEqualResponse
+}
+
+func (r *SetIfAbsentOrHashEqualRequest) cacheName() string { return r.CacheName }
+
+func (r *SetIfAbsentOrHashEqualRequest) key() Key { return r.Key }
+
+func (r *SetIfAbsentOrHashEqualRequest) value() Value { return r.Value }
+
+func (r *SetIfAbsentOrHashEqualRequest) equal() Value { return r.HashEqual }
+
+func (r *SetIfAbsentOrHashEqualRequest) ttl() time.Duration { return r.Ttl }
+
+func (r *SetIfAbsentOrHashEqualRequest) requestName() string { return "SetIfAbsentOrHashEqual" }
+
+func (r *SetIfAbsentOrHashEqualRequest) initGrpcRequest(client scsDataClient) error {
+	var err error
+
+	var key []byte
+	if key, err = prepareKey(r); err != nil {
+		return err
+	}
+
+	var value []byte
+	if value, err = prepareValue(r); err != nil {
+		return err
+	}
+
+	var hashEqual []byte
+	if hashEqual, err = prepareEqual(r); err != nil {
+		return err
+	}
+
+	var ttl uint64
+	if ttl, err = prepareTtl(r, client.defaultTtl); err != nil {
+		return err
+	}
+
+	var condition = &pb.XSetIfHashRequest_AbsentOrHashEqual{
+		AbsentOrEqual: &pb.AbsentOrHashEqual{
+			HashToCheck: hashEqual,
+		},
+	}
+	r.grpcRequest = &pb.XSetIfHashRequest{
+		CacheKey:        key,
+		CacheBody:       value,
+		TtlMilliseconds: ttl,
+		Condition:       condition,
+	}
+
+	return nil
+}
+
+func (r *SetIfAbsentOrHashEqualRequest) makeGrpcRequest(requestMetadata context.Context, client scsDataClient) (grpcResponse, []metadata.MD, error) {
+	var header, trailer metadata.MD
+	resp, err := client.grpcClient.SetIf(requestMetadata, r.grpcRequest, grpc.Header(&header), grpc.Trailer(&trailer))
+	responseMetadata := []metadata.MD{header, trailer}
+	if err != nil {
+		return nil, responseMetadata, err
+	}
+	r.grpcResponse = resp
+	return resp, nil, nil
+}
+
+func (r *SetIfAbsentOrHashEqualRequest) interpretGrpcResponse() error {
+	grpcResp := r.grpcResponse
+	var resp responses.SetIfAbsentOrHashEqualResponse
+
+	switch grpcResp.Result.(type) {
+	case *pb.XSetIfResponse_Stored:
+		resp = &responses.SetIfAbsentOrHashEqualStored{}
+	case *pb.XSetIfResponse_NotStored:
+		resp = &responses.SetIfAbsentOrHashEqualNotStored{}
+	default:
+		return errUnexpectedGrpcResponse(r, r.grpcResponse)
+	}
+
+	r.response = resp
+	return nil
+}

--- a/momento/set_if_absent_or_hash_not_equal.go
+++ b/momento/set_if_absent_or_hash_not_equal.go
@@ -1,0 +1,108 @@
+package momento
+
+import (
+	"context"
+	"time"
+
+	"github.com/momentohq/client-sdk-go/responses"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+
+	pb "github.com/momentohq/client-sdk-go/internal/protos"
+)
+
+type SetIfAbsentOrHashNotEqualRequest struct {
+	// Name of the cache to store the item in.
+	CacheName string
+	// string or byte key to be used to store item.
+	Key Key
+	// string ot byte value to be stored.
+	Value Value
+	// string or byte value to compare with the existing value in the cache.
+	HashNotEqual Value
+	// Optional Time to live in cache in seconds.
+	// If not provided, then default TTL for the cache client instance is used.
+	Ttl time.Duration
+
+	grpcRequest  *pb.XSetIfHashRequest
+	grpcResponse *pb.XSetIfHashResponse
+	response     responses.SetIfAbsentOrHashNotEqualResponse
+}
+
+func (r *SetIfAbsentOrHashNotEqualRequest) cacheName() string { return r.CacheName }
+
+func (r *SetIfAbsentOrHashNotEqualRequest) key() Key { return r.Key }
+
+func (r *SetIfAbsentOrHashNotEqualRequest) value() Value { return r.Value }
+
+func (r *SetIfAbsentOrHashNotEqualRequest) notEqual() Value { return r.HashNotEqual }
+
+func (r *SetIfAbsentOrHashNotEqualRequest) ttl() time.Duration { return r.Ttl }
+
+func (r *SetIfAbsentOrHashNotEqualRequest) requestName() string { return "SetIfAbsentOrHashNotEqual" }
+
+func (r *SetIfAbsentOrHashNotEqualRequest) initGrpcRequest(client scsDataClient) error {
+	var err error
+
+	var key []byte
+	if key, err = prepareKey(r); err != nil {
+		return err
+	}
+
+	var value []byte
+	if value, err = prepareValue(r); err != nil {
+		return err
+	}
+
+	var hashNotEqual []byte
+	if hashNotEqual, err = prepareNotEqual(r); err != nil {
+		return err
+	}
+
+	var ttl uint64
+	if ttl, err = prepareTtl(r, client.defaultTtl); err != nil {
+		return err
+	}
+
+	var condition = &pb.XSetIfHashRequest_AbsentOrNotHashEqual{
+		AbsentOrEqual: &pb.AbsentOrNotHashEqual{
+			HashToCheck: hashNotEqual,
+		},
+	}
+	r.grpcRequest = &pb.XSetIfHashRequest{
+		CacheKey:        key,
+		CacheBody:       value,
+		TtlMilliseconds: ttl,
+		Condition:       condition,
+	}
+
+	return nil
+}
+
+func (r *SetIfAbsentOrHashNotEqualRequest) makeGrpcRequest(requestMetadata context.Context, client scsDataClient) (grpcResponse, []metadata.MD, error) {
+	var header, trailer metadata.MD
+	resp, err := client.grpcClient.SetIf(requestMetadata, r.grpcRequest, grpc.Header(&header), grpc.Trailer(&trailer))
+	responseMetadata := []metadata.MD{header, trailer}
+	if err != nil {
+		return nil, responseMetadata, err
+	}
+	r.grpcResponse = resp
+	return resp, nil, nil
+}
+
+func (r *SetIfAbsentOrHashNotEqualRequest) interpretGrpcResponse() error {
+	grpcResp := r.grpcResponse
+	var resp responses.SetIfAbsentOrHashNotEqualResponse
+
+	switch grpcResp.Result.(type) {
+	case *pb.XSetIfResponse_Stored:
+		resp = &responses.SetIfAbsentOrHashNotEqualStored{}
+	case *pb.XSetIfResponse_NotStored:
+		resp = &responses.SetIfAbsentOrHashNotEqualNotStored{}
+	default:
+		return errUnexpectedGrpcResponse(r, r.grpcResponse)
+	}
+
+	r.response = resp
+	return nil
+}

--- a/momento/set_if_absent_or_hash_not_equal.go
+++ b/momento/set_if_absent_or_hash_not_equal.go
@@ -23,10 +23,6 @@ type SetIfAbsentOrHashNotEqualRequest struct {
 	// Optional Time to live in cache in seconds.
 	// If not provided, then default TTL for the cache client instance is used.
 	Ttl time.Duration
-
-	grpcRequest  *pb.XSetIfHashRequest
-	grpcResponse *pb.XSetIfHashResponse
-	response     responses.SetIfAbsentOrHashNotEqualResponse
 }
 
 func (r *SetIfAbsentOrHashNotEqualRequest) cacheName() string { return r.CacheName }
@@ -41,68 +37,67 @@ func (r *SetIfAbsentOrHashNotEqualRequest) ttl() time.Duration { return r.Ttl }
 
 func (r *SetIfAbsentOrHashNotEqualRequest) requestName() string { return "SetIfAbsentOrHashNotEqual" }
 
-func (r *SetIfAbsentOrHashNotEqualRequest) initGrpcRequest(client scsDataClient) error {
+func (r *SetIfAbsentOrHashNotEqualRequest) initGrpcRequest(client scsDataClient) (interface{}, error) {
 	var err error
 
 	var key []byte
 	if key, err = prepareKey(r); err != nil {
-		return err
+		return nil, err
 	}
 
 	var value []byte
 	if value, err = prepareValue(r); err != nil {
-		return err
+		return nil, err
 	}
 
 	var hashNotEqual []byte
 	if hashNotEqual, err = prepareNotEqual(r); err != nil {
-		return err
+		return nil, err
 	}
 
 	var ttl uint64
 	if ttl, err = prepareTtl(r, client.defaultTtl); err != nil {
-		return err
+		return nil, err
 	}
 
 	var condition = &pb.XSetIfHashRequest_AbsentOrNotHashEqual{
-		AbsentOrEqual: &pb.AbsentOrNotHashEqual{
+		AbsentOrNotHashEqual: &pb.AbsentOrNotHashEqual{
 			HashToCheck: hashNotEqual,
 		},
 	}
-	r.grpcRequest = &pb.XSetIfHashRequest{
+	grpcRequest := &pb.XSetIfHashRequest{
 		CacheKey:        key,
 		CacheBody:       value,
 		TtlMilliseconds: ttl,
 		Condition:       condition,
 	}
 
-	return nil
+	return grpcRequest, nil
 }
 
-func (r *SetIfAbsentOrHashNotEqualRequest) makeGrpcRequest(requestMetadata context.Context, client scsDataClient) (grpcResponse, []metadata.MD, error) {
+func (r *SetIfAbsentOrHashNotEqualRequest) makeGrpcRequest(grpcRequest interface{}, requestMetadata context.Context, client scsDataClient) (grpcResponse, []metadata.MD, error) {
 	var header, trailer metadata.MD
-	resp, err := client.grpcClient.SetIf(requestMetadata, r.grpcRequest, grpc.Header(&header), grpc.Trailer(&trailer))
+	resp, err := client.grpcClient.SetIfHash(
+		requestMetadata,
+		grpcRequest.(*pb.XSetIfHashRequest),
+		grpc.Header(&header),
+		grpc.Trailer(&trailer),
+	)
 	responseMetadata := []metadata.MD{header, trailer}
 	if err != nil {
 		return nil, responseMetadata, err
 	}
-	r.grpcResponse = resp
 	return resp, nil, nil
 }
 
-func (r *SetIfAbsentOrHashNotEqualRequest) interpretGrpcResponse() error {
-	grpcResp := r.grpcResponse
-	var resp responses.SetIfAbsentOrHashNotEqualResponse
-
-	switch grpcResp.Result.(type) {
-	case *pb.XSetIfResponse_Stored:
-		resp = &responses.SetIfAbsentOrHashNotEqualStored{}
-	case *pb.XSetIfResponse_NotStored:
-		resp = &responses.SetIfAbsentOrHashNotEqualNotStored{}
+func (r *SetIfAbsentOrHashNotEqualRequest) interpretGrpcResponse(resp interface{}) (interface{}, error) {
+	grpcResponse := resp.(*pb.XSetIfHashResponse)
+	switch response := grpcResponse.Result.(type) {
+	case *pb.XSetIfHashResponse_Stored:
+		return responses.NewSetIfAbsentOrHashNotEqualStored(response.Stored.NewHash), nil
+	case *pb.XSetIfHashResponse_NotStored:
+		return &responses.SetIfAbsentOrHashNotEqualNotStored{}, nil
 	default:
-		return errUnexpectedGrpcResponse(r, r.grpcResponse)
+		return nil, errUnexpectedGrpcResponse(r, grpcResponse)
 	}
-
-	r.response = resp
-	return nil
 }

--- a/momento/set_if_present_and_hash_equal.go
+++ b/momento/set_if_present_and_hash_equal.go
@@ -1,0 +1,108 @@
+package momento
+
+import (
+	"context"
+	"time"
+
+	"github.com/momentohq/client-sdk-go/responses"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+
+	pb "github.com/momentohq/client-sdk-go/internal/protos"
+)
+
+type SetIfPresentAndHashEqualRequest struct {
+	// Name of the cache to store the item in.
+	CacheName string
+	// string or byte key to be used to store item.
+	Key Key
+	// string ot byte value to be stored.
+	Value Value
+	// string or byte value to compare with the existing value in the cache.
+	HashEqual Value
+	// Optional Time to live in cache in seconds.
+	// If not provided, then default TTL for the cache client instance is used.
+	Ttl time.Duration
+
+	grpcRequest  *pb.XSetIfHashRequest
+	grpcResponse *pb.XSetIfHashResponse
+	response     responses.SetIfPresentAndHashEqualResponse
+}
+
+func (r *SetIfPresentAndHashEqualRequest) cacheName() string { return r.CacheName }
+
+func (r *SetIfPresentAndHashEqualRequest) key() Key { return r.Key }
+
+func (r *SetIfPresentAndHashEqualRequest) value() Value { return r.Value }
+
+func (r *SetIfPresentAndHashEqualRequest) equal() Value { return r.HashEqual }
+
+func (r *SetIfPresentAndHashEqualRequest) ttl() time.Duration { return r.Ttl }
+
+func (r *SetIfPresentAndHashEqualRequest) requestName() string { return "SetIfPresentAndHashEqual" }
+
+func (r *SetIfPresentAndHashEqualRequest) initGrpcRequest(client scsDataClient) error {
+	var err error
+
+	var key []byte
+	if key, err = prepareKey(r); err != nil {
+		return err
+	}
+
+	var value []byte
+	if value, err = prepareValue(r); err != nil {
+		return err
+	}
+
+	var hashEqual []byte
+	if hashEqual, err = prepareEqual(r); err != nil {
+		return err
+	}
+
+	var ttl uint64
+	if ttl, err = prepareTtl(r, client.defaultTtl); err != nil {
+		return err
+	}
+
+	var condition = &pb.XSetIfHashRequest_PresentAndHashEqual{
+		PresentAndEqual: &pb.PresentAndHashEqual{
+			HashToCheck: hashEqual,
+		},
+	}
+	r.grpcRequest = &pb.XSetIfHashRequest{
+		CacheKey:        key,
+		CacheBody:       value,
+		TtlMilliseconds: ttl,
+		Condition:       condition,
+	}
+
+	return nil
+}
+
+func (r *SetIfPresentAndHashEqualRequest) makeGrpcRequest(requestMetadata context.Context, client scsDataClient) (grpcResponse, []metadata.MD, error) {
+	var header, trailer metadata.MD
+	resp, err := client.grpcClient.SetIf(requestMetadata, r.grpcRequest, grpc.Header(&header), grpc.Trailer(&trailer))
+	responseMetadata := []metadata.MD{header, trailer}
+	if err != nil {
+		return nil, responseMetadata, err
+	}
+	r.grpcResponse = resp
+	return resp, nil, nil
+}
+
+func (r *SetIfPresentAndHashEqualRequest) interpretGrpcResponse() error {
+	grpcResp := r.grpcResponse
+	var resp responses.SetIfPresentAndHashEqualResponse
+
+	switch grpcResp.Result.(type) {
+	case *pb.XSetIfResponse_Stored:
+		resp = &responses.SetIfPresentAndHashEqualStored{}
+	case *pb.XSetIfResponse_NotStored:
+		resp = &responses.SetIfPresentAndHashEqualNotStored{}
+	default:
+		return errUnexpectedGrpcResponse(r, r.grpcResponse)
+	}
+
+	r.response = resp
+	return nil
+}

--- a/momento/set_if_present_and_hash_not_equal.go
+++ b/momento/set_if_present_and_hash_not_equal.go
@@ -1,0 +1,110 @@
+package momento
+
+import (
+	"context"
+	"time"
+
+	"github.com/momentohq/client-sdk-go/responses"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+
+	pb "github.com/momentohq/client-sdk-go/internal/protos"
+)
+
+type SetIfPresentAndHashNotEqualRequest struct {
+	// Name of the cache to store the item in.
+	CacheName string
+	// string or byte key to be used to store item.
+	Key Key
+	// string ot byte value to be stored.
+	Value Value
+	// string or byte value to compare with the existing value in the cache.
+	HashNotEqual Value
+	// Optional Time to live in cache in seconds.
+	// If not provided, then default TTL for the cache client instance is used.
+	Ttl time.Duration
+
+	grpcRequest  *pb.XSetIfHashRequest
+	grpcResponse *pb.XSetIfHashResponse
+	response     responses.SetIfPresentAndHashNotEqualResponse
+}
+
+func (r *SetIfPresentAndHashNotEqualRequest) cacheName() string { return r.CacheName }
+
+func (r *SetIfPresentAndHashNotEqualRequest) key() Key { return r.Key }
+
+func (r *SetIfPresentAndHashNotEqualRequest) value() Value { return r.Value }
+
+func (r *SetIfPresentAndHashNotEqualRequest) notEqual() Value { return r.HashNotEqual }
+
+func (r *SetIfPresentAndHashNotEqualRequest) ttl() time.Duration { return r.Ttl }
+
+func (r *SetIfPresentAndHashNotEqualRequest) requestName() string {
+	return "SetIfPresentAndHashNotEqual"
+}
+
+func (r *SetIfPresentAndHashNotEqualRequest) initGrpcRequest(client scsDataClient) error {
+	var err error
+
+	var key []byte
+	if key, err = prepareKey(r); err != nil {
+		return err
+	}
+
+	var value []byte
+	if value, err = prepareValue(r); err != nil {
+		return err
+	}
+
+	var hashNotEqual []byte
+	if hashNotEqual, err = prepareNotEqual(r); err != nil {
+		return err
+	}
+
+	var ttl uint64
+	if ttl, err = prepareTtl(r, client.defaultTtl); err != nil {
+		return err
+	}
+
+	var condition = &pb.XSetIfHashRequest_PresentAndHashNotEqual{
+		PresentAndEqual: &pb.PresentAndHashNotEqual{
+			HashToCheck: hashNotEqual,
+		},
+	}
+	r.grpcRequest = &pb.XSetIfHashRequest{
+		CacheKey:        key,
+		CacheBody:       value,
+		TtlMilliseconds: ttl,
+		Condition:       condition,
+	}
+
+	return nil
+}
+
+func (r *SetIfPresentAndHashNotEqualRequest) makeGrpcRequest(requestMetadata context.Context, client scsDataClient) (grpcResponse, []metadata.MD, error) {
+	var header, trailer metadata.MD
+	resp, err := client.grpcClient.SetIf(requestMetadata, r.grpcRequest, grpc.Header(&header), grpc.Trailer(&trailer))
+	responseMetadata := []metadata.MD{header, trailer}
+	if err != nil {
+		return nil, responseMetadata, err
+	}
+	r.grpcResponse = resp
+	return resp, nil, nil
+}
+
+func (r *SetIfPresentAndHashNotEqualRequest) interpretGrpcResponse() error {
+	grpcResp := r.grpcResponse
+	var resp responses.SetIfPresentAndHashNotEqualResponse
+
+	switch grpcResp.Result.(type) {
+	case *pb.XSetIfResponse_Stored:
+		resp = &responses.SetIfPresentAndHashNotEqualStored{}
+	case *pb.XSetIfResponse_NotStored:
+		resp = &responses.SetIfPresentAndHashNotEqualNotStored{}
+	default:
+		return errUnexpectedGrpcResponse(r, r.grpcResponse)
+	}
+
+	r.response = resp
+	return nil
+}

--- a/momento/set_with_hash.go
+++ b/momento/set_with_hash.go
@@ -1,0 +1,96 @@
+package momento
+
+import (
+	"context"
+	"time"
+
+	"github.com/momentohq/client-sdk-go/responses"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+
+	pb "github.com/momentohq/client-sdk-go/internal/protos"
+)
+
+type SetWithHashRequest struct {
+	// Name of the cache to store the item in.
+	CacheName string
+	// string or byte key to be used to store item.
+	Key Key
+	// string ot byte value to be stored.
+	Value Value
+	// Optional Time to live in cache in seconds.
+	// If not provided, then default TTL for the cache client instance is used.
+	Ttl time.Duration
+
+	grpcRequest  *pb.XSetIfHashRequest
+	grpcResponse *pb.XSetIfHashResponse
+	response     responses.SetWithHashResponse
+}
+
+func (r *SetWithHashRequest) cacheName() string { return r.CacheName }
+
+func (r *SetWithHashRequest) key() Key { return r.Key }
+
+func (r *SetWithHashRequest) value() Value { return r.Value }
+
+func (r *SetWithHashRequest) ttl() time.Duration { return r.Ttl }
+
+func (r *SetWithHashRequest) requestName() string {
+	return "SetWithHash"
+}
+
+func (r *SetWithHashRequest) initGrpcRequest(client scsDataClient) error {
+	var err error
+
+	var key []byte
+	if key, err = prepareKey(r); err != nil {
+		return err
+	}
+
+	var value []byte
+	if value, err = prepareValue(r); err != nil {
+		return err
+	}
+
+	var ttl uint64
+	if ttl, err = prepareTtl(r, client.defaultTtl); err != nil {
+		return err
+	}
+
+	r.grpcRequest = &pb.XSetIfHashRequest{
+		CacheKey:        key,
+		CacheBody:       value,
+		TtlMilliseconds: ttl,
+		Condition:       &pb.XSetIfHashRequest_Unconditional{},
+	}
+
+	return nil
+}
+
+func (r *SetWithHashRequest) makeGrpcRequest(requestMetadata context.Context, client scsDataClient) (grpcResponse, []metadata.MD, error) {
+	var header, trailer metadata.MD
+	resp, err := client.grpcClient.SetIf(requestMetadata, r.grpcRequest, grpc.Header(&header), grpc.Trailer(&trailer))
+	responseMetadata := []metadata.MD{header, trailer}
+	if err != nil {
+		return nil, responseMetadata, err
+	}
+	r.grpcResponse = resp
+	return resp, nil, nil
+}
+
+func (r *SetWithHashRequest) interpretGrpcResponse() error {
+	grpcResp := r.grpcResponse
+	var resp responses.SetWithHashResponse
+
+	switch grpcResp.Result.(type) {
+	case *pb.XSetIfResponse_Stored:
+		resp = &responses.SetWithHashStored{}
+	case *pb.XSetIfResponse_NotStored:
+		resp = &responses.SetWithHashNotStored{}
+	default:
+		return errUnexpectedGrpcResponse(r, r.grpcResponse)
+	}
+
+	r.response = resp
+	return nil
+}

--- a/responses/get_with_hash.go
+++ b/responses/get_with_hash.go
@@ -1,0 +1,44 @@
+package responses
+
+// GetWithHashResponse is the base response type for a get with hash request.
+type GetWithHashResponse interface {
+	isGetWithHashResponse()
+}
+
+// GetWithHashMiss Miss response to a cache GetWithHash api request.
+type GetWithHashMiss struct{}
+
+func (GetWithHashMiss) isGetWithHashResponse() {}
+
+// GetWithHashHit Hit response to a cache GetWithHash api request.
+type GetWithHashHit struct {
+	value []byte
+	hash  []byte
+}
+
+func (GetWithHashHit) isGetWithHashResponse() {}
+
+// ValueString Returns value stored in cache as string for GetWithHashHit responses.
+func (resp GetWithHashHit) ValueString() string {
+	return string(resp.value)
+}
+
+// ValueByte Returns value stored in cache as bytes for GetWithHashHit responses.
+func (resp GetWithHashHit) ValueByte() []byte {
+	return resp.value
+}
+
+// HashString Returns hash of value stored in cache as string for GetWithHashHit responses.
+func (resp GetWithHashHit) HashString() string {
+	return string(resp.hash)
+}
+
+// HashByte Returns hash of value stored in cache as bytes for GetWithHashHit responses.
+func (resp GetWithHashHit) HashByte() []byte {
+	return resp.hash
+}
+
+// NewGetWithHashHit returns a new GetWithHashHit containing the supplied value.
+func NewGetWithHashHit(value []byte, hash []byte) *GetWithHashHit {
+	return &GetWithHashHit{value: value, hash: hash}
+}

--- a/responses/set_if_absent_or_hash_equal.go
+++ b/responses/set_if_absent_or_hash_equal.go
@@ -1,0 +1,39 @@
+package responses
+
+// SetIfAbsentOrHashEqualResponse is the base response type
+// for a set if absent or hash equal request.
+type SetIfAbsentOrHashEqualResponse interface {
+	isSetIfAbsentOrHashEqualResponse()
+}
+
+// SetIfAbsentOrHashEqualNotStored NotStored response to a
+// cache SetIfAbsentOrHashEqual api request.
+type SetIfAbsentOrHashEqualNotStored struct{}
+
+func (SetIfAbsentOrHashEqualNotStored) isSetIfAbsentOrHashEqualResponse() {}
+
+// SetIfAbsentOrHashEqualStored Stored response to a
+// cache SetIfAbsentOrHashEqual api request.
+type SetIfAbsentOrHashEqualStored struct {
+	hash []byte
+}
+
+func (SetIfAbsentOrHashEqualStored) isSetIfAbsentOrHashEqualResponse() {}
+
+// HashString Returns hash of value stored in cache as string
+// for SetIfAbsentOrHashEqualStored responses.
+func (resp SetIfAbsentOrHashEqualStored) HashString() string {
+	return string(resp.hash)
+}
+
+// HashByte Returns hash of value stored in cache as bytes
+// for SetIfAbsentOrHashEqualStored responses.
+func (resp SetIfAbsentOrHashEqualStored) HashByte() []byte {
+	return resp.hash
+}
+
+// NewSetIfAbsentOrHashEqualStored returns a new
+// SetIfAbsentOrHashEqualStored containing the supplied value.
+func NewSetIfAbsentOrHashEqualStored(hash []byte) *SetIfAbsentOrHashEqualStored {
+	return &SetIfAbsentOrHashEqualStored{hash: hash}
+}

--- a/responses/set_if_absent_or_hash_not_equal.go
+++ b/responses/set_if_absent_or_hash_not_equal.go
@@ -1,0 +1,39 @@
+package responses
+
+// SetIfAbsentOrHashNotEqualResponse is the base response type
+// for a set if absent or hash not equal request.
+type SetIfAbsentOrHashNotEqualResponse interface {
+	isSetIfAbsentOrHashNotEqualResponse()
+}
+
+// SetIfAbsentOrHashNotEqualNotStored NotStored response to a
+// cache SetIfAbsentOrHashNotEqual api request.
+type SetIfAbsentOrHashNotEqualNotStored struct{}
+
+func (SetIfAbsentOrHashNotEqualNotStored) isSetIfAbsentOrHashNotEqualResponse() {}
+
+// SetIfAbsentOrHashNotEqualStored Stored response to a
+// cache SetIfAbsentOrHashNotEqual api request.
+type SetIfAbsentOrHashNotEqualStored struct {
+	hash []byte
+}
+
+func (SetIfAbsentOrHashNotEqualStored) isSetIfAbsentOrHashNotEqualResponse() {}
+
+// HashString Returns hash of value stored in cache as string
+// for SetIfAbsentOrHashNotEqualStored responses.
+func (resp SetIfAbsentOrHashNotEqualStored) HashString() string {
+	return string(resp.hash)
+}
+
+// HashByte Returns hash of value stored in cache as bytes
+// for SetIfAbsentOrHashNotEqualStored responses.
+func (resp SetIfAbsentOrHashNotEqualStored) HashByte() []byte {
+	return resp.hash
+}
+
+// NewSetIfAbsentOrHashNotEqualStored returns a new
+// SetIfAbsentOrHashNotEqualStored containing the supplied value.
+func NewSetIfAbsentOrHashNotEqualStored(hash []byte) *SetIfAbsentOrHashNotEqualStored {
+	return &SetIfAbsentOrHashNotEqualStored{hash: hash}
+}

--- a/responses/set_if_present_and_hash_equal.go
+++ b/responses/set_if_present_and_hash_equal.go
@@ -1,0 +1,39 @@
+package responses
+
+// SetIfPresentAndHashEqualResponse is the base response type
+// for a set if present and hash equal request.
+type SetIfPresentAndHashEqualResponse interface {
+	isSetIfPresentAndHashEqualResponse()
+}
+
+// SetIfPresentAndHashEqualNotStored NotStored response to a
+// cache SetIfPresentAndHashEqual api request.
+type SetIfPresentAndHashEqualNotStored struct{}
+
+func (SetIfPresentAndHashEqualNotStored) isSetIfPresentAndHashEqualResponse() {}
+
+// SetIfPresentAndHashEqualStored Stored response to a
+// cache SetIfPresentAndHashEqual api request.
+type SetIfPresentAndHashEqualStored struct {
+	hash []byte
+}
+
+func (SetIfPresentAndHashEqualStored) isSetIfPresentAndHashEqualResponse() {}
+
+// HashString Returns hash of value stored in cache as string for
+// SetIfPresentAndHashEqualStored responses.
+func (resp SetIfPresentAndHashEqualStored) HashString() string {
+	return string(resp.hash)
+}
+
+// HashByte Returns hash of value stored in cache as bytes for
+// SetIfPresentAndHashEqualStored responses.
+func (resp SetIfPresentAndHashEqualStored) HashByte() []byte {
+	return resp.hash
+}
+
+// NewSetIfPresentAndHashEqualStored returns a new
+// SetIfPresentAndHashEqualStored containing the supplied value.
+func NewSetIfPresentAndHashEqualStored(hash []byte) *SetIfPresentAndHashEqualStored {
+	return &SetIfPresentAndHashEqualStored{hash: hash}
+}

--- a/responses/set_if_present_and_hash_not_equal.go
+++ b/responses/set_if_present_and_hash_not_equal.go
@@ -1,0 +1,39 @@
+package responses
+
+// SetIfPresentAndHashNotEqualResponse is the base response type
+// for a set if present and hash not equal request.
+type SetIfPresentAndHashNotEqualResponse interface {
+	isSetIfPresentAndHashNotEqualResponse()
+}
+
+// SetIfPresentAndHashNotEqualNotStored NotStored response to a
+// cache SetIfPresentAndHashNotEqual api request.
+type SetIfPresentAndHashNotEqualNotStored struct{}
+
+func (SetIfPresentAndHashNotEqualNotStored) isSetIfPresentAndHashNotEqualResponse() {}
+
+// SetIfPresentAndHashNotEqualStored Stored response to a
+// cache SetIfPresentAndHashNotEqual api request.
+type SetIfPresentAndHashNotEqualStored struct {
+	hash []byte
+}
+
+func (SetIfPresentAndHashNotEqualStored) isSetIfPresentAndHashNotEqualResponse() {}
+
+// HashString Returns hash of value stored in cache as string for
+// SetIfPresentAndHashNotEqualStored responses.
+func (resp SetIfPresentAndHashNotEqualStored) HashString() string {
+	return string(resp.hash)
+}
+
+// HashByte Returns hash of value stored in cache as bytes for
+// SetIfPresentAndHashNotEqualStored responses.
+func (resp SetIfPresentAndHashNotEqualStored) HashByte() []byte {
+	return resp.hash
+}
+
+// NewSetIfPresentAndHashNotEqualStored returns a new
+// SetIfPresentAndHashNotEqualStored containing the supplied value.
+func NewSetIfPresentAndHashNotEqualStored(hash []byte) *SetIfPresentAndHashNotEqualStored {
+	return &SetIfPresentAndHashNotEqualStored{hash: hash}
+}

--- a/responses/set_with_hash.go
+++ b/responses/set_with_hash.go
@@ -1,0 +1,33 @@
+package responses
+
+// SetWithHashResponse is the base response type for a set with hash request.
+type SetWithHashResponse interface {
+	isSetWithHashResponse()
+}
+
+// SetWithHashNotStored NotStored response to a cache SetWithHash api request.
+type SetWithHashNotStored struct{}
+
+func (SetWithHashNotStored) isSetWithHashResponse() {}
+
+// SetWithHashStored Stored response to a cache SetWithHash api request.
+type SetWithHashStored struct {
+	hash []byte
+}
+
+func (SetWithHashStored) isSetWithHashResponse() {}
+
+// HashString Returns hash of value stored in cache as string for SetWithHashStored responses.
+func (resp SetWithHashStored) HashString() string {
+	return string(resp.hash)
+}
+
+// HashByte Returns hash of value stored in cache as bytes for SetWithHashStored responses.
+func (resp SetWithHashStored) HashByte() []byte {
+	return resp.hash
+}
+
+// NewSetWithHashStored returns a new SetWithHashStored containing the supplied value.
+func NewSetWithHashStored(hash []byte) *SetWithHashStored {
+	return &SetWithHashStored{hash: hash}
+}


### PR DESCRIPTION
Work towards https://github.com/momentohq/dev-eco-issue-tracker/issues/1198

Confirmed the APIs work as expected against alpha using the tests in https://github.com/momentohq/client-sdk-go/pull/612, but the tests will be merged at a later date to avoid unnecessary canary failures.

We should align on naming and any other public API implications on this PR:

- Use the proto names (e.g. SetIfPresentAnd**NotHashEqual**) or rearrange a little (e.g. SetIfPresentAnd**HashNotEqual**)?
- Unconditional get and set with hash names: GetWithHash and SetWithHash

