### PR TITLE
feat: timestamp channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,3 +109,4 @@ If you are interested in contributing to the SDK, please see the [CONTRIBUTING](
 
 ----------------------------------------------------------------------------------------
 For more info, visit our website at [https://gomomento.com](https://gomomento.com)!
+

--- a/config/config.go
+++ b/config/config.go
@@ -83,7 +83,7 @@ type Configuration interface {
 	//   myConfig := config.LaptopLatest().WithMiddleware([]middleware.Middleware{
 	//     NewMyMiddleware(middleware.Props{
 	//       Logger: loggerFactory.GetLogger("MyMiddleware"),
-	//       IncludeTypes: []interface{}{&momento.GetRequest{}, &momento.SetRequest{}},
+	//       IncludeTypes: []interface{}{momento.GetRequest{}, momento.SetRequest{}},
 	//     }),
 	//   })
 	WithMiddleware(middleware []middleware.Middleware) Configuration

--- a/config/middleware/in_flight_request_count_middleware.go
+++ b/config/middleware/in_flight_request_count_middleware.go
@@ -46,7 +46,7 @@ func NewInFlightRequestCountMiddlewareRequestHandler(
 	return &inFlightRequestCountMiddlewareRequestHandler{rh, countAfterAdd, remover}
 }
 
-func (rh *inFlightRequestCountMiddlewareRequestHandler) OnResponse(_ interface{}, _ error) (interface{}, error) {
+func (rh *inFlightRequestCountMiddlewareRequestHandler) OnResponse(_ interface{}) (interface{}, error) {
 	countAfterRemove := rh.remover()
 	rh.GetLogger().Info(
 		fmt.Sprintf(

--- a/config/middleware/middleware.go
+++ b/config/middleware/middleware.go
@@ -125,7 +125,7 @@ type RequestHandler interface {
 	GetLogger() logger.MomentoLogger
 	OnRequest(theRequest interface{}) (interface{}, error)
 	OnMetadata(map[string]string) map[string]string
-	OnResponse(theResponse interface{}, err error) (interface{}, error)
+	OnResponse(theResponse interface{}) (interface{}, error)
 }
 
 type HandlerProps struct {
@@ -171,19 +171,14 @@ func (rh *requestHandler) OnMetadata(map[string]string) map[string]string {
 	return nil
 }
 
-// OnResponse is called after the response is received from the backend. It is passed the response object, which can
-// be cast to the appropriate response type for further inspection. It is also passed the initial error, if any,
-// produced by the gRPC request. This gives the first request handler a chance to inspect the error and response and
-// decide whether to halt processing or continue with the next request handler. This pattern is generally only used for
-// special purpose request handling, and most request handlers should simply return any error they are passed.
+// OnResponse is called after the gRPC response is received from the backend. It is passed the response object, which
+// can be cast to the appropriate response type for further inspection.
 //
 // Returning nil for the response value leaves the response unchanged. Returning a new response object will replace the
 // current response object. The new response must be the same type as the original response object, and an error is
 // returned if this is not the case.
 //
-// Returning an error will immediately halt response processing, skipping any outstanding response handlers. A response
-// handler that is passed an error may inspect it and return nil for the error to indicate that request processing
-// should continue.
+// Returning an error will immediately halt response processing, skipping any outstanding response handlers.
 //
 //		func (rh *myRequestHandler) OnResponse(_ interface{}, err error) (interface{}, error) {
 //		  switch r := theResponse.(type) {
@@ -194,8 +189,8 @@ func (rh *requestHandler) OnMetadata(map[string]string) map[string]string {
 //		  }
 //	   return nil, err
 //		}
-func (rh *requestHandler) OnResponse(_ interface{}, err error) (interface{}, error) {
-	return nil, err
+func (rh *requestHandler) OnResponse(_ interface{}) (interface{}, error) {
+	return nil, nil
 }
 
 func NewRequestHandler(props HandlerProps) RequestHandler {

--- a/config/middleware/middleware.go
+++ b/config/middleware/middleware.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"strings"
 
 	"github.com/momentohq/client-sdk-go/config/retry"
 
@@ -80,7 +81,7 @@ func (mw *middleware) GetIncludeTypes() map[string]bool {
 // If the IncludeTypes are omitted or empty, all request types will be processed. For example, to limit processing
 // to only requests of type *momento.SetRequest and *momento.GetRequest, pass the following slice as the IncludeTypes:
 //
-//	[]interface{}{&momento.SetRequest{}, &momento.GetRequest{}}
+//	[]interface{}{momento.SetRequest{}, momento.GetRequest{}}
 //
 // Custom middleware implementations can use this constructor to create and store the base middleware:
 //
@@ -94,7 +95,12 @@ func NewMiddleware(props Props) Middleware {
 	if props.IncludeTypes != nil {
 		includeTypeMap = make(map[string]bool)
 		for _, t := range props.IncludeTypes {
-			includeTypeMap[reflect.TypeOf(t).String()] = true
+			myType := reflect.TypeOf(t).String()
+			// Let users pass in types or pointers to types. We'll normalize them to pointers.
+			if !strings.HasPrefix("*", myType) {
+				myType = "*" + myType
+			}
+			includeTypeMap[myType] = true
 		}
 	} else {
 		includeTypeMap = nil

--- a/config/middleware/middleware.go
+++ b/config/middleware/middleware.go
@@ -6,10 +6,6 @@ import (
 	"reflect"
 	"strings"
 
-	"github.com/momentohq/client-sdk-go/config/retry"
-
-	"google.golang.org/grpc"
-
 	"github.com/google/uuid"
 	"github.com/momentohq/client-sdk-go/config/logger"
 )
@@ -26,9 +22,9 @@ type Middleware interface {
 	GetIncludeTypes() map[string]bool
 }
 
-type RetryMiddleware interface {
+type InterceptorCallbackMiddleware interface {
 	Middleware
-	AddUnaryRetryInterceptor(s retry.Strategy) func(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error
+	OnInterceptorRequest(ctx context.Context, method string)
 }
 
 type Props struct {

--- a/config/middleware/middleware.go
+++ b/config/middleware/middleware.go
@@ -171,23 +171,22 @@ func (rh *requestHandler) OnMetadata(map[string]string) map[string]string {
 	return nil
 }
 
-// OnResponse is called after the gRPC response is received from the backend. It is passed the response object, which
-// can be cast to the appropriate response type for further inspection.
+// OnResponse is called after the gRPC response is received from the backend and converted into a Momento response type
+// (e.g., *responses.GetHit). It is supplied the response object as an interface, which can be type-asserted to the
+// appropriate response type.
 //
 // Returning nil for the response value leaves the response unchanged. Returning a new response object will replace the
-// current response object. The new response must be the same type as the original response object, and an error is
-// returned if this is not the case.
+// current response object. Returning an error will immediately halt response processing, skipping any outstanding
+// response handlers.
 //
-// Returning an error will immediately halt response processing, skipping any outstanding response handlers.
-//
-//		func (rh *myRequestHandler) OnResponse(_ interface{}, err error) (interface{}, error) {
+//		func (rh *myRequestHandler) OnResponse(_ interface{}) (interface{}, error) {
 //		  switch r := theResponse.(type) {
 //		  case *responses.ListPushFrontSuccess:
 //		    fmt.Printf("pushed to front of list whose length is now %d\n", r.ListLength())
 //		  case *responses.ListPushBackSuccess:
 //		    fmt.Printf("pushed to back of list whose length is now %d\n", r.ListLength())
 //		  }
-//	   return nil, err
+//	      return nil, nil
 //		}
 func (rh *requestHandler) OnResponse(_ interface{}) (interface{}, error) {
 	return nil, nil

--- a/internal/interceptor/retry_interceptor.go
+++ b/internal/interceptor/retry_interceptor.go
@@ -11,18 +11,14 @@ import (
 )
 
 // AddUnaryRetryInterceptor returns a unary interceptor that will retry the request based on the retry strategy.
-// This interceptor is duplicated with slight modifications in the test helpers package for testing purposes.
-//
-// #########################
-//
-// IF YOU MODIFY THIS FUNCTION ALSO MODIFY THE ONE IN test_helpers/retry_middleware.go
-//
-// #########################
-func AddUnaryRetryInterceptor(s retry.Strategy) func(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
+func AddUnaryRetryInterceptor(s retry.Strategy, onRequest func(context.Context, string)) func(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
 	return func(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
 		attempt := 1
 		for {
-
+			// This is currently used for testing purposes only by the RetryMetricsMiddleware.
+			if onRequest != nil {
+				onRequest(ctx, method)
+			}
 			// Execute api call
 			lastErr := invoker(ctx, method, req, reply, cc, opts...)
 			if lastErr == nil {

--- a/momento/cache_client.go
+++ b/momento/cache_client.go
@@ -897,11 +897,11 @@ func (c defaultScsClient) DictionaryGetField(ctx context.Context, r *DictionaryG
 		DictionaryName: r.DictionaryName,
 		Fields:         []Value{r.Field},
 	}
-	_, err := c.getNextDataClient().makeRequest(ctx, newRequest)
+	response, err := c.getNextDataClient().makeRequest(ctx, newRequest)
 	if err != nil {
 		return nil, err
 	}
-	switch rtype := newRequest.response.(type) {
+	switch rtype := response.(type) {
 	case *responses.DictionaryGetFieldsMiss:
 		return &responses.DictionaryGetFieldMiss{}, nil
 	case *responses.DictionaryGetFieldsHit:

--- a/momento/cache_client.go
+++ b/momento/cache_client.go
@@ -383,146 +383,164 @@ func (c defaultScsClient) ListCaches(ctx context.Context, request *ListCachesReq
 
 func (c defaultScsClient) Increment(ctx context.Context, r *IncrementRequest) (responses.IncrementResponse, error) {
 	r.CacheName = c.getCacheNameForRequest(r)
-	if err := c.getNextDataClient().makeRequest(ctx, r); err != nil {
+	resp, err := c.getNextDataClient().makeRequest(ctx, r)
+    if err != nil {
 		return nil, err
 	}
-	return r.response, nil
+	return resp.(responses.IncrementResponse), nil
 }
 
 func (c defaultScsClient) Set(ctx context.Context, r *SetRequest) (responses.SetResponse, error) {
 	r.CacheName = c.getCacheNameForRequest(r)
-	if err := c.getNextDataClient().makeRequest(ctx, r); err != nil {
+	resp, err := c.getNextDataClient().makeRequest(ctx, r)
+    if err != nil {
 		return nil, err
 	}
-	return r.response, nil
+	return resp.(responses.SetResponse), nil
 }
 
 func (c defaultScsClient) SetIfNotExists(ctx context.Context, r *SetIfNotExistsRequest) (responses.SetIfNotExistsResponse, error) {
 	r.CacheName = c.getCacheNameForRequest(r)
-	if err := c.getNextDataClient().makeRequest(ctx, r); err != nil {
+	resp, err := c.getNextDataClient().makeRequest(ctx, r)
+	if err != nil {
 		return nil, err
 	}
-	return r.response, nil
+	return resp.(responses.SetIfNotExistsResponse), nil
 }
 
 func (c defaultScsClient) SetIfAbsent(ctx context.Context, r *SetIfAbsentRequest) (responses.SetIfAbsentResponse, error) {
 	r.CacheName = c.getCacheNameForRequest(r)
-	if err := c.getNextDataClient().makeRequest(ctx, r); err != nil {
+	resp, err := c.getNextDataClient().makeRequest(ctx, r)
+	if err != nil {
 		return nil, err
 	}
-	return r.response, nil
+	return resp.(responses.SetIfAbsentResponse), nil
 }
 
 func (c defaultScsClient) SetIfPresent(ctx context.Context, r *SetIfPresentRequest) (responses.SetIfPresentResponse, error) {
 	r.CacheName = c.getCacheNameForRequest(r)
-	if err := c.getNextDataClient().makeRequest(ctx, r); err != nil {
+	resp, err := c.getNextDataClient().makeRequest(ctx, r)
+	if err != nil {
 		return nil, err
 	}
-	return r.response, nil
+	return resp.(responses.SetIfPresentResponse), nil
 }
 
 func (c defaultScsClient) SetIfPresentAndNotEqual(ctx context.Context, r *SetIfPresentAndNotEqualRequest) (responses.SetIfPresentAndNotEqualResponse, error) {
 	r.CacheName = c.getCacheNameForRequest(r)
-	if err := c.getNextDataClient().makeRequest(ctx, r); err != nil {
+	resp, err := c.getNextDataClient().makeRequest(ctx, r)
+	if err != nil {
 		return nil, err
 	}
-	return r.response, nil
+	return resp.(responses.SetIfPresentAndNotEqualResponse), nil
 }
 
 func (c defaultScsClient) SetIfEqual(ctx context.Context, r *SetIfEqualRequest) (responses.SetIfEqualResponse, error) {
 	r.CacheName = c.getCacheNameForRequest(r)
-	if err := c.getNextDataClient().makeRequest(ctx, r); err != nil {
+	resp, err := c.getNextDataClient().makeRequest(ctx, r)
+	if err != nil {
 		return nil, err
 	}
-	return r.response, nil
+	return resp.(responses.SetIfEqualResponse), nil
 }
 
 func (c defaultScsClient) SetIfAbsentOrEqual(ctx context.Context, r *SetIfAbsentOrEqualRequest) (responses.SetIfAbsentOrEqualResponse, error) {
 	r.CacheName = c.getCacheNameForRequest(r)
-	if err := c.getNextDataClient().makeRequest(ctx, r); err != nil {
+	resp, err := c.getNextDataClient().makeRequest(ctx, r)
+	if err != nil {
 		return nil, err
 	}
-	return r.response, nil
+	return resp.(responses.SetIfAbsentOrEqualResponse), nil
 }
 
 func (c defaultScsClient) SetIfNotEqual(ctx context.Context, r *SetIfNotEqualRequest) (responses.SetIfNotEqualResponse, error) {
 	r.CacheName = c.getCacheNameForRequest(r)
-	if err := c.getNextDataClient().makeRequest(ctx, r); err != nil {
+	resp, err := c.getNextDataClient().makeRequest(ctx, r)
+	if err != nil {
 		return nil, err
 	}
-	return r.response, nil
+	return resp.(responses.SetIfNotEqualResponse), nil
 }
 
 func (c defaultScsClient) SetBatch(ctx context.Context, r *SetBatchRequest) (responses.SetBatchResponse, error) {
 	r.CacheName = c.getCacheNameForRequest(r)
-	if err := c.getNextDataClient().makeRequest(ctx, r); err != nil {
+	resp, err := c.getNextDataClient().makeRequest(ctx, r)
+	if err != nil {
 		return nil, err
 	}
-	return r.response, nil
+	return resp.(responses.SetBatchResponse), nil
 }
 
 func (c defaultScsClient) Get(ctx context.Context, r *GetRequest) (responses.GetResponse, error) {
 	r.CacheName = c.getCacheNameForRequest(r)
-	if err := c.getNextDataClient().makeRequest(ctx, r); err != nil {
+	resp, err := c.getNextDataClient().makeRequest(ctx, r)
+	if err != nil {
 		return nil, err
 	}
-	return r.response, nil
+	return resp.(responses.GetResponse), nil
 }
 
 func (c defaultScsClient) GetBatch(ctx context.Context, r *GetBatchRequest) (responses.GetBatchResponse, error) {
 	r.CacheName = c.getCacheNameForRequest(r)
-	if err := c.getNextDataClient().makeRequest(ctx, r); err != nil {
+	resp, err := c.getNextDataClient().makeRequest(ctx, r)
+	if err != nil {
 		return nil, err
 	}
-	return r.response, nil
+	return resp.(responses.GetBatchResponse), nil
 }
 
 func (c defaultScsClient) Delete(ctx context.Context, r *DeleteRequest) (responses.DeleteResponse, error) {
 	r.CacheName = c.getCacheNameForRequest(r)
-	if err := c.getNextDataClient().makeRequest(ctx, r); err != nil {
+	resp, err := c.getNextDataClient().makeRequest(ctx, r)
+	if err != nil {
 		return nil, err
 	}
-	return r.response, nil
+	return resp.(responses.DeleteResponse), nil
 }
 
 func (c defaultScsClient) KeysExist(ctx context.Context, r *KeysExistRequest) (responses.KeysExistResponse, error) {
 	r.CacheName = c.getCacheNameForRequest(r)
-	if err := c.getNextDataClient().makeRequest(ctx, r); err != nil {
+	resp, err := c.getNextDataClient().makeRequest(ctx, r)
+	if err != nil {
 		return nil, err
 	}
-	return r.response, nil
+	return resp.(responses.KeysExistResponse), nil
 }
 
 func (c defaultScsClient) ItemGetType(ctx context.Context, r *ItemGetTypeRequest) (responses.ItemGetTypeResponse, error) {
 	r.CacheName = c.getCacheNameForRequest(r)
-	if err := c.getNextDataClient().makeRequest(ctx, r); err != nil {
+	resp, err := c.getNextDataClient().makeRequest(ctx, r)
+	if err != nil {
 		return nil, err
 	}
-	return r.response, nil
+	return resp.(responses.ItemGetTypeResponse), nil
 }
 
 func (c defaultScsClient) ItemGetTtl(ctx context.Context, r *ItemGetTtlRequest) (responses.ItemGetTtlResponse, error) {
 	r.CacheName = c.getCacheNameForRequest(r)
-	if err := c.getNextDataClient().makeRequest(ctx, r); err != nil {
+	resp, err := c.getNextDataClient().makeRequest(ctx, r)
+	if err != nil {
 		return nil, err
 	}
-	return r.response, nil
+	return resp.(responses.ItemGetTtlResponse), nil
 }
 
 func (c defaultScsClient) SortedSetFetchByRank(ctx context.Context, r *SortedSetFetchByRankRequest) (responses.SortedSetFetchResponse, error) {
 	r.CacheName = c.getCacheNameForRequest(r)
-	if err := c.getNextDataClient().makeRequest(ctx, r); err != nil {
+	resp, err := c.getNextDataClient().makeRequest(ctx, r)
+	if err != nil {
 		return nil, err
 	}
-	return r.response, nil
+	return resp.(responses.SortedSetFetchResponse), nil
 }
 
 func (c defaultScsClient) SortedSetFetchByScore(ctx context.Context, r *SortedSetFetchByScoreRequest) (responses.SortedSetFetchResponse, error) {
 	r.CacheName = c.getCacheNameForRequest(r)
-	if err := c.getNextDataClient().makeRequest(ctx, r); err != nil {
+	resp, err := c.getNextDataClient().makeRequest(ctx, r)
+	if err != nil {
 		return nil, err
 	}
-	return r.response, nil
+	return resp.(responses.SortedSetFetchResponse), nil
 }
 
 func (c defaultScsClient) SortedSetPutElement(ctx context.Context, r *SortedSetPutElementRequest) (responses.SortedSetPutElementResponse, error) {
@@ -540,7 +558,8 @@ func (c defaultScsClient) SortedSetPutElement(ctx context.Context, r *SortedSetP
 		Elements:  []SortedSetElement{{Value: r.Value, Score: r.Score}},
 		Ttl:       r.Ttl,
 	}
-	if err := c.getNextDataClient().makeRequest(ctx, newRequest); err != nil {
+	_, err := c.getNextDataClient().makeRequest(ctx, newRequest)
+	if err != nil {
 		return nil, err
 	}
 
@@ -549,18 +568,20 @@ func (c defaultScsClient) SortedSetPutElement(ctx context.Context, r *SortedSetP
 
 func (c defaultScsClient) SortedSetPutElements(ctx context.Context, r *SortedSetPutElementsRequest) (responses.SortedSetPutElementsResponse, error) {
 	r.CacheName = c.getCacheNameForRequest(r)
-	if err := c.getNextDataClient().makeRequest(ctx, r); err != nil {
+	resp, err := c.getNextDataClient().makeRequest(ctx, r)
+	if err != nil {
 		return nil, err
 	}
-	return r.response, nil
+	return resp.(responses.SortedSetPutElementsResponse), nil
 }
 
 func (c defaultScsClient) SortedSetGetScores(ctx context.Context, r *SortedSetGetScoresRequest) (responses.SortedSetGetScoresResponse, error) {
 	r.CacheName = c.getCacheNameForRequest(r)
-	if err := c.getNextDataClient().makeRequest(ctx, r); err != nil {
+	resp, err := c.getNextDataClient().makeRequest(ctx, r)
+	if err != nil {
 		return nil, err
 	}
-	return r.response, nil
+	return resp.(responses.SortedSetGetScoresResponse), nil
 }
 
 func (c defaultScsClient) SortedSetGetScore(ctx context.Context, r *SortedSetGetScoreRequest) (responses.SortedSetGetScoreResponse, error) {
@@ -570,10 +591,11 @@ func (c defaultScsClient) SortedSetGetScore(ctx context.Context, r *SortedSetGet
 		SetName:   r.SetName,
 		Values:    []Value{r.Value},
 	}
-	if err := c.getNextDataClient().makeRequest(ctx, newRequest); err != nil {
+	resp, err := c.getNextDataClient().makeRequest(ctx, newRequest)
+	if err != nil {
 		return nil, err
 	}
-	switch result := newRequest.response.(type) {
+	switch result := resp.(type) {
 	case *responses.SortedSetGetScoresHit:
 		return result.Responses()[0], nil
 	case *responses.SortedSetGetScoresMiss:
@@ -597,7 +619,8 @@ func (c defaultScsClient) SortedSetRemoveElement(ctx context.Context, r *SortedS
 		SetName:   r.SetName,
 		Values:    []Value{r.Value},
 	}
-	if err := c.getNextDataClient().makeRequest(ctx, newRequest); err != nil {
+	_, err := c.getNextDataClient().makeRequest(ctx, newRequest)
+	if err != nil {
 		return nil, err
 	}
 	return &responses.SortedSetRemoveElementSuccess{}, nil
@@ -605,42 +628,47 @@ func (c defaultScsClient) SortedSetRemoveElement(ctx context.Context, r *SortedS
 
 func (c defaultScsClient) SortedSetRemoveElements(ctx context.Context, r *SortedSetRemoveElementsRequest) (responses.SortedSetRemoveElementsResponse, error) {
 	r.CacheName = c.getCacheNameForRequest(r)
-	if err := c.getNextDataClient().makeRequest(ctx, r); err != nil {
+	resp, err := c.getNextDataClient().makeRequest(ctx, r)
+	if err != nil {
 		return nil, err
 	}
-	return r.response, nil
+	return resp.(responses.SortedSetRemoveElementsResponse), nil
 }
 
 func (c defaultScsClient) SortedSetGetRank(ctx context.Context, r *SortedSetGetRankRequest) (responses.SortedSetGetRankResponse, error) {
 	r.CacheName = c.getCacheNameForRequest(r)
-	if err := c.getNextDataClient().makeRequest(ctx, r); err != nil {
+	resp, err := c.getNextDataClient().makeRequest(ctx, r)
+	if err != nil {
 		return nil, err
 	}
-	return r.response, nil
+	return resp.(responses.SortedSetGetRankResponse), nil
 }
 
 func (c defaultScsClient) SortedSetLength(ctx context.Context, r *SortedSetLengthRequest) (responses.SortedSetLengthResponse, error) {
 	r.CacheName = c.getCacheNameForRequest(r)
-	if err := c.getNextDataClient().makeRequest(ctx, r); err != nil {
+	resp, err := c.getNextDataClient().makeRequest(ctx, r)
+	if err != nil {
 		return nil, err
 	}
-	return r.response, nil
+	return resp.(responses.SortedSetLengthResponse), nil
 }
 
 func (c defaultScsClient) SortedSetLengthByScore(ctx context.Context, r *SortedSetLengthByScoreRequest) (responses.SortedSetLengthByScoreResponse, error) {
 	r.CacheName = c.getCacheNameForRequest(r)
-	if err := c.getNextDataClient().makeRequest(ctx, r); err != nil {
+	resp, err := c.getNextDataClient().makeRequest(ctx, r)
+	if err != nil {
 		return nil, err
 	}
-	return r.response, nil
+	return resp.(responses.SortedSetLengthByScoreResponse), nil
 }
 
 func (c defaultScsClient) SortedSetIncrementScore(ctx context.Context, r *SortedSetIncrementScoreRequest) (responses.SortedSetIncrementScoreResponse, error) {
 	r.CacheName = c.getCacheNameForRequest(r)
-	if err := c.getNextDataClient().makeRequest(ctx, r); err != nil {
+	resp, err := c.getNextDataClient().makeRequest(ctx, r)
+	if err != nil {
 		return nil, err
 	}
-	return r.response, nil
+	return resp.(responses.SortedSetIncrementScoreResponse), nil
 }
 
 func (c defaultScsClient) SetAddElement(ctx context.Context, r *SetAddElementRequest) (responses.SetAddElementResponse, error) {
@@ -651,7 +679,8 @@ func (c defaultScsClient) SetAddElement(ctx context.Context, r *SetAddElementReq
 		Elements:  []Value{r.Element},
 		Ttl:       r.Ttl,
 	}
-	if err := c.getNextDataClient().makeRequest(ctx, newRequest); err != nil {
+	_, err := c.getNextDataClient().makeRequest(ctx, newRequest)
+	if err != nil {
 		return nil, err
 	}
 	return &responses.SetAddElementSuccess{}, nil
@@ -659,26 +688,29 @@ func (c defaultScsClient) SetAddElement(ctx context.Context, r *SetAddElementReq
 
 func (c defaultScsClient) SetAddElements(ctx context.Context, r *SetAddElementsRequest) (responses.SetAddElementsResponse, error) {
 	r.CacheName = c.getCacheNameForRequest(r)
-	if err := c.getNextDataClient().makeRequest(ctx, r); err != nil {
+	resp, err := c.getNextDataClient().makeRequest(ctx, r)
+	if err != nil {
 		return nil, err
 	}
-	return r.response, nil
+	return resp.(responses.SetAddElementsResponse), nil
 }
 
 func (c defaultScsClient) SetFetch(ctx context.Context, r *SetFetchRequest) (responses.SetFetchResponse, error) {
 	r.CacheName = c.getCacheNameForRequest(r)
-	if err := c.getNextDataClient().makeRequest(ctx, r); err != nil {
+	resp, err := c.getNextDataClient().makeRequest(ctx, r)
+	if err != nil {
 		return nil, err
 	}
-	return r.response, nil
+	return resp.(responses.SetFetchResponse), nil
 }
 
 func (c defaultScsClient) SetLength(ctx context.Context, r *SetLengthRequest) (responses.SetLengthResponse, error) {
 	r.CacheName = c.getCacheNameForRequest(r)
-	if err := c.getNextDataClient().makeRequest(ctx, r); err != nil {
+	resp, err := c.getNextDataClient().makeRequest(ctx, r)
+	if err != nil {
 		return nil, err
 	}
-	return r.response, nil
+	return resp.(responses.SetLengthResponse), nil
 }
 
 func (c defaultScsClient) SetRemoveElement(ctx context.Context, r *SetRemoveElementRequest) (responses.SetRemoveElementResponse, error) {
@@ -688,7 +720,8 @@ func (c defaultScsClient) SetRemoveElement(ctx context.Context, r *SetRemoveElem
 		SetName:   r.SetName,
 		Elements:  []Value{r.Element},
 	}
-	if err := c.getNextDataClient().makeRequest(ctx, newRequest); err != nil {
+	_, err := c.getNextDataClient().makeRequest(ctx, newRequest)
+	if err != nil {
 		return nil, err
 	}
 	return &responses.SetRemoveElementSuccess{}, nil
@@ -696,98 +729,110 @@ func (c defaultScsClient) SetRemoveElement(ctx context.Context, r *SetRemoveElem
 
 func (c defaultScsClient) SetRemoveElements(ctx context.Context, r *SetRemoveElementsRequest) (responses.SetRemoveElementsResponse, error) {
 	r.CacheName = c.getCacheNameForRequest(r)
-	if err := c.getNextDataClient().makeRequest(ctx, r); err != nil {
+	resp, err := c.getNextDataClient().makeRequest(ctx, r)
+	if err != nil {
 		return nil, err
 	}
-	return r.response, nil
+	return resp.(responses.SetRemoveElementsResponse), nil
 }
 
 func (c defaultScsClient) SetContainsElements(ctx context.Context, r *SetContainsElementsRequest) (responses.SetContainsElementsResponse, error) {
 	r.CacheName = c.getCacheNameForRequest(r)
-	if err := c.getNextDataClient().makeRequest(ctx, r); err != nil {
+	resp, err := c.getNextDataClient().makeRequest(ctx, r)
+	if err != nil {
 		return nil, err
 	}
-	return r.response, nil
+	return resp.(responses.SetContainsElementsResponse), nil
 }
 
 func (c defaultScsClient) SetPop(ctx context.Context, r *SetPopRequest) (responses.SetPopResponse, error) {
 	r.CacheName = c.getCacheNameForRequest(r)
-	if err := c.getNextDataClient().makeRequest(ctx, r); err != nil {
+	resp, err := c.getNextDataClient().makeRequest(ctx, r)
+	if err != nil {
 		return nil, err
 	}
-	return r.response, nil
+	return resp.(responses.SetPopResponse), nil
 }
 
 func (c defaultScsClient) ListPushFront(ctx context.Context, r *ListPushFrontRequest) (responses.ListPushFrontResponse, error) {
 	r.CacheName = c.getCacheNameForRequest(r)
-	if err := c.getNextDataClient().makeRequest(ctx, r); err != nil {
+	resp, err := c.getNextDataClient().makeRequest(ctx, r)
+	if err != nil {
 		return nil, err
 	}
-	return r.response, nil
+	return resp.(responses.ListPushFrontResponse), nil
 }
 
 func (c defaultScsClient) ListPushBack(ctx context.Context, r *ListPushBackRequest) (responses.ListPushBackResponse, error) {
 	r.CacheName = c.getCacheNameForRequest(r)
-	if err := c.getNextDataClient().makeRequest(ctx, r); err != nil {
+	resp, err := c.getNextDataClient().makeRequest(ctx, r)
+	if err != nil {
 		return nil, err
 	}
-	return r.response, nil
+	return resp.(responses.ListPushBackResponse), nil
 }
 
 func (c defaultScsClient) ListPopFront(ctx context.Context, r *ListPopFrontRequest) (responses.ListPopFrontResponse, error) {
 	r.CacheName = c.getCacheNameForRequest(r)
-	if err := c.getNextDataClient().makeRequest(ctx, r); err != nil {
+	resp, err := c.getNextDataClient().makeRequest(ctx, r)
+	if err != nil {
 		return nil, err
 	}
-	return r.response, nil
+	return resp.(responses.ListPopFrontResponse), nil
 }
 
 func (c defaultScsClient) ListPopBack(ctx context.Context, r *ListPopBackRequest) (responses.ListPopBackResponse, error) {
 	r.CacheName = c.getCacheNameForRequest(r)
-	if err := c.getNextDataClient().makeRequest(ctx, r); err != nil {
+	resp, err := c.getNextDataClient().makeRequest(ctx, r)
+	if err != nil {
 		return nil, err
 	}
-	return r.response, nil
+	return resp.(responses.ListPopBackResponse), nil
 }
 
 func (c defaultScsClient) ListConcatenateFront(ctx context.Context, r *ListConcatenateFrontRequest) (responses.ListConcatenateFrontResponse, error) {
 	r.CacheName = c.getCacheNameForRequest(r)
-	if err := c.getNextDataClient().makeRequest(ctx, r); err != nil {
+	resp, err := c.getNextDataClient().makeRequest(ctx, r)
+	if err != nil {
 		return nil, err
 	}
-	return r.response, nil
+	return resp.(responses.ListConcatenateFrontResponse), nil
 }
 
 func (c defaultScsClient) ListConcatenateBack(ctx context.Context, r *ListConcatenateBackRequest) (responses.ListConcatenateBackResponse, error) {
 	r.CacheName = c.getCacheNameForRequest(r)
-	if err := c.getNextDataClient().makeRequest(ctx, r); err != nil {
+	resp, err := c.getNextDataClient().makeRequest(ctx, r)
+	if err != nil {
 		return nil, err
 	}
-	return r.response, nil
+	return resp.(responses.ListConcatenateBackResponse), nil
 }
 
 func (c defaultScsClient) ListFetch(ctx context.Context, r *ListFetchRequest) (responses.ListFetchResponse, error) {
 	r.CacheName = c.getCacheNameForRequest(r)
-	if err := c.getNextDataClient().makeRequest(ctx, r); err != nil {
+	resp, err := c.getNextDataClient().makeRequest(ctx, r)
+	if err != nil {
 		return nil, err
 	}
-	return r.response, nil
+	return resp.(responses.ListFetchResponse), nil
 }
 
 func (c defaultScsClient) ListLength(ctx context.Context, r *ListLengthRequest) (responses.ListLengthResponse, error) {
 	r.CacheName = c.getCacheNameForRequest(r)
-	if err := c.getNextDataClient().makeRequest(ctx, r); err != nil {
+	resp, err := c.getNextDataClient().makeRequest(ctx, r)
+	if err != nil {
 		return nil, err
 	}
-	return r.response, nil
+	return resp.(responses.ListLengthResponse), nil
 }
 
 func (c defaultScsClient) ListRemoveValue(ctx context.Context, r *ListRemoveValueRequest) (responses.ListRemoveValueResponse, error) {
 	r.CacheName = c.getCacheNameForRequest(r)
-	if err := c.getNextDataClient().makeRequest(ctx, r); err != nil {
+	resp, err := c.getNextDataClient().makeRequest(ctx, r)
+	if err != nil {
 		return nil, err
 	}
-	return r.response, nil
+	return resp.(responses.ListRemoveValueResponse), nil
 }
 
 func (c defaultScsClient) DictionarySetField(ctx context.Context, r *DictionarySetFieldRequest) (responses.DictionarySetFieldResponse, error) {
@@ -811,7 +856,8 @@ func (c defaultScsClient) DictionarySetField(ctx context.Context, r *DictionaryS
 		Elements:       elements,
 		Ttl:            r.Ttl,
 	}
-	if err := c.getNextDataClient().makeRequest(ctx, newRequest); err != nil {
+	_, err := c.getNextDataClient().makeRequest(ctx, newRequest)
+	if err != nil {
 		return nil, err
 	}
 	return &responses.DictionarySetFieldSuccess{}, nil
@@ -819,26 +865,29 @@ func (c defaultScsClient) DictionarySetField(ctx context.Context, r *DictionaryS
 
 func (c defaultScsClient) DictionarySetFields(ctx context.Context, r *DictionarySetFieldsRequest) (responses.DictionarySetFieldsResponse, error) {
 	r.CacheName = c.getCacheNameForRequest(r)
-	if err := c.getNextDataClient().makeRequest(ctx, r); err != nil {
+	resp, err := c.getNextDataClient().makeRequest(ctx, r)
+	if err != nil {
 		return nil, err
 	}
-	return r.response, nil
+	return resp.(responses.DictionarySetFieldsResponse), nil
 }
 
 func (c defaultScsClient) DictionaryFetch(ctx context.Context, r *DictionaryFetchRequest) (responses.DictionaryFetchResponse, error) {
 	r.CacheName = c.getCacheNameForRequest(r)
-	if err := c.getNextDataClient().makeRequest(ctx, r); err != nil {
+	resp, err := c.getNextDataClient().makeRequest(ctx, r)
+	if err != nil {
 		return nil, err
 	}
-	return r.response, nil
+	return resp.(responses.DictionaryFetchResponse), nil
 }
 
 func (c defaultScsClient) DictionaryLength(ctx context.Context, r *DictionaryLengthRequest) (responses.DictionaryLengthResponse, error) {
 	r.CacheName = c.getCacheNameForRequest(r)
-	if err := c.getNextDataClient().makeRequest(ctx, r); err != nil {
+	resp, err := c.getNextDataClient().makeRequest(ctx, r)
+	if err != nil {
 		return nil, err
 	}
-	return r.response, nil
+	return resp.(responses.DictionaryLengthResponse), nil
 }
 
 func (c defaultScsClient) DictionaryGetField(ctx context.Context, r *DictionaryGetFieldRequest) (responses.DictionaryGetFieldResponse, error) {
@@ -848,7 +897,8 @@ func (c defaultScsClient) DictionaryGetField(ctx context.Context, r *DictionaryG
 		DictionaryName: r.DictionaryName,
 		Fields:         []Value{r.Field},
 	}
-	if err := c.getNextDataClient().makeRequest(ctx, newRequest); err != nil {
+	_, err := c.getNextDataClient().makeRequest(ctx, newRequest)
+	if err != nil {
 		return nil, err
 	}
 	switch rtype := newRequest.response.(type) {
@@ -870,18 +920,20 @@ func (c defaultScsClient) DictionaryGetField(ctx context.Context, r *DictionaryG
 
 func (c defaultScsClient) DictionaryGetFields(ctx context.Context, r *DictionaryGetFieldsRequest) (responses.DictionaryGetFieldsResponse, error) {
 	r.CacheName = c.getCacheNameForRequest(r)
-	if err := c.getNextDataClient().makeRequest(ctx, r); err != nil {
+	resp, err := c.getNextDataClient().makeRequest(ctx, r)
+	if err != nil {
 		return nil, err
 	}
-	return r.response, nil
+	return resp.(responses.DictionaryGetFieldsResponse), nil
 }
 
 func (c defaultScsClient) DictionaryIncrement(ctx context.Context, r *DictionaryIncrementRequest) (responses.DictionaryIncrementResponse, error) {
 	r.CacheName = c.getCacheNameForRequest(r)
-	if err := c.getNextDataClient().makeRequest(ctx, r); err != nil {
+	resp, err := c.getNextDataClient().makeRequest(ctx, r)
+	if err != nil {
 		return nil, err
 	}
-	return r.response, nil
+	return resp.(responses.DictionaryIncrementResponse), nil
 }
 
 func (c defaultScsClient) DictionaryRemoveField(ctx context.Context, r *DictionaryRemoveFieldRequest) (responses.DictionaryRemoveFieldResponse, error) {
@@ -898,7 +950,8 @@ func (c defaultScsClient) DictionaryRemoveField(ctx context.Context, r *Dictiona
 		DictionaryName: r.DictionaryName,
 		Fields:         []Value{r.Field},
 	}
-	if err := c.getNextDataClient().makeRequest(ctx, newRequest); err != nil {
+	_, err := c.getNextDataClient().makeRequest(ctx, newRequest)
+	if err != nil {
 		return nil, err
 	}
 	return &responses.DictionaryRemoveFieldSuccess{}, nil
@@ -906,34 +959,38 @@ func (c defaultScsClient) DictionaryRemoveField(ctx context.Context, r *Dictiona
 
 func (c defaultScsClient) DictionaryRemoveFields(ctx context.Context, r *DictionaryRemoveFieldsRequest) (responses.DictionaryRemoveFieldsResponse, error) {
 	r.CacheName = c.getCacheNameForRequest(r)
-	if err := c.getNextDataClient().makeRequest(ctx, r); err != nil {
+	resp, err := c.getNextDataClient().makeRequest(ctx, r)
+	if err != nil {
 		return nil, err
 	}
-	return r.response, nil
+	return resp.(responses.DictionaryRemoveFieldsResponse), nil
 }
 
 func (c defaultScsClient) UpdateTtl(ctx context.Context, r *UpdateTtlRequest) (responses.UpdateTtlResponse, error) {
 	r.CacheName = c.getCacheNameForRequest(r)
-	if err := c.getNextDataClient().makeRequest(ctx, r); err != nil {
+	resp, err := c.getNextDataClient().makeRequest(ctx, r)
+	if err != nil {
 		return nil, err
 	}
-	return r.response, nil
+	return resp.(responses.UpdateTtlResponse), nil
 }
 
 func (c defaultScsClient) IncreaseTtl(ctx context.Context, r *IncreaseTtlRequest) (responses.IncreaseTtlResponse, error) {
 	r.CacheName = c.getCacheNameForRequest(r)
-	if err := c.getNextDataClient().makeRequest(ctx, r); err != nil {
+	resp, err := c.getNextDataClient().makeRequest(ctx, r)
+	if err != nil {
 		return nil, err
 	}
-	return r.response, nil
+	return resp.(responses.IncreaseTtlResponse), nil
 }
 
 func (c defaultScsClient) DecreaseTtl(ctx context.Context, r *DecreaseTtlRequest) (responses.DecreaseTtlResponse, error) {
 	r.CacheName = c.getCacheNameForRequest(r)
-	if err := c.getNextDataClient().makeRequest(ctx, r); err != nil {
+	resp, err := c.getNextDataClient().makeRequest(ctx, r)
+	if err != nil {
 		return nil, err
 	}
-	return r.response, nil
+	return resp.(responses.DecreaseTtlResponse), nil
 }
 
 func (c defaultScsClient) Ping(ctx context.Context) (responses.PingResponse, error) {

--- a/momento/cache_client.go
+++ b/momento/cache_client.go
@@ -384,7 +384,7 @@ func (c defaultScsClient) ListCaches(ctx context.Context, request *ListCachesReq
 func (c defaultScsClient) Increment(ctx context.Context, r *IncrementRequest) (responses.IncrementResponse, error) {
 	r.CacheName = c.getCacheNameForRequest(r)
 	resp, err := c.getNextDataClient().makeRequest(ctx, r)
-    if err != nil {
+	if err != nil {
 		return nil, err
 	}
 	return resp.(responses.IncrementResponse), nil
@@ -393,7 +393,7 @@ func (c defaultScsClient) Increment(ctx context.Context, r *IncrementRequest) (r
 func (c defaultScsClient) Set(ctx context.Context, r *SetRequest) (responses.SetResponse, error) {
 	r.CacheName = c.getCacheNameForRequest(r)
 	resp, err := c.getNextDataClient().makeRequest(ctx, r)
-    if err != nil {
+	if err != nil {
 		return nil, err
 	}
 	return resp.(responses.SetResponse), nil

--- a/momento/decrease_ttl.go
+++ b/momento/decrease_ttl.go
@@ -17,7 +17,6 @@ type DecreaseTtlRequest struct {
 	Key Key
 	// Time to live that you want to decrease to.
 	Ttl time.Duration
-
 }
 
 func (r *DecreaseTtlRequest) cacheName() string { return r.CacheName }

--- a/momento/decrease_ttl.go
+++ b/momento/decrease_ttl.go
@@ -18,7 +18,6 @@ type DecreaseTtlRequest struct {
 	// Time to live that you want to decrease to.
 	Ttl time.Duration
 
-	response responses.DecreaseTtlResponse
 }
 
 func (r *DecreaseTtlRequest) cacheName() string { return r.CacheName }
@@ -57,7 +56,7 @@ func (r *DecreaseTtlRequest) makeGrpcRequest(grpcRequest interface{}, requestMet
 	return resp, nil, nil
 }
 
-func (r *DecreaseTtlRequest) interpretGrpcResponse(theResponse interface{}) error {
+func (r *DecreaseTtlRequest) interpretGrpcResponse(theResponse interface{}) (interface{}, error) {
 	myResp := theResponse.(*pb.XUpdateTtlResponse)
 
 	var resp responses.DecreaseTtlResponse
@@ -69,18 +68,7 @@ func (r *DecreaseTtlRequest) interpretGrpcResponse(theResponse interface{}) erro
 	case *pb.XUpdateTtlResponse_Set:
 		resp = &responses.DecreaseTtlSet{}
 	default:
-		return errUnexpectedGrpcResponse(r, myResp)
+		return nil, errUnexpectedGrpcResponse(r, myResp)
 	}
-
-	r.response = resp
-
-	return nil
-}
-
-func (r *DecreaseTtlRequest) validateResponseType(resp grpcResponse) error {
-	_, ok := resp.(*pb.XUpdateTtlResponse)
-	if !ok {
-		return errUnexpectedGrpcResponse(nil, resp)
-	}
-	return nil
+	return resp, nil
 }

--- a/momento/delete.go
+++ b/momento/delete.go
@@ -16,7 +16,6 @@ type DeleteRequest struct {
 	// string or byte key to be used to delete the item.
 	Key Key
 
-	response responses.DeleteResponse
 }
 
 func (r *DeleteRequest) cacheName() string { return r.CacheName }
@@ -49,15 +48,6 @@ func (r *DeleteRequest) makeGrpcRequest(grpcRequest interface{}, requestMetadata
 	return resp, nil, nil
 }
 
-func (r *DeleteRequest) interpretGrpcResponse(_ interface{}) error {
-	r.response = &responses.DeleteSuccess{}
-	return nil
-}
-
-func (r *DeleteRequest) validateResponseType(resp grpcResponse) error {
-	_, ok := resp.(*pb.XDeleteResponse)
-	if !ok {
-		return errUnexpectedGrpcResponse(nil, resp)
-	}
-	return nil
+func (r *DeleteRequest) interpretGrpcResponse(_ interface{}) (interface{}, error) {
+	return &responses.DeleteSuccess{}, nil
 }

--- a/momento/delete.go
+++ b/momento/delete.go
@@ -15,7 +15,6 @@ type DeleteRequest struct {
 	CacheName string
 	// string or byte key to be used to delete the item.
 	Key Key
-
 }
 
 func (r *DeleteRequest) cacheName() string { return r.CacheName }

--- a/momento/dictionary_fetch.go
+++ b/momento/dictionary_fetch.go
@@ -13,7 +13,6 @@ import (
 type DictionaryFetchRequest struct {
 	CacheName      string
 	DictionaryName string
-
 }
 
 func (r *DictionaryFetchRequest) cacheName() string { return r.CacheName }

--- a/momento/dictionary_get_fields.go
+++ b/momento/dictionary_get_fields.go
@@ -55,11 +55,11 @@ func (r *DictionaryGetFieldsRequest) makeGrpcRequest(grpcRequest interface{}, re
 	return resp, nil, nil
 }
 
-func (r *DictionaryGetFieldsRequest) interpretGrpcResponse(resp interface{}) error {
+func (r *DictionaryGetFieldsRequest) interpretGrpcResponse(resp interface{}) (interface{}, error) {
 	r.grpcResponse = resp.(*pb.XDictionaryGetResponse)
 	switch rtype := r.grpcResponse.Dictionary.(type) {
 	case *pb.XDictionaryGetResponse_Missing:
-		r.response = &responses.DictionaryGetFieldsMiss{}
+		return &responses.DictionaryGetFieldsMiss{}, nil
 	case *pb.XDictionaryGetResponse_Found:
 		var responsesToReturn []responses.DictionaryGetFieldResponse
 		var fields [][]byte
@@ -74,17 +74,8 @@ func (r *DictionaryGetFieldsRequest) interpretGrpcResponse(resp interface{}) err
 			}
 			fields = append(fields, field)
 		}
-		r.response = responses.NewDictionaryGetFieldsHit(fields, rtype.Found.Items, responsesToReturn)
+		return responses.NewDictionaryGetFieldsHit(fields, rtype.Found.Items, responsesToReturn), nil
 	default:
-		return errUnexpectedGrpcResponse(r, r.grpcResponse)
+		return nil, errUnexpectedGrpcResponse(r, r.grpcResponse)
 	}
-	return nil
-}
-
-func (r *DictionaryGetFieldsRequest) validateResponseType(resp grpcResponse) error {
-	_, ok := resp.(*pb.XDictionaryGetResponse)
-	if !ok {
-		return errUnexpectedGrpcResponse(nil, resp)
-	}
-	return nil
 }

--- a/momento/dictionary_get_fields.go
+++ b/momento/dictionary_get_fields.go
@@ -16,7 +16,6 @@ type DictionaryGetFieldsRequest struct {
 	Fields         []Value
 
 	grpcResponse *pb.XDictionaryGetResponse
-	response     responses.DictionaryGetFieldsResponse
 }
 
 func (r *DictionaryGetFieldsRequest) cacheName() string { return r.CacheName }

--- a/momento/dictionary_increment.go
+++ b/momento/dictionary_increment.go
@@ -21,7 +21,6 @@ type DictionaryIncrementRequest struct {
 	Amount         int64
 	Ttl            *utils.CollectionTtl
 
-	response responses.DictionaryIncrementResponse
 }
 
 func (r *DictionaryIncrementRequest) cacheName() string { return r.CacheName }
@@ -81,16 +80,7 @@ func (r *DictionaryIncrementRequest) makeGrpcRequest(grpcRequest interface{}, re
 	return resp, nil, nil
 }
 
-func (r *DictionaryIncrementRequest) interpretGrpcResponse(resp interface{}) error {
+func (r *DictionaryIncrementRequest) interpretGrpcResponse(resp interface{}) (interface{}, error) {
 	myResp := resp.(*pb.XDictionaryIncrementResponse)
-	r.response = responses.NewDictionaryIncrementSuccess(myResp.Value)
-	return nil
-}
-
-func (r *DictionaryIncrementRequest) validateResponseType(resp grpcResponse) error {
-	_, ok := resp.(*pb.XDictionaryIncrementResponse)
-	if !ok {
-		return errUnexpectedGrpcResponse(nil, resp)
-	}
-	return nil
+	return responses.NewDictionaryIncrementSuccess(myResp.Value), nil
 }

--- a/momento/dictionary_increment.go
+++ b/momento/dictionary_increment.go
@@ -20,7 +20,6 @@ type DictionaryIncrementRequest struct {
 	Field          Value
 	Amount         int64
 	Ttl            *utils.CollectionTtl
-
 }
 
 func (r *DictionaryIncrementRequest) cacheName() string { return r.CacheName }

--- a/momento/dictionary_length.go
+++ b/momento/dictionary_length.go
@@ -14,7 +14,6 @@ type DictionaryLengthRequest struct {
 	CacheName      string
 	DictionaryName string
 
-	response responses.DictionaryLengthResponse
 }
 
 func (r *DictionaryLengthRequest) cacheName() string { return r.CacheName }
@@ -43,23 +42,14 @@ func (r *DictionaryLengthRequest) makeGrpcRequest(grpcRequest interface{}, reque
 	return resp, nil, nil
 }
 
-func (r *DictionaryLengthRequest) interpretGrpcResponse(resp interface{}) error {
+func (r *DictionaryLengthRequest) interpretGrpcResponse(resp interface{}) (interface{}, error) {
 	myResp := resp.(*pb.XDictionaryLengthResponse)
 	switch rtype := myResp.Dictionary.(type) {
 	case *pb.XDictionaryLengthResponse_Found:
-		r.response = responses.NewDictionaryLengthHit(rtype.Found.Length)
+		return responses.NewDictionaryLengthHit(rtype.Found.Length), nil
 	case *pb.XDictionaryLengthResponse_Missing:
-		r.response = &responses.DictionaryLengthMiss{}
+		return &responses.DictionaryLengthMiss{}, nil
 	default:
-		return errUnexpectedGrpcResponse(r, myResp)
+		return nil, errUnexpectedGrpcResponse(r, myResp)
 	}
-	return nil
-}
-
-func (r *DictionaryLengthRequest) validateResponseType(resp grpcResponse) error {
-	_, ok := resp.(*pb.XDictionaryLengthResponse)
-	if !ok {
-		return errUnexpectedGrpcResponse(nil, resp)
-	}
-	return nil
 }

--- a/momento/dictionary_length.go
+++ b/momento/dictionary_length.go
@@ -13,7 +13,6 @@ import (
 type DictionaryLengthRequest struct {
 	CacheName      string
 	DictionaryName string
-
 }
 
 func (r *DictionaryLengthRequest) cacheName() string { return r.CacheName }

--- a/momento/dictionary_remove_fields.go
+++ b/momento/dictionary_remove_fields.go
@@ -15,7 +15,6 @@ type DictionaryRemoveFieldsRequest struct {
 	DictionaryName string
 	Fields         []Value
 
-	response responses.DictionaryRemoveFieldsResponse
 }
 
 func (r *DictionaryRemoveFieldsRequest) cacheName() string { return r.CacheName }
@@ -53,15 +52,6 @@ func (r *DictionaryRemoveFieldsRequest) makeGrpcRequest(grpcRequest interface{},
 	return resp, nil, nil
 }
 
-func (r *DictionaryRemoveFieldsRequest) interpretGrpcResponse(_ interface{}) error {
-	r.response = &responses.DictionaryRemoveFieldsSuccess{}
-	return nil
-}
-
-func (r *DictionaryRemoveFieldsRequest) validateResponseType(resp grpcResponse) error {
-	_, ok := resp.(*pb.XDictionaryDeleteResponse)
-	if !ok {
-		return errUnexpectedGrpcResponse(nil, resp)
-	}
-	return nil
+func (r *DictionaryRemoveFieldsRequest) interpretGrpcResponse(_ interface{}) (interface{}, error) {
+	return &responses.DictionaryRemoveFieldsSuccess{}, nil
 }

--- a/momento/dictionary_remove_fields.go
+++ b/momento/dictionary_remove_fields.go
@@ -14,7 +14,6 @@ type DictionaryRemoveFieldsRequest struct {
 	CacheName      string
 	DictionaryName string
 	Fields         []Value
-
 }
 
 func (r *DictionaryRemoveFieldsRequest) cacheName() string { return r.CacheName }

--- a/momento/dictionary_set_fields.go
+++ b/momento/dictionary_set_fields.go
@@ -21,7 +21,6 @@ type DictionarySetFieldsRequest struct {
 	Elements       []DictionaryElement
 	Ttl            *utils.CollectionTtl
 
-	response responses.DictionarySetFieldsResponse
 }
 
 func (r *DictionarySetFieldsRequest) cacheName() string { return r.CacheName }
@@ -80,15 +79,6 @@ func (r *DictionarySetFieldsRequest) makeGrpcRequest(grpcRequest interface{}, re
 	return resp, nil, nil
 }
 
-func (r *DictionarySetFieldsRequest) interpretGrpcResponse(_ interface{}) error {
-	r.response = &responses.DictionarySetFieldsSuccess{}
-	return nil
-}
-
-func (r *DictionarySetFieldsRequest) validateResponseType(resp grpcResponse) error {
-	_, ok := resp.(*pb.XDictionarySetResponse)
-	if !ok {
-		return errUnexpectedGrpcResponse(nil, resp)
-	}
-	return nil
+func (r *DictionarySetFieldsRequest) interpretGrpcResponse(_ interface{}) (interface{}, error) {
+	return &responses.DictionarySetFieldsSuccess{}, nil
 }

--- a/momento/dictionary_set_fields.go
+++ b/momento/dictionary_set_fields.go
@@ -20,7 +20,6 @@ type DictionarySetFieldsRequest struct {
 	DictionaryName string
 	Elements       []DictionaryElement
 	Ttl            *utils.CollectionTtl
-
 }
 
 func (r *DictionarySetFieldsRequest) cacheName() string { return r.CacheName }

--- a/momento/get.go
+++ b/momento/get.go
@@ -15,7 +15,6 @@ type GetRequest struct {
 	CacheName string
 	// string or byte key to be used to store item
 	Key Key
-
 }
 
 func (r *GetRequest) cacheName() string { return r.CacheName }

--- a/momento/get_batch.go
+++ b/momento/get_batch.go
@@ -68,7 +68,7 @@ func (r *GetBatchRequest) makeGrpcRequest(grpcRequest interface{}, requestMetada
 	return nil, nil, nil
 }
 
-func (r *GetBatchRequest) interpretGrpcResponse(_ interface{}) error {
+func (r *GetBatchRequest) interpretGrpcResponse(_ interface{}) (interface{}, error) {
 	var getResponses []responses.GetResponse
 	for {
 		resp, err := r.grpcStream.Recv()
@@ -82,17 +82,12 @@ func (r *GetBatchRequest) interpretGrpcResponse(_ interface{}) error {
 			case pb.ECacheResult_Miss:
 				getResponses = append(getResponses, &responses.GetMiss{})
 			default:
-				return momentoerrors.ConvertSvcErr(err)
+				return nil, momentoerrors.ConvertSvcErr(err)
 			}
 		} else {
-			return momentoerrors.ConvertSvcErr(err)
+			return nil, momentoerrors.ConvertSvcErr(err)
 		}
 	}
 
-	r.response = *responses.NewGetBatchSuccess(getResponses, r.byteKeys)
-	return nil
-}
-
-func (r *GetBatchRequest) validateResponseType(resp grpcResponse) error {
-	return nil
+	return *responses.NewGetBatchSuccess(getResponses, r.byteKeys), nil
 }

--- a/momento/get_batch.go
+++ b/momento/get_batch.go
@@ -15,7 +15,6 @@ type GetBatchRequest struct {
 	Keys      []Value
 
 	grpcStream pb.Scs_GetBatchClient
-	response   responses.GetBatchResponse
 	byteKeys   [][]byte
 }
 

--- a/momento/increase_ttl.go
+++ b/momento/increase_ttl.go
@@ -17,7 +17,6 @@ type IncreaseTtlRequest struct {
 	Key Key
 	// Time to live that you want to increase to.
 	Ttl time.Duration
-
 }
 
 func (r *IncreaseTtlRequest) cacheName() string { return r.CacheName }

--- a/momento/increase_ttl.go
+++ b/momento/increase_ttl.go
@@ -18,7 +18,6 @@ type IncreaseTtlRequest struct {
 	// Time to live that you want to increase to.
 	Ttl time.Duration
 
-	response responses.IncreaseTtlResponse
 }
 
 func (r *IncreaseTtlRequest) cacheName() string { return r.CacheName }
@@ -56,7 +55,7 @@ func (r *IncreaseTtlRequest) makeGrpcRequest(grpcRequest interface{}, requestMet
 	return resp, nil, nil
 }
 
-func (r *IncreaseTtlRequest) interpretGrpcResponse(resp interface{}) error {
+func (r *IncreaseTtlRequest) interpretGrpcResponse(resp interface{}) (interface{}, error) {
 	myResp := resp.(*pb.XUpdateTtlResponse)
 
 	var theResponse responses.IncreaseTtlResponse
@@ -68,18 +67,8 @@ func (r *IncreaseTtlRequest) interpretGrpcResponse(resp interface{}) error {
 	case *pb.XUpdateTtlResponse_Set:
 		theResponse = &responses.IncreaseTtlSet{}
 	default:
-		return errUnexpectedGrpcResponse(r, myResp)
+		return nil, errUnexpectedGrpcResponse(r, myResp)
 	}
 
-	r.response = theResponse
-
-	return nil
-}
-
-func (r *IncreaseTtlRequest) validateResponseType(resp grpcResponse) error {
-	_, ok := resp.(*pb.XUpdateTtlResponse)
-	if !ok {
-		return errUnexpectedGrpcResponse(nil, resp)
-	}
-	return nil
+	return theResponse, nil
 }

--- a/momento/increment.go
+++ b/momento/increment.go
@@ -18,7 +18,6 @@ type IncrementRequest struct {
 	Amount    int64
 	Ttl       *utils.CollectionTtl
 
-	response responses.IncrementResponse
 }
 
 func (r *IncrementRequest) cacheName() string { return r.CacheName }
@@ -63,16 +62,7 @@ func (r *IncrementRequest) makeGrpcRequest(grpcRequest interface{}, requestMetad
 	return resp, nil, nil
 }
 
-func (r *IncrementRequest) interpretGrpcResponse(resp interface{}) error {
+func (r *IncrementRequest) interpretGrpcResponse(resp interface{}) (interface{}, error) {
 	myResp := resp.(*pb.XIncrementResponse)
-	r.response = responses.NewIncrementSuccess(myResp.Value)
-	return nil
-}
-
-func (r *IncrementRequest) validateResponseType(resp grpcResponse) error {
-	_, ok := resp.(*pb.XIncrementResponse)
-	if !ok {
-		return errUnexpectedGrpcResponse(nil, resp)
-	}
-	return nil
+	return responses.NewIncrementSuccess(myResp.Value), nil
 }

--- a/momento/increment.go
+++ b/momento/increment.go
@@ -17,7 +17,6 @@ type IncrementRequest struct {
 	Field     Field
 	Amount    int64
 	Ttl       *utils.CollectionTtl
-
 }
 
 func (r *IncrementRequest) cacheName() string { return r.CacheName }

--- a/momento/item_get_ttl.go
+++ b/momento/item_get_ttl.go
@@ -12,7 +12,6 @@ import (
 type ItemGetTtlRequest struct {
 	CacheName string
 	Key       Key
-
 }
 
 func (r *ItemGetTtlRequest) cacheName() string { return r.CacheName }

--- a/momento/item_get_type.go
+++ b/momento/item_get_type.go
@@ -13,7 +13,6 @@ import (
 type ItemGetTypeRequest struct {
 	CacheName string
 	Key       Key
-
 }
 
 func (r *ItemGetTypeRequest) cacheName() string { return r.CacheName }

--- a/momento/item_get_type.go
+++ b/momento/item_get_type.go
@@ -14,7 +14,6 @@ type ItemGetTypeRequest struct {
 	CacheName string
 	Key       Key
 
-	response responses.ItemGetTypeResponse
 }
 
 func (r *ItemGetTypeRequest) cacheName() string { return r.CacheName }
@@ -45,25 +44,15 @@ func (r *ItemGetTypeRequest) makeGrpcRequest(grpcRequest interface{}, requestMet
 	return resp, nil, nil
 }
 
-func (r *ItemGetTypeRequest) interpretGrpcResponse(resp interface{}) error {
+func (r *ItemGetTypeRequest) interpretGrpcResponse(resp interface{}) (interface{}, error) {
 	myResp := resp.(*pb.XItemGetTypeResponse)
 
 	switch myResp.Result.(type) {
 	case *pb.XItemGetTypeResponse_Found:
-		r.response = responses.NewItemGetTypeHit(myResp.GetFound().ItemType)
-		return nil
+		return responses.NewItemGetTypeHit(myResp.GetFound().ItemType), nil
 	case *pb.XItemGetTypeResponse_Missing:
-		r.response = &responses.ItemGetTypeMiss{}
-		return nil
+		return &responses.ItemGetTypeMiss{}, nil
 	default:
-		return errUnexpectedGrpcResponse(r, myResp)
+		return nil, errUnexpectedGrpcResponse(r, myResp)
 	}
-}
-
-func (r *ItemGetTypeRequest) validateResponseType(resp grpcResponse) error {
-	_, ok := resp.(*pb.XItemGetTypeResponse)
-	if !ok {
-		return errUnexpectedGrpcResponse(nil, resp)
-	}
-	return nil
 }

--- a/momento/keys_exist.go
+++ b/momento/keys_exist.go
@@ -13,7 +13,6 @@ import (
 type KeysExistRequest struct {
 	CacheName string
 	Keys      []Key
-
 }
 
 func (r *KeysExistRequest) cacheName() string { return r.CacheName }

--- a/momento/keys_exist.go
+++ b/momento/keys_exist.go
@@ -14,7 +14,6 @@ type KeysExistRequest struct {
 	CacheName string
 	Keys      []Key
 
-	response responses.KeysExistResponse
 }
 
 func (r *KeysExistRequest) cacheName() string { return r.CacheName }
@@ -47,16 +46,7 @@ func (r *KeysExistRequest) makeGrpcRequest(grpcRequest interface{}, requestMetad
 	return resp, nil, nil
 }
 
-func (r *KeysExistRequest) interpretGrpcResponse(resp interface{}) error {
+func (r *KeysExistRequest) interpretGrpcResponse(resp interface{}) (interface{}, error) {
 	myResp := resp.(*pb.XKeysExistResponse)
-	r.response = responses.NewKeysExistSuccess(myResp.Exists)
-	return nil
-}
-
-func (r *KeysExistRequest) validateResponseType(resp grpcResponse) error {
-	_, ok := resp.(*pb.XKeysExistResponse)
-	if !ok {
-		return errUnexpectedGrpcResponse(nil, resp)
-	}
-	return nil
+	return responses.NewKeysExistSuccess(myResp.Exists), nil
 }

--- a/momento/list_concatenate_back.go
+++ b/momento/list_concatenate_back.go
@@ -19,7 +19,6 @@ type ListConcatenateBackRequest struct {
 	TruncateFrontToSize uint32
 	Ttl                 *utils.CollectionTtl
 
-	response responses.ListConcatenateBackResponse
 }
 
 func (r *ListConcatenateBackRequest) cacheName() string { return r.CacheName }
@@ -71,16 +70,7 @@ func (r *ListConcatenateBackRequest) makeGrpcRequest(grpcRequest interface{}, re
 	return resp, nil, nil
 }
 
-func (r *ListConcatenateBackRequest) interpretGrpcResponse(resp interface{}) error {
+func (r *ListConcatenateBackRequest) interpretGrpcResponse(resp interface{}) (interface{}, error) {
 	myResp := resp.(*pb.XListConcatenateBackResponse)
-	r.response = responses.NewListConcatenateBackSuccess(myResp.ListLength)
-	return nil
-}
-
-func (r *ListConcatenateBackRequest) validateResponseType(resp grpcResponse) error {
-	_, ok := resp.(*pb.XListConcatenateBackResponse)
-	if !ok {
-		return errUnexpectedGrpcResponse(nil, resp)
-	}
-	return nil
+	return responses.NewListConcatenateBackSuccess(myResp.ListLength), nil
 }

--- a/momento/list_concatenate_back.go
+++ b/momento/list_concatenate_back.go
@@ -18,7 +18,6 @@ type ListConcatenateBackRequest struct {
 	Values              []Value
 	TruncateFrontToSize uint32
 	Ttl                 *utils.CollectionTtl
-
 }
 
 func (r *ListConcatenateBackRequest) cacheName() string { return r.CacheName }

--- a/momento/list_concatenate_front.go
+++ b/momento/list_concatenate_front.go
@@ -18,7 +18,6 @@ type ListConcatenateFrontRequest struct {
 	TruncateBackToSize uint32
 	Ttl                *utils.CollectionTtl
 
-	response responses.ListConcatenateFrontResponse
 }
 
 func (r *ListConcatenateFrontRequest) cacheName() string { return r.CacheName }
@@ -70,16 +69,7 @@ func (r *ListConcatenateFrontRequest) makeGrpcRequest(grpcRequest interface{}, r
 	return resp, nil, nil
 }
 
-func (r *ListConcatenateFrontRequest) interpretGrpcResponse(resp interface{}) error {
+func (r *ListConcatenateFrontRequest) interpretGrpcResponse(resp interface{}) (interface{}, error) {
 	myResp := resp.(*pb.XListConcatenateFrontResponse)
-	r.response = responses.NewListConcatenateFrontSuccess(myResp.ListLength)
-	return nil
-}
-
-func (r *ListConcatenateFrontRequest) validateResponseType(resp grpcResponse) error {
-	_, ok := resp.(*pb.XListConcatenateFrontResponse)
-	if !ok {
-		return errUnexpectedGrpcResponse(nil, resp)
-	}
-	return nil
+	return responses.NewListConcatenateFrontSuccess(myResp.ListLength), nil
 }

--- a/momento/list_concatenate_front.go
+++ b/momento/list_concatenate_front.go
@@ -17,7 +17,6 @@ type ListConcatenateFrontRequest struct {
 	Values             []Value
 	TruncateBackToSize uint32
 	Ttl                *utils.CollectionTtl
-
 }
 
 func (r *ListConcatenateFrontRequest) cacheName() string { return r.CacheName }

--- a/momento/list_fetch.go
+++ b/momento/list_fetch.go
@@ -15,7 +15,6 @@ type ListFetchRequest struct {
 	ListName   string
 	StartIndex *int32
 	EndIndex   *int32
-
 }
 
 func (r *ListFetchRequest) cacheName() string { return r.CacheName }

--- a/momento/list_length.go
+++ b/momento/list_length.go
@@ -13,7 +13,6 @@ import (
 type ListLengthRequest struct {
 	CacheName string
 	ListName  string
-
 }
 
 func (r *ListLengthRequest) cacheName() string { return r.CacheName }

--- a/momento/list_length.go
+++ b/momento/list_length.go
@@ -14,7 +14,6 @@ type ListLengthRequest struct {
 	CacheName string
 	ListName  string
 
-	response responses.ListLengthResponse
 }
 
 func (r *ListLengthRequest) cacheName() string { return r.CacheName }
@@ -43,23 +42,14 @@ func (r *ListLengthRequest) makeGrpcRequest(grpcRequest interface{}, requestMeta
 	return resp, nil, nil
 }
 
-func (r *ListLengthRequest) interpretGrpcResponse(resp interface{}) error {
+func (r *ListLengthRequest) interpretGrpcResponse(resp interface{}) (interface{}, error) {
 	myResp := resp.(*pb.XListLengthResponse)
 	switch rtype := myResp.List.(type) {
 	case *pb.XListLengthResponse_Found:
-		r.response = responses.NewListLengthHit(rtype.Found.Length)
+		return responses.NewListLengthHit(rtype.Found.Length), nil
 	case *pb.XListLengthResponse_Missing:
-		r.response = &responses.ListLengthMiss{}
+		return &responses.ListLengthMiss{}, nil
 	default:
-		return errUnexpectedGrpcResponse(r, myResp)
+		return nil, errUnexpectedGrpcResponse(r, myResp)
 	}
-	return nil
-}
-
-func (r *ListLengthRequest) validateResponseType(resp grpcResponse) error {
-	_, ok := resp.(*pb.XListLengthResponse)
-	if !ok {
-		return errUnexpectedGrpcResponse(nil, resp)
-	}
-	return nil
 }

--- a/momento/list_pop_back.go
+++ b/momento/list_pop_back.go
@@ -13,7 +13,6 @@ import (
 type ListPopBackRequest struct {
 	CacheName string
 	ListName  string
-
 }
 
 func (r *ListPopBackRequest) cacheName() string { return r.CacheName }

--- a/momento/list_pop_back.go
+++ b/momento/list_pop_back.go
@@ -14,7 +14,6 @@ type ListPopBackRequest struct {
 	CacheName string
 	ListName  string
 
-	response responses.ListPopBackResponse
 }
 
 func (r *ListPopBackRequest) cacheName() string { return r.CacheName }
@@ -41,23 +40,14 @@ func (r *ListPopBackRequest) makeGrpcRequest(grpcRequest interface{}, requestMet
 	return resp, nil, nil
 }
 
-func (r *ListPopBackRequest) interpretGrpcResponse(resp interface{}) error {
+func (r *ListPopBackRequest) interpretGrpcResponse(resp interface{}) (interface{}, error) {
 	myResp := resp.(*pb.XListPopBackResponse)
 	switch rtype := myResp.List.(type) {
 	case *pb.XListPopBackResponse_Found:
-		r.response = responses.NewListPopBackHit(rtype.Found.Back)
+		return responses.NewListPopBackHit(rtype.Found.Back), nil
 	case *pb.XListPopBackResponse_Missing:
-		r.response = &responses.ListPopBackMiss{}
+		return &responses.ListPopBackMiss{}, nil
 	default:
-		return errUnexpectedGrpcResponse(r, myResp)
+		return nil, errUnexpectedGrpcResponse(r, myResp)
 	}
-	return nil
-}
-
-func (r *ListPopBackRequest) validateResponseType(resp grpcResponse) error {
-	_, ok := resp.(*pb.XListPopBackResponse)
-	if !ok {
-		return errUnexpectedGrpcResponse(nil, resp)
-	}
-	return nil
 }

--- a/momento/list_pop_front.go
+++ b/momento/list_pop_front.go
@@ -14,7 +14,6 @@ type ListPopFrontRequest struct {
 	CacheName string
 	ListName  string
 
-	response responses.ListPopFrontResponse
 }
 
 func (r *ListPopFrontRequest) cacheName() string { return r.CacheName }
@@ -41,23 +40,14 @@ func (r *ListPopFrontRequest) makeGrpcRequest(grpcRequest interface{}, requestMe
 	return resp, nil, nil
 }
 
-func (r *ListPopFrontRequest) interpretGrpcResponse(resp interface{}) error {
+func (r *ListPopFrontRequest) interpretGrpcResponse(resp interface{}) (interface{}, error) {
 	myResp := resp.(*pb.XListPopFrontResponse)
 	switch rtype := myResp.List.(type) {
 	case *pb.XListPopFrontResponse_Found:
-		r.response = responses.NewListPopFrontHit(rtype.Found.Front)
+		return responses.NewListPopFrontHit(rtype.Found.Front), nil
 	case *pb.XListPopFrontResponse_Missing:
-		r.response = &responses.ListPopFrontMiss{}
+		return &responses.ListPopFrontMiss{}, nil
 	default:
-		return errUnexpectedGrpcResponse(r, myResp)
+		return nil, errUnexpectedGrpcResponse(r, myResp)
 	}
-	return nil
-}
-
-func (r *ListPopFrontRequest) validateResponseType(resp grpcResponse) error {
-	_, ok := resp.(*pb.XListPopFrontResponse)
-	if !ok {
-		return errUnexpectedGrpcResponse(nil, resp)
-	}
-	return nil
 }

--- a/momento/list_pop_front.go
+++ b/momento/list_pop_front.go
@@ -13,7 +13,6 @@ import (
 type ListPopFrontRequest struct {
 	CacheName string
 	ListName  string
-
 }
 
 func (r *ListPopFrontRequest) cacheName() string { return r.CacheName }

--- a/momento/list_push_back.go
+++ b/momento/list_push_back.go
@@ -18,7 +18,6 @@ type ListPushBackRequest struct {
 	Value               Value
 	TruncateFrontToSize uint32
 	Ttl                 *utils.CollectionTtl
-
 }
 
 func (r *ListPushBackRequest) cacheName() string { return r.CacheName }

--- a/momento/list_push_back.go
+++ b/momento/list_push_back.go
@@ -19,7 +19,6 @@ type ListPushBackRequest struct {
 	TruncateFrontToSize uint32
 	Ttl                 *utils.CollectionTtl
 
-	response responses.ListPushBackResponse
 }
 
 func (r *ListPushBackRequest) cacheName() string { return r.CacheName }
@@ -71,16 +70,7 @@ func (r *ListPushBackRequest) makeGrpcRequest(grpcRequest interface{}, requestMe
 	return resp, nil, nil
 }
 
-func (r *ListPushBackRequest) interpretGrpcResponse(resp interface{}) error {
+func (r *ListPushBackRequest) interpretGrpcResponse(resp interface{}) (interface{}, error) {
 	myResp := resp.(*pb.XListPushBackResponse)
-	r.response = responses.NewListPushBackSuccess(myResp.ListLength)
-	return nil
-}
-
-func (r *ListPushBackRequest) validateResponseType(resp grpcResponse) error {
-	_, ok := resp.(*pb.XListPushBackResponse)
-	if !ok {
-		return errUnexpectedGrpcResponse(nil, resp)
-	}
-	return nil
+	return responses.NewListPushBackSuccess(myResp.ListLength), nil
 }

--- a/momento/list_push_front.go
+++ b/momento/list_push_front.go
@@ -18,7 +18,6 @@ type ListPushFrontRequest struct {
 	Value              Value
 	TruncateBackToSize uint32
 	Ttl                *utils.CollectionTtl
-
 }
 
 func (r *ListPushFrontRequest) cacheName() string { return r.CacheName }

--- a/momento/list_push_front.go
+++ b/momento/list_push_front.go
@@ -19,7 +19,6 @@ type ListPushFrontRequest struct {
 	TruncateBackToSize uint32
 	Ttl                *utils.CollectionTtl
 
-	response responses.ListPushFrontResponse
 }
 
 func (r *ListPushFrontRequest) cacheName() string { return r.CacheName }
@@ -71,16 +70,7 @@ func (r *ListPushFrontRequest) makeGrpcRequest(grpcRequest interface{}, requestM
 	return resp, nil, nil
 }
 
-func (r *ListPushFrontRequest) interpretGrpcResponse(resp interface{}) error {
+func (r *ListPushFrontRequest) interpretGrpcResponse(resp interface{}) (interface{}, error) {
 	myResp := resp.(*pb.XListPushFrontResponse)
-	r.response = responses.NewListPushFrontSuccess(myResp.ListLength)
-	return nil
-}
-
-func (r *ListPushFrontRequest) validateResponseType(resp grpcResponse) error {
-	_, ok := resp.(*pb.XListPushFrontResponse)
-	if !ok {
-		return errUnexpectedGrpcResponse(nil, resp)
-	}
-	return nil
+	return responses.NewListPushFrontSuccess(myResp.ListLength), nil
 }

--- a/momento/list_remove_value.go
+++ b/momento/list_remove_value.go
@@ -15,7 +15,6 @@ type ListRemoveValueRequest struct {
 	ListName  string
 	Value     Value
 
-	response responses.ListRemoveValueResponse
 }
 
 func (r *ListRemoveValueRequest) cacheName() string { return r.CacheName }
@@ -54,15 +53,6 @@ func (r *ListRemoveValueRequest) makeGrpcRequest(grpcRequest interface{}, reques
 	return resp, nil, nil
 }
 
-func (r *ListRemoveValueRequest) interpretGrpcResponse(_ interface{}) error {
-	r.response = &responses.ListRemoveValueSuccess{}
-	return nil
-}
-
-func (r *ListRemoveValueRequest) validateResponseType(resp grpcResponse) error {
-	_, ok := resp.(*pb.XListRemoveResponse)
-	if !ok {
-		return errUnexpectedGrpcResponse(nil, resp)
-	}
-	return nil
+func (r *ListRemoveValueRequest) interpretGrpcResponse(_ interface{}) (interface{}, error) {
+	return &responses.ListRemoveValueSuccess{}, nil
 }

--- a/momento/list_remove_value.go
+++ b/momento/list_remove_value.go
@@ -14,7 +14,6 @@ type ListRemoveValueRequest struct {
 	CacheName string
 	ListName  string
 	Value     Value
-
 }
 
 func (r *ListRemoveValueRequest) cacheName() string { return r.CacheName }

--- a/momento/requester.go
+++ b/momento/requester.go
@@ -30,9 +30,8 @@ type requester interface {
 	hasCacheName
 	initGrpcRequest(client scsDataClient) (interface{}, error)
 	makeGrpcRequest(grpcRequest interface{}, requestMetadata context.Context, client scsDataClient) (grpcResponse, []metadata.MD, error)
-	interpretGrpcResponse(theResponse interface{}) error
+	interpretGrpcResponse(theResponse interface{}) (interface{}, error)
 	requestName() string
-	validateResponseType(resp grpcResponse) error
 }
 
 type grpcResponse interface {

--- a/momento/retry_test.go
+++ b/momento/retry_test.go
@@ -407,43 +407,6 @@ var _ = Describe(
 				Expect(getResponse.(*responses.GetHit).ValueString()).To(Equal("value"))
 				Expect(metricsCollector.GetTotalRetryCount("cache", "Get")).To(Equal(1))
 			})
-
-			It("shouldn't gather metrics if the request is not included", func() {
-				status := "unavailable"
-				errCount := 3
-				retryMiddleware := helpers.NewRetryMetricsMiddleware(helpers.RetryMetricsMiddlewareProps{
-					RetryMetricsMiddlewareRequestHandlerProps: helpers.RetryMetricsMiddlewareRequestHandlerProps{
-						ReturnError:  &status,
-						ErrorRpcList: &[]string{"get"},
-						ErrorCount:   &errCount,
-						DelayRpcList: nil,
-						DelayMillis:  nil,
-						DelayCount:   nil,
-					},
-				})
-				metricsCollector := *retryMiddleware.(helpers.RetryMetricsMiddleware).GetMetricsCollector()
-				clientConfig := config.LaptopLatest().WithMiddleware([]middleware.Middleware{
-					retryMiddleware,
-				})
-				cacheClient := setupCacheClientTest(clientConfig)
-				setResponse, err := cacheClient.Set(context.Background(), &momento.SetRequest{
-					CacheName: "cache",
-					Key:       momento.String("key"),
-					Value:     momento.String("value"),
-				})
-				Expect(err).To(BeNil())
-				Expect(setResponse).To(Not(BeNil()))
-
-				getResponse, err := cacheClient.Get(context.Background(), &momento.GetRequest{
-					CacheName: "cache",
-					Key:       momento.String("key"),
-				})
-				Expect(err).To(BeNil())
-				Expect(getResponse).To(Not(BeNil()))
-				Expect(getResponse.(*responses.GetHit).ValueString()).To(Equal("value"))
-				Expect(metricsCollector.GetTotalRetryCount("cache", "Get")).To(Equal(0))
-			})
-
 		})
 	},
 )

--- a/momento/retry_test.go
+++ b/momento/retry_test.go
@@ -346,7 +346,7 @@ var _ = Describe(
 				status := "unavailable"
 				retryMiddleware := helpers.NewRetryMetricsMiddleware(helpers.RetryMetricsMiddlewareProps{
 					Props: middleware.Props{
-						Logger: momento_default_logger.NewDefaultMomentoLoggerFactory(momento_default_logger.DEBUG).GetLogger("retry-metrics"),
+						Logger:       momento_default_logger.NewDefaultMomentoLoggerFactory(momento_default_logger.DEBUG).GetLogger("retry-metrics"),
 						IncludeTypes: []interface{}{momento.IncrementRequest{}, momento.DictionaryIncrementRequest{}},
 					},
 					RetryMetricsMiddlewareRequestHandlerProps: helpers.RetryMetricsMiddlewareRequestHandlerProps{

--- a/momento/retry_test.go
+++ b/momento/retry_test.go
@@ -86,9 +86,6 @@ var _ = Describe(
 				strategy := retry.NewNeverRetryStrategy()
 				retryMiddleware := helpers.NewRetryMetricsMiddleware(
 					helpers.RetryMetricsMiddlewareProps{
-						Props: middleware.Props{
-							IncludeTypes: []interface{}{momento.SetRequest{}},
-						},
 						RetryMetricsMiddlewareRequestHandlerProps: helpers.RetryMetricsMiddlewareRequestHandlerProps{
 							ReturnError:  &status,
 							ErrorRpcList: &[]string{"set"},
@@ -125,9 +122,6 @@ var _ = Describe(
 					MaxBackoffMillis:   2000,
 				})
 				retryMiddleware := helpers.NewRetryMetricsMiddleware(helpers.RetryMetricsMiddlewareProps{
-					Props: middleware.Props{
-						IncludeTypes: []interface{}{momento.SetRequest{}},
-					},
 					RetryMetricsMiddlewareRequestHandlerProps: helpers.RetryMetricsMiddlewareRequestHandlerProps{
 						ReturnError:  &status,
 						ErrorRpcList: &[]string{"set"},
@@ -164,9 +158,6 @@ var _ = Describe(
 				})
 				errorCount := 5
 				retryMiddleware := helpers.NewRetryMetricsMiddleware(helpers.RetryMetricsMiddlewareProps{
-					Props: middleware.Props{
-						IncludeTypes: []interface{}{momento.SetRequest{}},
-					},
 					RetryMetricsMiddlewareRequestHandlerProps: helpers.RetryMetricsMiddlewareRequestHandlerProps{
 						ReturnError:  &status,
 						ErrorRpcList: &[]string{"set"},
@@ -202,9 +193,6 @@ var _ = Describe(
 					MaxBackoffMillis:   2000,
 				})
 				retryMiddleware := helpers.NewRetryMetricsMiddleware(helpers.RetryMetricsMiddlewareProps{
-					Props: middleware.Props{
-						IncludeTypes: []interface{}{momento.SetRequest{}},
-					},
 					RetryMetricsMiddlewareRequestHandlerProps: helpers.RetryMetricsMiddlewareRequestHandlerProps{
 						ReturnError:  &status,
 						ErrorRpcList: &[]string{"set"},
@@ -273,9 +261,6 @@ var _ = Describe(
 					MaxAttempts:   3,
 				})
 				retryMiddleware := helpers.NewRetryMetricsMiddleware(helpers.RetryMetricsMiddlewareProps{
-					Props: middleware.Props{
-						IncludeTypes: []interface{}{momento.GetRequest{}},
-					},
 					RetryMetricsMiddlewareRequestHandlerProps: helpers.RetryMetricsMiddlewareRequestHandlerProps{
 						ReturnError:  &status,
 						ErrorRpcList: &[]string{"get"},
@@ -313,9 +298,6 @@ var _ = Describe(
 			It("should not retry if the status code is not retryable", func() {
 				status := "unknown"
 				retryMiddleware := helpers.NewRetryMetricsMiddleware(helpers.RetryMetricsMiddlewareProps{
-					Props: middleware.Props{
-						IncludeTypes: []interface{}{momento.SetRequest{}},
-					},
 					RetryMetricsMiddlewareRequestHandlerProps: helpers.RetryMetricsMiddlewareRequestHandlerProps{
 						ReturnError:  &status,
 						ErrorRpcList: &[]string{"set"},
@@ -345,10 +327,6 @@ var _ = Describe(
 			It("should not retry if the api is not retryable", func() {
 				status := "unavailable"
 				retryMiddleware := helpers.NewRetryMetricsMiddleware(helpers.RetryMetricsMiddlewareProps{
-					Props: middleware.Props{
-						Logger:       momento_default_logger.NewDefaultMomentoLoggerFactory(momento_default_logger.DEBUG).GetLogger("retry-metrics"),
-						IncludeTypes: []interface{}{momento.IncrementRequest{}, momento.DictionaryIncrementRequest{}},
-					},
 					RetryMetricsMiddlewareRequestHandlerProps: helpers.RetryMetricsMiddlewareRequestHandlerProps{
 						ReturnError:  &status,
 						ErrorRpcList: &[]string{"increment", "dictionary-increment"},
@@ -398,9 +376,6 @@ var _ = Describe(
 				status := "unavailable"
 				errCount := 1
 				retryMiddleware := helpers.NewRetryMetricsMiddleware(helpers.RetryMetricsMiddlewareProps{
-					Props: middleware.Props{
-						IncludeTypes: []interface{}{momento.GetRequest{}},
-					},
 					RetryMetricsMiddlewareRequestHandlerProps: helpers.RetryMetricsMiddlewareRequestHandlerProps{
 						ReturnError:  &status,
 						ErrorRpcList: &[]string{"get"},
@@ -437,9 +412,6 @@ var _ = Describe(
 				status := "unavailable"
 				errCount := 3
 				retryMiddleware := helpers.NewRetryMetricsMiddleware(helpers.RetryMetricsMiddlewareProps{
-					Props: middleware.Props{
-						IncludeTypes: []interface{}{momento.SetRequest{}},
-					},
 					RetryMetricsMiddlewareRequestHandlerProps: helpers.RetryMetricsMiddlewareRequestHandlerProps{
 						ReturnError:  &status,
 						ErrorRpcList: &[]string{"get"},

--- a/momento/retry_test.go
+++ b/momento/retry_test.go
@@ -84,9 +84,9 @@ var _ = Describe(
 			It("shouldn't retry", func() {
 				status := "unavailable"
 				strategy := retry.NewNeverRetryStrategy()
-				retryMiddleware := helpers.NewRetryMetricsMiddleware(
-					helpers.RetryMetricsMiddlewareProps{
-						RetryMetricsMiddlewareRequestHandlerProps: helpers.RetryMetricsMiddlewareRequestHandlerProps{
+				retryMiddleware := helpers.NewMomentoLocalMiddleware(
+					helpers.MomentoLocalMiddlewareProps{
+						MomentoLocalMiddlewareRequestHandlerProps: helpers.MomentoLocalMiddlewareRequestHandlerProps{
 							ReturnError:  &status,
 							ErrorRpcList: &[]string{"set"},
 							ErrorCount:   nil,
@@ -96,7 +96,7 @@ var _ = Describe(
 						},
 					},
 				)
-				metricsCollector := *retryMiddleware.(helpers.RetryMetricsMiddleware).GetMetricsCollector()
+				metricsCollector := *retryMiddleware.(helpers.MomentoLocalMiddleware).GetMetricsCollector()
 				clientConfig := config.LaptopLatest().WithMiddleware([]middleware.Middleware{
 					retryMiddleware,
 				}).WithRetryStrategy(strategy)
@@ -121,8 +121,8 @@ var _ = Describe(
 					InitialDelayMillis: 100,
 					MaxBackoffMillis:   2000,
 				})
-				retryMiddleware := helpers.NewRetryMetricsMiddleware(helpers.RetryMetricsMiddlewareProps{
-					RetryMetricsMiddlewareRequestHandlerProps: helpers.RetryMetricsMiddlewareRequestHandlerProps{
+				retryMiddleware := helpers.NewMomentoLocalMiddleware(helpers.MomentoLocalMiddlewareProps{
+					MomentoLocalMiddlewareRequestHandlerProps: helpers.MomentoLocalMiddlewareRequestHandlerProps{
 						ReturnError:  &status,
 						ErrorRpcList: &[]string{"set"},
 						ErrorCount:   nil,
@@ -131,7 +131,7 @@ var _ = Describe(
 						DelayCount:   nil,
 					},
 				})
-				metricsCollector := *retryMiddleware.(helpers.RetryMetricsMiddleware).GetMetricsCollector()
+				metricsCollector := *retryMiddleware.(helpers.MomentoLocalMiddleware).GetMetricsCollector()
 				clientConfig := config.LaptopLatest().WithMiddleware([]middleware.Middleware{
 					retryMiddleware,
 				}).WithRetryStrategy(strategy).WithClientTimeout(1 * time.Second)
@@ -157,8 +157,8 @@ var _ = Describe(
 					MaxBackoffMillis:   2000,
 				})
 				errorCount := 5
-				retryMiddleware := helpers.NewRetryMetricsMiddleware(helpers.RetryMetricsMiddlewareProps{
-					RetryMetricsMiddlewareRequestHandlerProps: helpers.RetryMetricsMiddlewareRequestHandlerProps{
+				retryMiddleware := helpers.NewMomentoLocalMiddleware(helpers.MomentoLocalMiddlewareProps{
+					MomentoLocalMiddlewareRequestHandlerProps: helpers.MomentoLocalMiddlewareRequestHandlerProps{
 						ReturnError:  &status,
 						ErrorRpcList: &[]string{"set"},
 						ErrorCount:   &errorCount,
@@ -167,7 +167,7 @@ var _ = Describe(
 						DelayCount:   nil,
 					},
 				})
-				metricsCollector := *retryMiddleware.(helpers.RetryMetricsMiddleware).GetMetricsCollector()
+				metricsCollector := *retryMiddleware.(helpers.MomentoLocalMiddleware).GetMetricsCollector()
 				clientConfig := config.LaptopLatest().WithMiddleware([]middleware.Middleware{
 					retryMiddleware,
 				}).WithRetryStrategy(strategy).WithClientTimeout(10 * time.Second)
@@ -192,8 +192,8 @@ var _ = Describe(
 					InitialDelayMillis: 100,
 					MaxBackoffMillis:   2000,
 				})
-				retryMiddleware := helpers.NewRetryMetricsMiddleware(helpers.RetryMetricsMiddlewareProps{
-					RetryMetricsMiddlewareRequestHandlerProps: helpers.RetryMetricsMiddlewareRequestHandlerProps{
+				retryMiddleware := helpers.NewMomentoLocalMiddleware(helpers.MomentoLocalMiddlewareProps{
+					MomentoLocalMiddlewareRequestHandlerProps: helpers.MomentoLocalMiddlewareRequestHandlerProps{
 						ReturnError:  &status,
 						ErrorRpcList: &[]string{"set"},
 						ErrorCount:   nil,
@@ -202,7 +202,7 @@ var _ = Describe(
 						DelayCount:   nil,
 					},
 				})
-				metricsCollector := *retryMiddleware.(helpers.RetryMetricsMiddleware).GetMetricsCollector()
+				metricsCollector := *retryMiddleware.(helpers.MomentoLocalMiddleware).GetMetricsCollector()
 				clientConfig := config.LaptopLatest().WithMiddleware([]middleware.Middleware{
 					retryMiddleware,
 				}).WithRetryStrategy(strategy)
@@ -225,8 +225,8 @@ var _ = Describe(
 					InitialDelayMillis: 100,
 					MaxBackoffMillis:   2000,
 				})
-				retryMiddleware := helpers.NewRetryMetricsMiddleware(helpers.RetryMetricsMiddlewareProps{
-					RetryMetricsMiddlewareRequestHandlerProps: helpers.RetryMetricsMiddlewareRequestHandlerProps{
+				retryMiddleware := helpers.NewMomentoLocalMiddleware(helpers.MomentoLocalMiddlewareProps{
+					MomentoLocalMiddlewareRequestHandlerProps: helpers.MomentoLocalMiddlewareRequestHandlerProps{
 						ReturnError:  &status,
 						ErrorRpcList: &[]string{"dictionary-increment"},
 						ErrorCount:   nil,
@@ -235,7 +235,7 @@ var _ = Describe(
 						DelayCount:   nil,
 					},
 				})
-				metricsCollector := *retryMiddleware.(helpers.RetryMetricsMiddleware).GetMetricsCollector()
+				metricsCollector := *retryMiddleware.(helpers.MomentoLocalMiddleware).GetMetricsCollector()
 				clientConfig := config.LaptopLatest().WithMiddleware([]middleware.Middleware{
 					retryMiddleware,
 				}).WithRetryStrategy(strategy)
@@ -260,8 +260,8 @@ var _ = Describe(
 					LoggerFactory: momento_default_logger.DefaultMomentoLoggerFactory{},
 					MaxAttempts:   3,
 				})
-				retryMiddleware := helpers.NewRetryMetricsMiddleware(helpers.RetryMetricsMiddlewareProps{
-					RetryMetricsMiddlewareRequestHandlerProps: helpers.RetryMetricsMiddlewareRequestHandlerProps{
+				retryMiddleware := helpers.NewMomentoLocalMiddleware(helpers.MomentoLocalMiddlewareProps{
+					MomentoLocalMiddlewareRequestHandlerProps: helpers.MomentoLocalMiddlewareRequestHandlerProps{
 						ReturnError:  &status,
 						ErrorRpcList: &[]string{"get"},
 						ErrorCount:   nil,
@@ -270,7 +270,7 @@ var _ = Describe(
 						DelayCount:   nil,
 					},
 				})
-				metricsCollector := *retryMiddleware.(helpers.RetryMetricsMiddleware).GetMetricsCollector()
+				metricsCollector := *retryMiddleware.(helpers.MomentoLocalMiddleware).GetMetricsCollector()
 				clientConfig := config.LaptopLatest().WithMiddleware([]middleware.Middleware{
 					retryMiddleware,
 				}).WithRetryStrategy(retryStrategy)
@@ -297,8 +297,8 @@ var _ = Describe(
 
 			It("should not retry if the status code is not retryable", func() {
 				status := "unknown"
-				retryMiddleware := helpers.NewRetryMetricsMiddleware(helpers.RetryMetricsMiddlewareProps{
-					RetryMetricsMiddlewareRequestHandlerProps: helpers.RetryMetricsMiddlewareRequestHandlerProps{
+				retryMiddleware := helpers.NewMomentoLocalMiddleware(helpers.MomentoLocalMiddlewareProps{
+					MomentoLocalMiddlewareRequestHandlerProps: helpers.MomentoLocalMiddlewareRequestHandlerProps{
 						ReturnError:  &status,
 						ErrorRpcList: &[]string{"set"},
 						ErrorCount:   nil,
@@ -307,7 +307,7 @@ var _ = Describe(
 						DelayCount:   nil,
 					},
 				})
-				metricsCollector := *retryMiddleware.(helpers.RetryMetricsMiddleware).GetMetricsCollector()
+				metricsCollector := *retryMiddleware.(helpers.MomentoLocalMiddleware).GetMetricsCollector()
 				clientConfig := config.LaptopLatest().WithMiddleware([]middleware.Middleware{
 					retryMiddleware,
 				})
@@ -326,8 +326,8 @@ var _ = Describe(
 
 			It("should not retry if the api is not retryable", func() {
 				status := "unavailable"
-				retryMiddleware := helpers.NewRetryMetricsMiddleware(helpers.RetryMetricsMiddlewareProps{
-					RetryMetricsMiddlewareRequestHandlerProps: helpers.RetryMetricsMiddlewareRequestHandlerProps{
+				retryMiddleware := helpers.NewMomentoLocalMiddleware(helpers.MomentoLocalMiddlewareProps{
+					MomentoLocalMiddlewareRequestHandlerProps: helpers.MomentoLocalMiddlewareRequestHandlerProps{
 						ReturnError:  &status,
 						ErrorRpcList: &[]string{"increment", "dictionary-increment"},
 						ErrorCount:   nil,
@@ -336,7 +336,7 @@ var _ = Describe(
 						DelayCount:   nil,
 					},
 				})
-				metricsCollector := *retryMiddleware.(helpers.RetryMetricsMiddleware).GetMetricsCollector()
+				metricsCollector := *retryMiddleware.(helpers.MomentoLocalMiddleware).GetMetricsCollector()
 				clientConfig := config.LaptopLatest().WithMiddleware([]middleware.Middleware{
 					retryMiddleware,
 				})
@@ -375,8 +375,8 @@ var _ = Describe(
 			It("should return a value on success after a retry", func() {
 				status := "unavailable"
 				errCount := 1
-				retryMiddleware := helpers.NewRetryMetricsMiddleware(helpers.RetryMetricsMiddlewareProps{
-					RetryMetricsMiddlewareRequestHandlerProps: helpers.RetryMetricsMiddlewareRequestHandlerProps{
+				retryMiddleware := helpers.NewMomentoLocalMiddleware(helpers.MomentoLocalMiddlewareProps{
+					MomentoLocalMiddlewareRequestHandlerProps: helpers.MomentoLocalMiddlewareRequestHandlerProps{
 						ReturnError:  &status,
 						ErrorRpcList: &[]string{"get"},
 						ErrorCount:   &errCount,
@@ -385,7 +385,7 @@ var _ = Describe(
 						DelayCount:   nil,
 					},
 				})
-				metricsCollector := *retryMiddleware.(helpers.RetryMetricsMiddleware).GetMetricsCollector()
+				metricsCollector := *retryMiddleware.(helpers.MomentoLocalMiddleware).GetMetricsCollector()
 				clientConfig := config.LaptopLatest().WithMiddleware([]middleware.Middleware{
 					retryMiddleware,
 				})

--- a/momento/set.go
+++ b/momento/set.go
@@ -22,7 +22,6 @@ type SetRequest struct {
 	// If not provided, then default TTL for the cache client instance is used.
 	Ttl time.Duration
 
-	response responses.SetResponse
 }
 
 func (r *SetRequest) cacheName() string { return r.CacheName }
@@ -72,15 +71,6 @@ func (r *SetRequest) makeGrpcRequest(grpcRequest interface{}, requestMetadata co
 	return resp, nil, nil
 }
 
-func (r *SetRequest) interpretGrpcResponse(_ interface{}) error {
-	r.response = &responses.SetSuccess{}
-	return nil
-}
-
-func (r *SetRequest) validateResponseType(resp grpcResponse) error {
-	_, ok := resp.(*pb.XSetResponse)
-	if !ok {
-		return errUnexpectedGrpcResponse(nil, resp)
-	}
-	return nil
+func (r *SetRequest) interpretGrpcResponse(_ interface{}) (interface{}, error) {
+	return &responses.SetSuccess{}, nil
 }

--- a/momento/set.go
+++ b/momento/set.go
@@ -21,7 +21,6 @@ type SetRequest struct {
 	// Optional Time to live in cache in seconds.
 	// If not provided, then default TTL for the cache client instance is used.
 	Ttl time.Duration
-
 }
 
 func (r *SetRequest) cacheName() string { return r.CacheName }

--- a/momento/set_add_elements.go
+++ b/momento/set_add_elements.go
@@ -18,7 +18,6 @@ type SetAddElementsRequest struct {
 	Elements  []Value
 	Ttl       *utils.CollectionTtl
 
-	response responses.SetAddElementsResponse
 }
 
 func (r *SetAddElementsRequest) cacheName() string { return r.CacheName }
@@ -69,15 +68,6 @@ func (r *SetAddElementsRequest) makeGrpcRequest(grpcRequest interface{}, request
 	return resp, nil, nil
 }
 
-func (r *SetAddElementsRequest) interpretGrpcResponse(_ interface{}) error {
-	r.response = &responses.SetAddElementsSuccess{}
-	return nil
-}
-
-func (r *SetAddElementsRequest) validateResponseType(resp grpcResponse) error {
-	_, ok := resp.(*pb.XSetUnionResponse)
-	if !ok {
-		return errUnexpectedGrpcResponse(nil, resp)
-	}
-	return nil
+func (r *SetAddElementsRequest) interpretGrpcResponse(_ interface{}) (interface{}, error) {
+	return &responses.SetAddElementsSuccess{}, nil
 }

--- a/momento/set_add_elements.go
+++ b/momento/set_add_elements.go
@@ -17,7 +17,6 @@ type SetAddElementsRequest struct {
 	SetName   string
 	Elements  []Value
 	Ttl       *utils.CollectionTtl
-
 }
 
 func (r *SetAddElementsRequest) cacheName() string { return r.CacheName }

--- a/momento/set_batch.go
+++ b/momento/set_batch.go
@@ -17,7 +17,6 @@ type SetBatchRequest struct {
 	Ttl       time.Duration
 
 	grpcStream pb.Scs_SetBatchClient
-	response   responses.SetBatchResponse
 }
 
 func (r *SetBatchRequest) cacheName() string { return r.CacheName }

--- a/momento/set_batch.go
+++ b/momento/set_batch.go
@@ -73,7 +73,7 @@ func (r *SetBatchRequest) makeGrpcRequest(grpcRequest interface{}, requestMetada
 	return nil, nil, nil
 }
 
-func (r *SetBatchRequest) interpretGrpcResponse(_ interface{}) error {
+func (r *SetBatchRequest) interpretGrpcResponse(_ interface{}) (interface{}, error) {
 	var setResponses []responses.SetResponse
 	for {
 		resp, err := r.grpcStream.Recv()
@@ -84,17 +84,12 @@ func (r *SetBatchRequest) interpretGrpcResponse(_ interface{}) error {
 			case pb.ECacheResult_Ok:
 				setResponses = append(setResponses, &responses.SetSuccess{})
 			default:
-				return momentoerrors.ConvertSvcErr(err)
+				return nil, momentoerrors.ConvertSvcErr(err)
 			}
 		} else {
-			return momentoerrors.ConvertSvcErr(err)
+			return nil, momentoerrors.ConvertSvcErr(err)
 		}
 	}
 
-	r.response = *responses.NewSetBatchSuccess(setResponses)
-	return nil
-}
-
-func (r *SetBatchRequest) validateResponseType(resp grpcResponse) error {
-	return nil
+	return *responses.NewSetBatchSuccess(setResponses), nil
 }

--- a/momento/set_contains_elements.go
+++ b/momento/set_contains_elements.go
@@ -15,7 +15,6 @@ type SetContainsElementsRequest struct {
 	SetName   string
 	Elements  []Value
 
-	response responses.SetContainsElementsResponse
 }
 
 func (r *SetContainsElementsRequest) cacheName() string { return r.CacheName }
@@ -52,23 +51,14 @@ func (r *SetContainsElementsRequest) makeGrpcRequest(grpcRequest interface{}, re
 	return resp, nil, nil
 }
 
-func (r *SetContainsElementsRequest) interpretGrpcResponse(resp interface{}) error {
+func (r *SetContainsElementsRequest) interpretGrpcResponse(resp interface{}) (interface{}, error) {
 	myResp := resp.(*pb.XSetContainsResponse)
 	switch rtype := myResp.Set.(type) {
 	case *pb.XSetContainsResponse_Missing:
-		r.response = &responses.SetContainsElementsMiss{}
+		return &responses.SetContainsElementsMiss{}, nil
 	case *pb.XSetContainsResponse_Found:
-		r.response = responses.NewSetContainsElementsHit(rtype.Found.Contains)
+		return responses.NewSetContainsElementsHit(rtype.Found.Contains), nil
 	default:
-		return errUnexpectedGrpcResponse(r, myResp)
+		return nil, errUnexpectedGrpcResponse(r, myResp)
 	}
-	return nil
-}
-
-func (r *SetContainsElementsRequest) validateResponseType(resp grpcResponse) error {
-	_, ok := resp.(*pb.XSetContainsResponse)
-	if !ok {
-		return errUnexpectedGrpcResponse(nil, resp)
-	}
-	return nil
 }

--- a/momento/set_contains_elements.go
+++ b/momento/set_contains_elements.go
@@ -14,7 +14,6 @@ type SetContainsElementsRequest struct {
 	CacheName string
 	SetName   string
 	Elements  []Value
-
 }
 
 func (r *SetContainsElementsRequest) cacheName() string { return r.CacheName }

--- a/momento/set_fetch.go
+++ b/momento/set_fetch.go
@@ -13,7 +13,6 @@ import (
 type SetFetchRequest struct {
 	CacheName string
 	SetName   string
-
 }
 
 func (r *SetFetchRequest) cacheName() string { return r.CacheName }

--- a/momento/set_fetch.go
+++ b/momento/set_fetch.go
@@ -14,7 +14,6 @@ type SetFetchRequest struct {
 	CacheName string
 	SetName   string
 
-	response responses.SetFetchResponse
 }
 
 func (r *SetFetchRequest) cacheName() string { return r.CacheName }
@@ -43,23 +42,14 @@ func (r *SetFetchRequest) makeGrpcRequest(grpcRequest interface{}, requestMetada
 	return resp, nil, nil
 }
 
-func (r *SetFetchRequest) interpretGrpcResponse(resp interface{}) error {
+func (r *SetFetchRequest) interpretGrpcResponse(resp interface{}) (interface{}, error) {
 	myResp := resp.(*pb.XSetFetchResponse)
 	switch rtype := myResp.Set.(type) {
 	case *pb.XSetFetchResponse_Found:
-		r.response = responses.NewSetFetchHit(rtype.Found.Elements)
+		return responses.NewSetFetchHit(rtype.Found.Elements), nil
 	case *pb.XSetFetchResponse_Missing:
-		r.response = &responses.SetFetchMiss{}
+		return &responses.SetFetchMiss{}, nil
 	default:
-		return errUnexpectedGrpcResponse(r, myResp)
+		return nil, errUnexpectedGrpcResponse(r, myResp)
 	}
-	return nil
-}
-
-func (r *SetFetchRequest) validateResponseType(resp grpcResponse) error {
-	_, ok := resp.(*pb.XSetFetchResponse)
-	if !ok {
-		return errUnexpectedGrpcResponse(nil, resp)
-	}
-	return nil
 }

--- a/momento/set_if_absent.go
+++ b/momento/set_if_absent.go
@@ -25,7 +25,6 @@ type SetIfAbsentRequest struct {
 	// We issue a SetIfNotExists request to the server instead of a SetIf request because
 	// the backend implementation of SetIfNotExists is more efficient than SetIf.
 
-	response responses.SetIfAbsentResponse
 }
 
 func (r *SetIfAbsentRequest) cacheName() string { return r.CacheName }
@@ -79,23 +78,14 @@ func (r *SetIfAbsentRequest) makeGrpcRequest(grpcRequest interface{}, requestMet
 	return resp, nil, nil
 }
 
-func (r *SetIfAbsentRequest) interpretGrpcResponse(resp interface{}) error {
+func (r *SetIfAbsentRequest) interpretGrpcResponse(resp interface{}) (interface{}, error) {
 	myResp := resp.(*pb.XSetIfResponse)
 	switch myResp.Result.(type) {
 	case *pb.XSetIfResponse_Stored:
-		r.response = &responses.SetIfAbsentStored{}
+		return &responses.SetIfAbsentStored{}, nil
 	case *pb.XSetIfResponse_NotStored:
-		r.response = &responses.SetIfAbsentNotStored{}
+		return &responses.SetIfAbsentNotStored{}, nil
 	default:
-		return errUnexpectedGrpcResponse(r, myResp)
+		return nil, errUnexpectedGrpcResponse(r, myResp)
 	}
-	return nil
-}
-
-func (r *SetIfAbsentRequest) validateResponseType(resp grpcResponse) error {
-	_, ok := resp.(*pb.XSetIfResponse)
-	if !ok {
-		return errUnexpectedGrpcResponse(nil, resp)
-	}
-	return nil
 }

--- a/momento/set_if_absent_or_equal.go
+++ b/momento/set_if_absent_or_equal.go
@@ -24,7 +24,6 @@ type SetIfAbsentOrEqualRequest struct {
 	// If not provided, then default TTL for the cache client instance is used.
 	Ttl time.Duration
 
-	response responses.SetIfAbsentOrEqualResponse
 }
 
 func (r *SetIfAbsentOrEqualRequest) cacheName() string { return r.CacheName }
@@ -87,24 +86,15 @@ func (r *SetIfAbsentOrEqualRequest) makeGrpcRequest(grpcRequest interface{}, req
 	return resp, nil, nil
 }
 
-func (r *SetIfAbsentOrEqualRequest) interpretGrpcResponse(resp interface{}) error {
+func (r *SetIfAbsentOrEqualRequest) interpretGrpcResponse(resp interface{}) (interface{}, error) {
 	myResp := resp.(*pb.XSetIfResponse)
 
 	switch myResp.Result.(type) {
 	case *pb.XSetIfResponse_Stored:
-		r.response = &responses.SetIfAbsentOrEqualStored{}
+		return &responses.SetIfAbsentOrEqualStored{}, nil
 	case *pb.XSetIfResponse_NotStored:
-		r.response = &responses.SetIfAbsentOrEqualNotStored{}
+		return &responses.SetIfAbsentOrEqualNotStored{}, nil
 	default:
-		return errUnexpectedGrpcResponse(r, myResp)
+		return nil, errUnexpectedGrpcResponse(r, myResp)
 	}
-	return nil
-}
-
-func (r *SetIfAbsentOrEqualRequest) validateResponseType(resp grpcResponse) error {
-	_, ok := resp.(*pb.XSetIfResponse)
-	if !ok {
-		return errUnexpectedGrpcResponse(nil, resp)
-	}
-	return nil
 }

--- a/momento/set_if_absent_or_equal.go
+++ b/momento/set_if_absent_or_equal.go
@@ -23,7 +23,6 @@ type SetIfAbsentOrEqualRequest struct {
 	// Optional Time to live in cache in seconds.
 	// If not provided, then default TTL for the cache client instance is used.
 	Ttl time.Duration
-
 }
 
 func (r *SetIfAbsentOrEqualRequest) cacheName() string { return r.CacheName }

--- a/momento/set_if_equal.go
+++ b/momento/set_if_equal.go
@@ -23,7 +23,6 @@ type SetIfEqualRequest struct {
 	// Optional Time to live in cache in seconds.
 	// If not provided, then default TTL for the cache client instance is used.
 	Ttl time.Duration
-
 }
 
 func (r *SetIfEqualRequest) cacheName() string { return r.CacheName }

--- a/momento/set_if_equal.go
+++ b/momento/set_if_equal.go
@@ -24,7 +24,6 @@ type SetIfEqualRequest struct {
 	// If not provided, then default TTL for the cache client instance is used.
 	Ttl time.Duration
 
-	response responses.SetIfEqualResponse
 }
 
 func (r *SetIfEqualRequest) cacheName() string { return r.CacheName }
@@ -87,23 +86,14 @@ func (r *SetIfEqualRequest) makeGrpcRequest(grpcRequest interface{}, requestMeta
 	return resp, nil, nil
 }
 
-func (r *SetIfEqualRequest) interpretGrpcResponse(resp interface{}) error {
+func (r *SetIfEqualRequest) interpretGrpcResponse(resp interface{}) (interface{}, error) {
 	myResp := resp.(*pb.XSetIfResponse)
 	switch myResp.Result.(type) {
 	case *pb.XSetIfResponse_Stored:
-		r.response = &responses.SetIfEqualStored{}
+		return &responses.SetIfEqualStored{}, nil
 	case *pb.XSetIfResponse_NotStored:
-		r.response = &responses.SetIfEqualNotStored{}
+		return &responses.SetIfEqualNotStored{}, nil
 	default:
-		return errUnexpectedGrpcResponse(r, myResp)
+		return nil, errUnexpectedGrpcResponse(r, myResp)
 	}
-	return nil
-}
-
-func (r *SetIfEqualRequest) validateResponseType(resp grpcResponse) error {
-	_, ok := resp.(*pb.XSetIfResponse)
-	if !ok {
-		return errUnexpectedGrpcResponse(nil, resp)
-	}
-	return nil
 }

--- a/momento/set_if_not_equal.go
+++ b/momento/set_if_not_equal.go
@@ -23,7 +23,6 @@ type SetIfNotEqualRequest struct {
 	// Optional Time to live in cache in seconds.
 	// If not provided, then default TTL for the cache client instance is used.
 	Ttl time.Duration
-
 }
 
 func (r *SetIfNotEqualRequest) cacheName() string { return r.CacheName }

--- a/momento/set_if_not_equal.go
+++ b/momento/set_if_not_equal.go
@@ -24,7 +24,6 @@ type SetIfNotEqualRequest struct {
 	// If not provided, then default TTL for the cache client instance is used.
 	Ttl time.Duration
 
-	response responses.SetIfNotEqualResponse
 }
 
 func (r *SetIfNotEqualRequest) cacheName() string { return r.CacheName }
@@ -87,25 +86,15 @@ func (r *SetIfNotEqualRequest) makeGrpcRequest(grpcRequest interface{}, requestM
 	return resp, nil, nil
 }
 
-func (r *SetIfNotEqualRequest) interpretGrpcResponse(resp interface{}) error {
+func (r *SetIfNotEqualRequest) interpretGrpcResponse(resp interface{}) (interface{}, error) {
 	myResp := resp.(*pb.XSetIfResponse)
 
 	switch myResp.Result.(type) {
 	case *pb.XSetIfResponse_Stored:
-		r.response = &responses.SetIfNotEqualStored{}
+		return &responses.SetIfNotEqualStored{}, nil
 	case *pb.XSetIfResponse_NotStored:
-		r.response = &responses.SetIfNotEqualNotStored{}
+		return &responses.SetIfNotEqualNotStored{}, nil
 	default:
-		return errUnexpectedGrpcResponse(r, myResp)
+		return nil, errUnexpectedGrpcResponse(r, myResp)
 	}
-
-	return nil
-}
-
-func (r *SetIfNotEqualRequest) validateResponseType(resp grpcResponse) error {
-	_, ok := resp.(*pb.XSetIfResponse)
-	if !ok {
-		return errUnexpectedGrpcResponse(nil, resp)
-	}
-	return nil
 }

--- a/momento/set_if_not_exists.go
+++ b/momento/set_if_not_exists.go
@@ -21,7 +21,6 @@ type SetIfNotExistsRequest struct {
 	// Optional Time to live in cache in seconds.
 	// If not provided, then default TTL for the cache client instance is used.
 	Ttl time.Duration
-
 }
 
 func (r *SetIfNotExistsRequest) cacheName() string { return r.CacheName }

--- a/momento/set_if_not_exists.go
+++ b/momento/set_if_not_exists.go
@@ -22,7 +22,6 @@ type SetIfNotExistsRequest struct {
 	// If not provided, then default TTL for the cache client instance is used.
 	Ttl time.Duration
 
-	response responses.SetIfNotExistsResponse
 }
 
 func (r *SetIfNotExistsRequest) cacheName() string { return r.CacheName }
@@ -76,24 +75,15 @@ func (r *SetIfNotExistsRequest) makeGrpcRequest(grpcRequest interface{}, request
 	return resp, nil, nil
 }
 
-func (r *SetIfNotExistsRequest) interpretGrpcResponse(resp interface{}) error {
+func (r *SetIfNotExistsRequest) interpretGrpcResponse(resp interface{}) (interface{}, error) {
 	myResp := resp.(*pb.XSetIfResponse)
 
 	switch myResp.Result.(type) {
 	case *pb.XSetIfResponse_Stored:
-		r.response = &responses.SetIfNotExistsStored{}
+		return &responses.SetIfNotExistsStored{}, nil
 	case *pb.XSetIfResponse_NotStored:
-		r.response = &responses.SetIfNotExistsNotStored{}
+		return &responses.SetIfNotExistsNotStored{}, nil
 	default:
-		return errUnexpectedGrpcResponse(r, myResp)
+		return nil, errUnexpectedGrpcResponse(r, myResp)
 	}
-	return nil
-}
-
-func (r *SetIfNotExistsRequest) validateResponseType(resp grpcResponse) error {
-	_, ok := resp.(*pb.XSetIfResponse)
-	if !ok {
-		return errUnexpectedGrpcResponse(nil, resp)
-	}
-	return nil
 }

--- a/momento/set_if_present.go
+++ b/momento/set_if_present.go
@@ -22,7 +22,6 @@ type SetIfPresentRequest struct {
 	// If not provided, then default TTL for the cache client instance is used.
 	Ttl time.Duration
 
-	response responses.SetIfPresentResponse
 }
 
 func (r *SetIfPresentRequest) cacheName() string { return r.CacheName }
@@ -72,23 +71,14 @@ func (r *SetIfPresentRequest) makeGrpcRequest(grpcRequest interface{}, requestMe
 	return resp, nil, nil
 }
 
-func (r *SetIfPresentRequest) interpretGrpcResponse(resp interface{}) error {
+func (r *SetIfPresentRequest) interpretGrpcResponse(resp interface{}) (interface{}, error) {
 	myResp := resp.(*pb.XSetIfResponse)
 	switch myResp.Result.(type) {
 	case *pb.XSetIfResponse_Stored:
-		r.response = &responses.SetIfPresentStored{}
+		return &responses.SetIfPresentStored{}, nil
 	case *pb.XSetIfResponse_NotStored:
-		r.response = &responses.SetIfPresentNotStored{}
+		return &responses.SetIfPresentNotStored{}, nil
 	default:
-		return errUnexpectedGrpcResponse(r, myResp)
+		return nil, errUnexpectedGrpcResponse(r, myResp)
 	}
-	return nil
-}
-
-func (r *SetIfPresentRequest) validateResponseType(resp grpcResponse) error {
-	_, ok := resp.(*pb.XSetIfResponse)
-	if !ok {
-		return errUnexpectedGrpcResponse(nil, resp)
-	}
-	return nil
 }

--- a/momento/set_if_present.go
+++ b/momento/set_if_present.go
@@ -21,7 +21,6 @@ type SetIfPresentRequest struct {
 	// Optional Time to live in cache in seconds.
 	// If not provided, then default TTL for the cache client instance is used.
 	Ttl time.Duration
-
 }
 
 func (r *SetIfPresentRequest) cacheName() string { return r.CacheName }

--- a/momento/set_if_present_and_not_equal.go
+++ b/momento/set_if_present_and_not_equal.go
@@ -24,7 +24,6 @@ type SetIfPresentAndNotEqualRequest struct {
 	// If not provided, then default TTL for the cache client instance is used.
 	Ttl time.Duration
 
-	response responses.SetIfPresentAndNotEqualResponse
 }
 
 func (r *SetIfPresentAndNotEqualRequest) cacheName() string { return r.CacheName }
@@ -87,23 +86,14 @@ func (r *SetIfPresentAndNotEqualRequest) makeGrpcRequest(grpcRequest interface{}
 	return resp, nil, nil
 }
 
-func (r *SetIfPresentAndNotEqualRequest) interpretGrpcResponse(resp interface{}) error {
+func (r *SetIfPresentAndNotEqualRequest) interpretGrpcResponse(resp interface{}) (interface{}, error) {
 	myResp := resp.(*pb.XSetIfResponse)
 	switch myResp.Result.(type) {
 	case *pb.XSetIfResponse_Stored:
-		r.response = &responses.SetIfPresentAndNotEqualStored{}
+		return &responses.SetIfPresentAndNotEqualStored{}, nil
 	case *pb.XSetIfResponse_NotStored:
-		r.response = &responses.SetIfPresentAndNotEqualNotStored{}
+		return &responses.SetIfPresentAndNotEqualNotStored{}, nil
 	default:
-		return errUnexpectedGrpcResponse(r, myResp)
+		return nil, errUnexpectedGrpcResponse(r, myResp)
 	}
-	return nil
-}
-
-func (r *SetIfPresentAndNotEqualRequest) validateResponseType(resp grpcResponse) error {
-	_, ok := resp.(*pb.XSetIfResponse)
-	if !ok {
-		return errUnexpectedGrpcResponse(nil, resp)
-	}
-	return nil
 }

--- a/momento/set_if_present_and_not_equal.go
+++ b/momento/set_if_present_and_not_equal.go
@@ -23,7 +23,6 @@ type SetIfPresentAndNotEqualRequest struct {
 	// Optional Time to live in cache in seconds.
 	// If not provided, then default TTL for the cache client instance is used.
 	Ttl time.Duration
-
 }
 
 func (r *SetIfPresentAndNotEqualRequest) cacheName() string { return r.CacheName }

--- a/momento/set_length.go
+++ b/momento/set_length.go
@@ -14,7 +14,6 @@ type SetLengthRequest struct {
 	CacheName string
 	SetName   string
 
-	response responses.SetLengthResponse
 }
 
 func (r *SetLengthRequest) cacheName() string { return r.CacheName }
@@ -43,23 +42,14 @@ func (r *SetLengthRequest) makeGrpcRequest(grpcRequest interface{}, requestMetad
 	return resp, nil, nil
 }
 
-func (r *SetLengthRequest) interpretGrpcResponse(resp interface{}) error {
+func (r *SetLengthRequest) interpretGrpcResponse(resp interface{}) (interface{}, error) {
 	myResp := resp.(*pb.XSetLengthResponse)
 	switch rtype := myResp.Set.(type) {
 	case *pb.XSetLengthResponse_Found:
-		r.response = responses.NewSetLengthHit(rtype.Found.Length)
+		return responses.NewSetLengthHit(rtype.Found.Length), nil
 	case *pb.XSetLengthResponse_Missing:
-		r.response = &responses.SetLengthMiss{}
+		return &responses.SetLengthMiss{}, nil
 	default:
-		return errUnexpectedGrpcResponse(r, myResp)
+		return nil, errUnexpectedGrpcResponse(r, myResp)
 	}
-	return nil
-}
-
-func (r *SetLengthRequest) validateResponseType(resp grpcResponse) error {
-	_, ok := resp.(*pb.XSetLengthResponse)
-	if !ok {
-		return errUnexpectedGrpcResponse(nil, resp)
-	}
-	return nil
 }

--- a/momento/set_length.go
+++ b/momento/set_length.go
@@ -13,7 +13,6 @@ import (
 type SetLengthRequest struct {
 	CacheName string
 	SetName   string
-
 }
 
 func (r *SetLengthRequest) cacheName() string { return r.CacheName }

--- a/momento/set_pop.go
+++ b/momento/set_pop.go
@@ -14,7 +14,6 @@ type SetPopRequest struct {
 	CacheName string
 	SetName   string
 	Count     *uint32
-
 }
 
 func (r *SetPopRequest) cacheName() string { return r.CacheName }

--- a/momento/set_pop.go
+++ b/momento/set_pop.go
@@ -15,7 +15,6 @@ type SetPopRequest struct {
 	SetName   string
 	Count     *uint32
 
-	response responses.SetPopResponse
 }
 
 func (r *SetPopRequest) cacheName() string { return r.CacheName }
@@ -52,23 +51,14 @@ func (r *SetPopRequest) makeGrpcRequest(grpcRequest interface{}, requestMetadata
 	return resp, nil, nil
 }
 
-func (r *SetPopRequest) interpretGrpcResponse(resp interface{}) error {
+func (r *SetPopRequest) interpretGrpcResponse(resp interface{}) (interface{}, error) {
 	myResp := resp.(*pb.XSetPopResponse)
 	switch rtype := myResp.Set.(type) {
 	case *pb.XSetPopResponse_Found:
-		r.response = responses.NewSetPopHit(rtype.Found.Elements)
+		return responses.NewSetPopHit(rtype.Found.Elements), nil
 	case *pb.XSetPopResponse_Missing:
-		r.response = &responses.SetPopMiss{}
+		return &responses.SetPopMiss{}, nil
 	default:
-		return errUnexpectedGrpcResponse(r, myResp)
+		return nil, errUnexpectedGrpcResponse(r, myResp)
 	}
-	return nil
-}
-
-func (r *SetPopRequest) validateResponseType(resp grpcResponse) error {
-	_, ok := resp.(*pb.XSetPopResponse)
-	if !ok {
-		return errUnexpectedGrpcResponse(nil, resp)
-	}
-	return nil
 }

--- a/momento/set_remove_elements.go
+++ b/momento/set_remove_elements.go
@@ -15,7 +15,6 @@ type SetRemoveElementsRequest struct {
 	SetName   string
 	Elements  []Value
 
-	response responses.SetRemoveElementsResponse
 }
 
 func (r *SetRemoveElementsRequest) cacheName() string { return r.CacheName }
@@ -60,15 +59,6 @@ func (r *SetRemoveElementsRequest) makeGrpcRequest(grpcRequest interface{}, requ
 	return resp, nil, nil
 }
 
-func (r *SetRemoveElementsRequest) interpretGrpcResponse(_ interface{}) error {
-	r.response = &responses.SetRemoveElementsSuccess{}
-	return nil
-}
-
-func (r *SetRemoveElementsRequest) validateResponseType(resp grpcResponse) error {
-	_, ok := resp.(*pb.XSetDifferenceResponse)
-	if !ok {
-		return errUnexpectedGrpcResponse(nil, resp)
-	}
-	return nil
+func (r *SetRemoveElementsRequest) interpretGrpcResponse(_ interface{}) (interface{}, error) {
+	return &responses.SetRemoveElementsSuccess{}, nil
 }

--- a/momento/set_remove_elements.go
+++ b/momento/set_remove_elements.go
@@ -14,7 +14,6 @@ type SetRemoveElementsRequest struct {
 	CacheName string
 	SetName   string
 	Elements  []Value
-
 }
 
 func (r *SetRemoveElementsRequest) cacheName() string { return r.CacheName }

--- a/momento/sorted_set_fetch_by_rank.go
+++ b/momento/sorted_set_fetch_by_rank.go
@@ -16,7 +16,6 @@ type SortedSetFetchByRankRequest struct {
 	Order     SortedSetOrder
 	StartRank *int32
 	EndRank   *int32
-
 }
 
 func (r *SortedSetFetchByRankRequest) cacheName() string { return r.CacheName }

--- a/momento/sorted_set_fetch_by_rank.go
+++ b/momento/sorted_set_fetch_by_rank.go
@@ -17,7 +17,6 @@ type SortedSetFetchByRankRequest struct {
 	StartRank *int32
 	EndRank   *int32
 
-	response responses.SortedSetFetchResponse
 }
 
 func (r *SortedSetFetchByRankRequest) cacheName() string { return r.CacheName }
@@ -78,17 +77,16 @@ func (r *SortedSetFetchByRankRequest) makeGrpcRequest(grpcRequest interface{}, r
 	return resp, nil, nil
 }
 
-func (r *SortedSetFetchByRankRequest) interpretGrpcResponse(resp interface{}) error {
+func (r *SortedSetFetchByRankRequest) interpretGrpcResponse(resp interface{}) (interface{}, error) {
 	myResp := resp.(*pb.XSortedSetFetchResponse)
 	switch grpcResp := myResp.SortedSet.(type) {
 	case *pb.XSortedSetFetchResponse_Found:
-		r.response = responses.NewSortedSetFetchHit(sortedSetByRankGrpcElementToModel(grpcResp.Found.GetValuesWithScores().Elements))
+		return responses.NewSortedSetFetchHit(sortedSetByRankGrpcElementToModel(grpcResp.Found.GetValuesWithScores().Elements)), nil
 	case *pb.XSortedSetFetchResponse_Missing:
-		r.response = &responses.SortedSetFetchMiss{}
+		return &responses.SortedSetFetchMiss{}, nil
 	default:
-		return errUnexpectedGrpcResponse(r, myResp)
+		return nil, errUnexpectedGrpcResponse(r, myResp)
 	}
-	return nil
 }
 
 func sortedSetByRankGrpcElementToModel(grpcSetElements []*pb.XSortedSetElement) []responses.SortedSetBytesElement {
@@ -100,12 +98,4 @@ func sortedSetByRankGrpcElementToModel(grpcSetElements []*pb.XSortedSetElement) 
 		})
 	}
 	return returnList
-}
-
-func (r *SortedSetFetchByRankRequest) validateResponseType(resp grpcResponse) error {
-	_, ok := resp.(*pb.XSortedSetFetchResponse)
-	if !ok {
-		return errUnexpectedGrpcResponse(nil, resp)
-	}
-	return nil
 }

--- a/momento/sorted_set_fetch_by_score.go
+++ b/momento/sorted_set_fetch_by_score.go
@@ -18,7 +18,6 @@ type SortedSetFetchByScoreRequest struct {
 	MaxScore  *float64
 	Offset    *uint32
 	Count     *uint32
-
 }
 
 func (r *SortedSetFetchByScoreRequest) cacheName() string { return r.CacheName }

--- a/momento/sorted_set_get_rank.go
+++ b/momento/sorted_set_get_rank.go
@@ -15,7 +15,6 @@ type SortedSetGetRankRequest struct {
 	SetName   string
 	Value     Value
 	Order     SortedSetOrder
-
 }
 
 func (r *SortedSetGetRankRequest) cacheName() string { return r.CacheName }

--- a/momento/sorted_set_get_rank.go
+++ b/momento/sorted_set_get_rank.go
@@ -16,7 +16,6 @@ type SortedSetGetRankRequest struct {
 	Value     Value
 	Order     SortedSetOrder
 
-	response responses.SortedSetGetRankResponse
 }
 
 func (r *SortedSetGetRankRequest) cacheName() string { return r.CacheName }
@@ -55,30 +54,21 @@ func (r *SortedSetGetRankRequest) makeGrpcRequest(grpcRequest interface{}, reque
 	return resp, nil, nil
 }
 
-func (r *SortedSetGetRankRequest) interpretGrpcResponse(resp interface{}) error {
+func (r *SortedSetGetRankRequest) interpretGrpcResponse(resp interface{}) (interface{}, error) {
 	myResp := resp.(*pb.XSortedSetGetRankResponse)
 	switch rank := myResp.Rank.(type) {
 	case *pb.XSortedSetGetRankResponse_ElementRank:
 		switch rank.ElementRank.Result {
 		case pb.ECacheResult_Hit:
-			r.response = responses.SortedSetGetRankHit(rank.ElementRank.Rank)
+			return responses.SortedSetGetRankHit(rank.ElementRank.Rank), nil
 		case pb.ECacheResult_Miss:
-			r.response = &responses.SortedSetGetRankMiss{}
+			return &responses.SortedSetGetRankMiss{}, nil
 		default:
-			return errUnexpectedGrpcResponse(r, myResp)
+			return nil, errUnexpectedGrpcResponse(r, myResp)
 		}
 	case *pb.XSortedSetGetRankResponse_Missing:
-		r.response = &responses.SortedSetGetRankMiss{}
+		return &responses.SortedSetGetRankMiss{}, nil
 	default:
-		return errUnexpectedGrpcResponse(r, myResp)
+		return nil, errUnexpectedGrpcResponse(r, myResp)
 	}
-	return nil
-}
-
-func (r *SortedSetGetRankRequest) validateResponseType(resp grpcResponse) error {
-	_, ok := resp.(*pb.XSortedSetGetRankResponse)
-	if !ok {
-		return errUnexpectedGrpcResponse(nil, resp)
-	}
-	return nil
 }

--- a/momento/sorted_set_get_scores.go
+++ b/momento/sorted_set_get_scores.go
@@ -55,21 +55,19 @@ func (r *SortedSetGetScoresRequest) makeGrpcRequest(grpcRequest interface{}, req
 	return resp, nil, nil
 }
 
-func (r *SortedSetGetScoresRequest) interpretGrpcResponse(resp interface{}) error {
+func (r *SortedSetGetScoresRequest) interpretGrpcResponse(resp interface{}) (interface{}, error) {
 	r.grpcResponse = resp.(*pb.XSortedSetGetScoreResponse)
 	switch t := r.grpcResponse.SortedSet.(type) {
 	case *pb.XSortedSetGetScoreResponse_Found:
-		r.response = responses.NewSortedSetGetScoresHit(
+		return responses.NewSortedSetGetScoresHit(
 			convertSortedSetScoreElement(t.Found.Elements),
 			r.grpcRequest.Values,
-		)
+		), nil
 	case *pb.XSortedSetGetScoreResponse_Missing:
-		r.response = &responses.SortedSetGetScoresMiss{}
+		return &responses.SortedSetGetScoresMiss{}, nil
 	default:
-		return errUnexpectedGrpcResponse(r, r.grpcResponse)
+		return nil, errUnexpectedGrpcResponse(r, r.grpcResponse)
 	}
-
-	return nil
 }
 
 func convertSortedSetScoreElement(grpcSetElements []*pb.XSortedSetGetScoreResponse_XSortedSetGetScoreResponsePart) []responses.SortedSetGetScoreResponse {
@@ -85,12 +83,4 @@ func convertSortedSetScoreElement(grpcSetElements []*pb.XSortedSetGetScoreRespon
 		}
 	}
 	return rList
-}
-
-func (r *SortedSetGetScoresRequest) validateResponseType(resp grpcResponse) error {
-	_, ok := resp.(*pb.XSortedSetGetScoreResponse)
-	if !ok {
-		return errUnexpectedGrpcResponse(nil, resp)
-	}
-	return nil
 }

--- a/momento/sorted_set_get_scores.go
+++ b/momento/sorted_set_get_scores.go
@@ -17,7 +17,6 @@ type SortedSetGetScoresRequest struct {
 
 	grpcResponse *pb.XSortedSetGetScoreResponse
 	grpcRequest  *pb.XSortedSetGetScoreRequest
-	response     responses.SortedSetGetScoresResponse
 }
 
 func (r *SortedSetGetScoresRequest) cacheName() string { return r.CacheName }

--- a/momento/sorted_set_increment_score.go
+++ b/momento/sorted_set_increment_score.go
@@ -22,7 +22,6 @@ type SortedSetIncrementScoreRequest struct {
 	Amount    float64
 	Ttl       *utils.CollectionTtl
 
-	response responses.SortedSetIncrementScoreResponse
 }
 
 func (r *SortedSetIncrementScoreRequest) cacheName() string { return r.CacheName }
@@ -81,17 +80,7 @@ func (r *SortedSetIncrementScoreRequest) makeGrpcRequest(grpcRequest interface{}
 	return resp, nil, nil
 }
 
-func (r *SortedSetIncrementScoreRequest) interpretGrpcResponse(resp interface{}) error {
+func (r *SortedSetIncrementScoreRequest) interpretGrpcResponse(resp interface{}) (interface{}, error) {
 	myResp := resp.(*pb.XSortedSetIncrementResponse)
-	r.response = responses.SortedSetIncrementScoreSuccess(myResp.Score)
-
-	return nil
-}
-
-func (r *SortedSetIncrementScoreRequest) validateResponseType(resp grpcResponse) error {
-	_, ok := resp.(*pb.XSortedSetIncrementResponse)
-	if !ok {
-		return errUnexpectedGrpcResponse(nil, resp)
-	}
-	return nil
+	return responses.SortedSetIncrementScoreSuccess(myResp.Score), nil
 }

--- a/momento/sorted_set_increment_score.go
+++ b/momento/sorted_set_increment_score.go
@@ -21,7 +21,6 @@ type SortedSetIncrementScoreRequest struct {
 	Value     Value
 	Amount    float64
 	Ttl       *utils.CollectionTtl
-
 }
 
 func (r *SortedSetIncrementScoreRequest) cacheName() string { return r.CacheName }

--- a/momento/sorted_set_length.go
+++ b/momento/sorted_set_length.go
@@ -14,7 +14,6 @@ type SortedSetLengthRequest struct {
 	CacheName string
 	SetName   string
 
-	response responses.SortedSetLengthResponse
 }
 
 func (r *SortedSetLengthRequest) cacheName() string { return r.CacheName }
@@ -43,23 +42,14 @@ func (r *SortedSetLengthRequest) makeGrpcRequest(grpcRequest interface{}, reques
 	return resp, nil, nil
 }
 
-func (r *SortedSetLengthRequest) interpretGrpcResponse(resp interface{}) error {
+func (r *SortedSetLengthRequest) interpretGrpcResponse(resp interface{}) (interface{}, error) {
 	myResp := resp.(*pb.XSortedSetLengthResponse)
 	switch rtype := myResp.SortedSet.(type) {
 	case *pb.XSortedSetLengthResponse_Found:
-		r.response = responses.NewSortedSetLengthHit(rtype.Found.Length)
+		return responses.NewSortedSetLengthHit(rtype.Found.Length), nil
 	case *pb.XSortedSetLengthResponse_Missing:
-		r.response = &responses.SortedSetLengthMiss{}
+		return &responses.SortedSetLengthMiss{}, nil
 	default:
-		return errUnexpectedGrpcResponse(r, myResp)
+		return nil, errUnexpectedGrpcResponse(r, myResp)
 	}
-	return nil
-}
-
-func (r *SortedSetLengthRequest) validateResponseType(resp grpcResponse) error {
-	_, ok := resp.(*pb.XSortedSetLengthResponse)
-	if !ok {
-		return errUnexpectedGrpcResponse(nil, resp)
-	}
-	return nil
 }

--- a/momento/sorted_set_length.go
+++ b/momento/sorted_set_length.go
@@ -13,7 +13,6 @@ import (
 type SortedSetLengthRequest struct {
 	CacheName string
 	SetName   string
-
 }
 
 func (r *SortedSetLengthRequest) cacheName() string { return r.CacheName }

--- a/momento/sorted_set_length_by_score.go
+++ b/momento/sorted_set_length_by_score.go
@@ -15,7 +15,6 @@ type SortedSetLengthByScoreRequest struct {
 	SetName   string
 	MinScore  *float64
 	MaxScore  *float64
-
 }
 
 func (r *SortedSetLengthByScoreRequest) cacheName() string { return r.CacheName }

--- a/momento/sorted_set_length_by_score.go
+++ b/momento/sorted_set_length_by_score.go
@@ -16,7 +16,6 @@ type SortedSetLengthByScoreRequest struct {
 	MinScore  *float64
 	MaxScore  *float64
 
-	response responses.SortedSetLengthByScoreResponse
 }
 
 func (r *SortedSetLengthByScoreRequest) cacheName() string { return r.CacheName }
@@ -66,23 +65,14 @@ func (r *SortedSetLengthByScoreRequest) makeGrpcRequest(grpcRequest interface{},
 	return resp, nil, nil
 }
 
-func (r *SortedSetLengthByScoreRequest) interpretGrpcResponse(resp interface{}) error {
+func (r *SortedSetLengthByScoreRequest) interpretGrpcResponse(resp interface{}) (interface{}, error) {
 	myResp := resp.(*pb.XSortedSetLengthByScoreResponse)
 	switch rtype := myResp.SortedSet.(type) {
 	case *pb.XSortedSetLengthByScoreResponse_Found:
-		r.response = responses.NewSortedSetLengthByScoreHit(rtype.Found.Length)
+		return responses.NewSortedSetLengthByScoreHit(rtype.Found.Length), nil
 	case *pb.XSortedSetLengthByScoreResponse_Missing:
-		r.response = &responses.SortedSetLengthByScoreMiss{}
+		return &responses.SortedSetLengthByScoreMiss{}, nil
 	default:
-		return errUnexpectedGrpcResponse(r, myResp)
+		return nil, errUnexpectedGrpcResponse(r, myResp)
 	}
-	return nil
-}
-
-func (r *SortedSetLengthByScoreRequest) validateResponseType(resp grpcResponse) error {
-	_, ok := resp.(*pb.XSortedSetLengthByScoreResponse)
-	if !ok {
-		return errUnexpectedGrpcResponse(nil, resp)
-	}
-	return nil
 }

--- a/momento/sorted_set_put_elements.go
+++ b/momento/sorted_set_put_elements.go
@@ -19,7 +19,6 @@ type SortedSetPutElementsRequest struct {
 	Elements  []SortedSetElement
 	Ttl       *utils.CollectionTtl
 
-	response responses.SortedSetPutElementsResponse
 }
 
 func (r *SortedSetPutElementsRequest) cacheName() string { return r.CacheName }
@@ -67,9 +66,8 @@ func (r *SortedSetPutElementsRequest) makeGrpcRequest(grpcRequest interface{}, r
 	return resp, nil, nil
 }
 
-func (r *SortedSetPutElementsRequest) interpretGrpcResponse(_ interface{}) error {
-	r.response = &responses.SortedSetPutElementsSuccess{}
-	return nil
+func (r *SortedSetPutElementsRequest) interpretGrpcResponse(_ interface{}) (interface{}, error) {
+	return &responses.SortedSetPutElementsSuccess{}, nil
 }
 
 func convertSortedSetElementsToGrpc(modelSetElements []SortedSetElement) ([]*pb.XSortedSetElement, error) {
@@ -91,12 +89,4 @@ func convertSortedSetElementsToGrpc(modelSetElements []SortedSetElement) ([]*pb.
 		})
 	}
 	return returnList, nil
-}
-
-func (r *SortedSetPutElementsRequest) validateResponseType(resp grpcResponse) error {
-	_, ok := resp.(*pb.XSortedSetPutResponse)
-	if !ok {
-		return errUnexpectedGrpcResponse(nil, resp)
-	}
-	return nil
 }

--- a/momento/sorted_set_put_elements.go
+++ b/momento/sorted_set_put_elements.go
@@ -18,7 +18,6 @@ type SortedSetPutElementsRequest struct {
 	SetName   string
 	Elements  []SortedSetElement
 	Ttl       *utils.CollectionTtl
-
 }
 
 func (r *SortedSetPutElementsRequest) cacheName() string { return r.CacheName }

--- a/momento/sorted_set_remove_elements.go
+++ b/momento/sorted_set_remove_elements.go
@@ -15,7 +15,6 @@ type SortedSetRemoveElementsRequest struct {
 	SetName   string
 	Values    []Value
 
-	response responses.SortedSetRemoveElementsResponse
 }
 
 func (r *SortedSetRemoveElementsRequest) cacheName() string { return r.CacheName }
@@ -56,15 +55,6 @@ func (r *SortedSetRemoveElementsRequest) makeGrpcRequest(grpcRequest interface{}
 	return resp, nil, nil
 }
 
-func (r *SortedSetRemoveElementsRequest) interpretGrpcResponse(_ interface{}) error {
-	r.response = &responses.SortedSetRemoveElementsSuccess{}
-	return nil
-}
-
-func (r *SortedSetRemoveElementsRequest) validateResponseType(resp grpcResponse) error {
-	_, ok := resp.(*pb.XSortedSetRemoveResponse)
-	if !ok {
-		return errUnexpectedGrpcResponse(nil, resp)
-	}
-	return nil
+func (r *SortedSetRemoveElementsRequest) interpretGrpcResponse(_ interface{}) (interface{}, error) {
+	return &responses.SortedSetRemoveElementsSuccess{}, nil
 }

--- a/momento/sorted_set_remove_elements.go
+++ b/momento/sorted_set_remove_elements.go
@@ -14,7 +14,6 @@ type SortedSetRemoveElementsRequest struct {
 	CacheName string
 	SetName   string
 	Values    []Value
-
 }
 
 func (r *SortedSetRemoveElementsRequest) cacheName() string { return r.CacheName }

--- a/momento/test_helpers/momento_local_middleware.go
+++ b/momento/test_helpers/momento_local_middleware.go
@@ -53,6 +53,7 @@ func (r *retryMetrics) GetTotalRetryCount(cacheName string, requestName string) 
 }
 
 // GetAverageTimeBetweenRetries returns the average time between retries in seconds.
+//
 //	Limited to second resolution, but I can obviously change that if desired.
 //	This tracks with the JS implementation.
 func (r *retryMetrics) GetAverageTimeBetweenRetries(cacheName string, requestName string) (int64, error) {
@@ -129,13 +130,14 @@ func (r *momentoLocalMiddleware) listenForMetrics(metricsChan chan *timestampPay
 		if msg == nil {
 			return
 		}
-		// All requests are prefixed with "/cache_client.Scs/", so we cut that off
-		parsedRequest, ok := strings.CutPrefix(msg.requestName, "/cache_client.Scs/")
-		if !ok {
+		// All requests are prefixed with "/cache_client.Scs/", so we cut that off.
+		parts := strings.Split(msg.requestName, "/")
+		if len(parts) < 2 {
 			// Because this middleware is for test use only, we can panic here.
 			panic(fmt.Sprintf("Could not parse request name %s", msg.requestName))
 		}
-		r.metricsCollector.AddTimestamp(msg.cacheName, parsedRequest, msg.timestamp)
+		shortRequestName := parts[2]
+		r.metricsCollector.AddTimestamp(msg.cacheName, shortRequestName, msg.timestamp)
 	}
 }
 

--- a/momento/update_ttl.go
+++ b/momento/update_ttl.go
@@ -18,7 +18,6 @@ type UpdateTtlRequest struct {
 	// Time to live that you want to update in cache in seconds.
 	Ttl time.Duration
 
-	response responses.UpdateTtlResponse
 }
 
 func (r *UpdateTtlRequest) cacheName() string { return r.CacheName }
@@ -56,24 +55,15 @@ func (r *UpdateTtlRequest) makeGrpcRequest(grpcRequest interface{}, requestMetad
 	return resp, nil, nil
 }
 
-func (r *UpdateTtlRequest) interpretGrpcResponse(resp interface{}) error {
+func (r *UpdateTtlRequest) interpretGrpcResponse(resp interface{}) (interface{}, error) {
 	myResp := resp.(*pb.XUpdateTtlResponse)
 
 	switch myResp.Result.(type) {
 	case *pb.XUpdateTtlResponse_Missing:
-		r.response = &responses.UpdateTtlMiss{}
+		return &responses.UpdateTtlMiss{}, nil
 	case *pb.XUpdateTtlResponse_Set:
-		r.response = &responses.UpdateTtlSet{}
+		return &responses.UpdateTtlSet{}, nil
 	default:
-		return errUnexpectedGrpcResponse(r, myResp)
+		return nil, errUnexpectedGrpcResponse(r, myResp)
 	}
-	return nil
-}
-
-func (r *UpdateTtlRequest) validateResponseType(resp grpcResponse) error {
-	_, ok := resp.(*pb.XUpdateTtlResponse)
-	if !ok {
-		return errUnexpectedGrpcResponse(nil, resp)
-	}
-	return nil
 }

--- a/momento/update_ttl.go
+++ b/momento/update_ttl.go
@@ -17,7 +17,6 @@ type UpdateTtlRequest struct {
 	Key Key
 	// Time to live that you want to update in cache in seconds.
 	Ttl time.Duration
-
 }
 
 func (r *UpdateTtlRequest) cacheName() string { return r.CacheName }


### PR DESCRIPTION
This commit removes the custom interceptor used to gathering timestamp data for retry testing middleware. It instead adds an optional function parameter to the existing `interceptor.AddUnaryRetryInterceptor` function. Whereas the old interceptor gathered retry timestamp data and used custom response types to return that data to the middleware, the improved setup uses an optional callback in the interceptor to write timestamp data to a channel that is read by a goroutine started when the middleware is constructed. This allows us to use the same interceptor in production and under test without compromising performance in production and ensuring that test and production interceptor behavior won't drift.

Removing the custom error types that needed to be processed in `OnResponse` also allowed the removal of any and all potential error handling from `OnResponse` handlers, which gets rid of a potential point of fragility and confusion for authors of middleware.

This commit also fixes the response handling portion of the middleware layer (and removes the last bit of unnecessary state from the `requester` objects) by returning Momento responses from `interpretGrpcResponse` instead of locking them away in a `requester`. This allows the handing Momento responses instead of gRPC responses to the `OnResponse` handlers, as was intended from the beginning.

This commit also makes the middleware responsible for constructing its own metrics collector instead of requiring users to pass in a metrics collector to the middleware, which was non-optimal.