### PR TITLE
feat: add FixedTimeoutRetryStrategy and tests

### DIFF
--- a/config/retry/exponential_backoff_retry_strategy.go
+++ b/config/retry/exponential_backoff_retry_strategy.go
@@ -111,6 +111,10 @@ func (r *exponentialBackoffRetryStrategy) WithGrowthFactor(growthFactor int) Str
 	}
 }
 
+func (r *exponentialBackoffRetryStrategy) GetResponseDataReceivedTimeoutMillis() *int {
+	return nil
+}
+
 func (r *exponentialBackoffRetryStrategy) DetermineWhenToRetry(props StrategyProps) *int {
 	// attempt is 0-based, so we subtract 1 to get the correct attempt number
 	attempt := props.AttemptNumber - 1

--- a/config/retry/exponential_backoff_retry_strategy.go
+++ b/config/retry/exponential_backoff_retry_strategy.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"math"
 	"math/rand"
+	"time"
 
 	"github.com/momentohq/client-sdk-go/config/logger"
 )
@@ -156,4 +157,8 @@ func randInRange(min, max int) int {
 		return min
 	}
 	return rand.Intn(max-min) + min
+}
+
+func (r *exponentialBackoffRetryStrategy) CalculateRetryDeadline(overallDeadline time.Time) *time.Time {
+	return nil
 }

--- a/config/retry/exponential_backoff_retry_strategy.go
+++ b/config/retry/exponential_backoff_retry_strategy.go
@@ -111,10 +111,6 @@ func (r *exponentialBackoffRetryStrategy) WithGrowthFactor(growthFactor int) Str
 	}
 }
 
-func (r *exponentialBackoffRetryStrategy) GetResponseDataReceivedTimeoutMillis() *int {
-	return nil
-}
-
 func (r *exponentialBackoffRetryStrategy) DetermineWhenToRetry(props StrategyProps) *int {
 	// attempt is 0-based, so we subtract 1 to get the correct attempt number
 	attempt := props.AttemptNumber - 1

--- a/config/retry/fixed_count_retry_strategy.go
+++ b/config/retry/fixed_count_retry_strategy.go
@@ -64,6 +64,10 @@ func (r *fixedCountRetryStrategy) WithEligibilityStrategy(s EligibilityStrategy)
 	}
 }
 
+func (r *fixedCountRetryStrategy) GetResponseDataReceivedTimeoutMillis() *int {
+	return nil
+}
+
 func (r *fixedCountRetryStrategy) DetermineWhenToRetry(props StrategyProps) *int {
 	if !r.eligibilityStrategy.IsEligibleForRetry(props) {
 		r.log.Debug(

--- a/config/retry/fixed_count_retry_strategy.go
+++ b/config/retry/fixed_count_retry_strategy.go
@@ -64,10 +64,6 @@ func (r *fixedCountRetryStrategy) WithEligibilityStrategy(s EligibilityStrategy)
 	}
 }
 
-func (r *fixedCountRetryStrategy) GetResponseDataReceivedTimeoutMillis() *int {
-	return nil
-}
-
 func (r *fixedCountRetryStrategy) DetermineWhenToRetry(props StrategyProps) *int {
 	if !r.eligibilityStrategy.IsEligibleForRetry(props) {
 		r.log.Debug(

--- a/config/retry/fixed_count_retry_strategy.go
+++ b/config/retry/fixed_count_retry_strategy.go
@@ -3,6 +3,7 @@ package retry
 import (
 	"fmt"
 	"strconv"
+	"time"
 
 	"github.com/momentohq/client-sdk-go/config/logger"
 )
@@ -101,4 +102,8 @@ func (r *fixedCountRetryStrategy) String() string {
 		r.maxAttempts,
 		r.log,
 	)
+}
+
+func (r *fixedCountRetryStrategy) CalculateRetryDeadline(overallDeadline time.Time) *time.Time {
+	return nil
 }

--- a/config/retry/fixed_timeout_retry_strategy.go
+++ b/config/retry/fixed_timeout_retry_strategy.go
@@ -1,0 +1,128 @@
+package retry
+
+import (
+	"fmt"
+	"math/rand"
+
+	"github.com/momentohq/client-sdk-go/config/logger"
+)
+
+const (
+	DefaultResponseDataReceivedTimeoutMillis = 1000 // 1 second default timeout for retry attempts
+	DefaultRetryDelayIntervalMillis          = 100  // Schedule retry attempt for 100ms later +/- jitter
+)
+
+type fixedTimeoutRetryStrategy struct {
+	eligibilityStrategy               EligibilityStrategy
+	log                               logger.MomentoLogger
+	responseDataReceivedTimeoutMillis int
+	retryDelayIntervalMillis          int
+}
+
+type FixedTimeoutRetryStrategy interface {
+	Strategy
+	WithResponseDataReceivedTimeoutMillis(timeout int) Strategy
+	WithRetryDelayIntervalMillis(delay int) Strategy
+	WithEligibilityStrategy(s EligibilityStrategy) Strategy
+}
+
+type FixedTimeoutRetryStrategyProps struct {
+	EligibilityStrategy               EligibilityStrategy
+	LoggerFactory                     logger.MomentoLoggerFactory
+	ResponseDataReceivedTimeoutMillis int
+	RetryDelayIntervalMillis          int
+}
+
+func NewFixedTimeoutRetryStrategy(props FixedTimeoutRetryStrategyProps) Strategy {
+	eligibilityStrategy := EligibilityStrategy(DefaultEligibilityStrategy{})
+	if props.EligibilityStrategy != nil {
+		eligibilityStrategy = props.EligibilityStrategy
+	}
+	responseDataReceivedTimeoutMillis := DefaultResponseDataReceivedTimeoutMillis
+	if props.ResponseDataReceivedTimeoutMillis != 0 {
+		responseDataReceivedTimeoutMillis = props.ResponseDataReceivedTimeoutMillis
+	}
+	retryDelayIntervalMillis := DefaultRetryDelayIntervalMillis
+	if props.RetryDelayIntervalMillis != 0 {
+		retryDelayIntervalMillis = props.RetryDelayIntervalMillis
+	}
+	var log logger.MomentoLogger
+	if props.LoggerFactory != nil {
+		log = props.LoggerFactory.GetLogger("fixed-timeout-retry-strategy")
+	} else {
+		log = logger.NewNoopMomentoLoggerFactory().GetLogger("fixed-timeout-retry-strategy")
+	}
+
+	return &fixedTimeoutRetryStrategy{
+		eligibilityStrategy:               eligibilityStrategy,
+		log:                               log,
+		responseDataReceivedTimeoutMillis: responseDataReceivedTimeoutMillis,
+		retryDelayIntervalMillis:          retryDelayIntervalMillis,
+	}
+}
+
+func (r *fixedTimeoutRetryStrategy) WithResponseDataReceivedTimeoutMillis(timeout int) Strategy {
+	return &fixedTimeoutRetryStrategy{
+		log:                               r.log,
+		eligibilityStrategy:               r.eligibilityStrategy,
+		responseDataReceivedTimeoutMillis: timeout,
+		retryDelayIntervalMillis:          r.retryDelayIntervalMillis,
+	}
+}
+
+func (r *fixedTimeoutRetryStrategy) WithRetryDelayIntervalMillis(delay int) Strategy {
+	return &fixedTimeoutRetryStrategy{
+		log:                               r.log,
+		eligibilityStrategy:               r.eligibilityStrategy,
+		responseDataReceivedTimeoutMillis: r.responseDataReceivedTimeoutMillis,
+		retryDelayIntervalMillis:          delay,
+	}
+}
+
+func (r *fixedTimeoutRetryStrategy) WithEligibilityStrategy(strategy EligibilityStrategy) Strategy {
+	return &fixedTimeoutRetryStrategy{
+		log:                               r.log,
+		eligibilityStrategy:               strategy,
+		responseDataReceivedTimeoutMillis: r.responseDataReceivedTimeoutMillis,
+		retryDelayIntervalMillis:          r.retryDelayIntervalMillis,
+	}
+}
+
+func (r *fixedTimeoutRetryStrategy) DetermineWhenToRetry(props StrategyProps) *int {
+	r.log.Debug(
+		"Determining whether request is eligible for retry; status code: %s, "+
+			"request type: %s, attemptNumber: %d",
+		props.GrpcStatusCode, props.GrpcMethod, props.AttemptNumber,
+	)
+
+	if !r.eligibilityStrategy.IsEligibleForRetry(props) {
+		r.log.Debug(
+			"Request is not retryable: [method: %s, status: %s]", props.GrpcMethod, props.GrpcStatusCode.String(),
+		)
+		return nil
+	}
+
+	timeoutWithJitter := addJitter(r.retryDelayIntervalMillis)
+
+	r.log.Debug(
+		"Determined request is retryable; retrying after %d ms: [method: %s, status: %s, attempt: %d]",
+		timeoutWithJitter,
+		props.GrpcMethod,
+		props.GrpcStatusCode.String(),
+		props.AttemptNumber,
+	)
+	return &timeoutWithJitter
+}
+
+func addJitter(whenToRetry int) int {
+	return int((0.2*rand.Float64() + 0.9) * float64(whenToRetry))
+}
+
+func (r *fixedTimeoutRetryStrategy) String() string {
+	return fmt.Sprintf(
+		"fixedTimeoutRetryStrategy{eligibilityStrategy=%v, responseDataReceivedTimeoutMillis=%v, retryDelayIntervalMillis=%v}",
+		r.eligibilityStrategy,
+		r.responseDataReceivedTimeoutMillis,
+		r.retryDelayIntervalMillis,
+	)
+}

--- a/config/retry/legacy_topic_subscription_retry_strategy.go
+++ b/config/retry/legacy_topic_subscription_retry_strategy.go
@@ -2,6 +2,7 @@ package retry
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/momentohq/client-sdk-go/config/logger"
 )
@@ -69,4 +70,8 @@ func NewLegacyTopicSubscriptionRetryStrategy(props LegacyTopicSubscriptionRetryS
 		log:     log,
 		retryMs: retryMs,
 	}
+}
+
+func (r *legacyTopicSubscriptionRetryStrategy) CalculateRetryDeadline(overallDeadline time.Time) *time.Time {
+	return nil
 }

--- a/config/retry/legacy_topic_subscription_retry_strategy.go
+++ b/config/retry/legacy_topic_subscription_retry_strategy.go
@@ -28,10 +28,6 @@ func (r *legacyTopicSubscriptionRetryStrategy) WithRetryMs(ms int) Strategy {
 	}
 }
 
-func (r *legacyTopicSubscriptionRetryStrategy) GetResponseDataReceivedTimeoutMillis() *int {
-	return nil
-}
-
 func (r *legacyTopicSubscriptionRetryStrategy) DetermineWhenToRetry(props StrategyProps) *int {
 	r.log.Debug(
 		"Always retry strategy returning %d ms for [method: %s, status: %s]",

--- a/config/retry/legacy_topic_subscription_retry_strategy.go
+++ b/config/retry/legacy_topic_subscription_retry_strategy.go
@@ -28,6 +28,10 @@ func (r *legacyTopicSubscriptionRetryStrategy) WithRetryMs(ms int) Strategy {
 	}
 }
 
+func (r *legacyTopicSubscriptionRetryStrategy) GetResponseDataReceivedTimeoutMillis() *int {
+	return nil
+}
+
 func (r *legacyTopicSubscriptionRetryStrategy) DetermineWhenToRetry(props StrategyProps) *int {
 	r.log.Debug(
 		"Always retry strategy returning %d ms for [method: %s, status: %s]",

--- a/config/retry/never_retry_strategy.go
+++ b/config/retry/never_retry_strategy.go
@@ -10,6 +10,10 @@ func (r *neverRetryStrategy) String() string {
 	return "neverRetryStrategy{}"
 }
 
+func (r *neverRetryStrategy) GetResponseDataReceivedTimeoutMillis() *int {
+	return nil
+}
+
 // NewNeverRetryStrategy is a retry strategy that never retries any request
 func NewNeverRetryStrategy() Strategy {
 	return &neverRetryStrategy{}

--- a/config/retry/never_retry_strategy.go
+++ b/config/retry/never_retry_strategy.go
@@ -1,5 +1,7 @@
 package retry
 
+import "time"
+
 type neverRetryStrategy struct{}
 
 func (r *neverRetryStrategy) DetermineWhenToRetry(_ StrategyProps) *int {
@@ -13,4 +15,8 @@ func (r *neverRetryStrategy) String() string {
 // NewNeverRetryStrategy is a retry strategy that never retries any request
 func NewNeverRetryStrategy() Strategy {
 	return &neverRetryStrategy{}
+}
+
+func (r *neverRetryStrategy) CalculateRetryDeadline(_ time.Time) *time.Time {
+	return nil
 }

--- a/config/retry/never_retry_strategy.go
+++ b/config/retry/never_retry_strategy.go
@@ -10,10 +10,6 @@ func (r *neverRetryStrategy) String() string {
 	return "neverRetryStrategy{}"
 }
 
-func (r *neverRetryStrategy) GetResponseDataReceivedTimeoutMillis() *int {
-	return nil
-}
-
 // NewNeverRetryStrategy is a retry strategy that never retries any request
 func NewNeverRetryStrategy() Strategy {
 	return &neverRetryStrategy{}

--- a/config/retry/retry.go
+++ b/config/retry/retry.go
@@ -23,4 +23,8 @@ type Strategy interface {
 	//
 	// Returns The time in milliseconds before the next retry should occur or nil if no retry should be attempted.
 	DetermineWhenToRetry(props StrategyProps) *int
+
+	// CalculateRetryDeadline calculates the deadline for a retry attempt.
+	// Returns nil if there is no adjustment to the deadline.
+	CalculateRetryDeadline(overallDeadline time.Time) *time.Time
 }

--- a/config/retry/retry.go
+++ b/config/retry/retry.go
@@ -1,13 +1,16 @@
 package retry
 
 import (
+	"time"
+
 	"google.golang.org/grpc/codes"
 )
 
 type StrategyProps struct {
-	GrpcStatusCode codes.Code
-	GrpcMethod     string
-	AttemptNumber  int
+	GrpcStatusCode  codes.Code
+	GrpcMethod      string
+	AttemptNumber   int
+	OverallDeadline time.Time
 }
 type Strategy interface {
 	// DetermineWhenToRetry Determines whether a grpc call can be retried and how long to wait before that retry.
@@ -17,4 +20,7 @@ type Strategy interface {
 	//
 	// Returns The time in milliseconds before the next retry should occur or nil if no retry should be attempted.
 	DetermineWhenToRetry(props StrategyProps) *int
+
+	// GetResponseDataReceivedTimeoutMillis returns the timeout for a retry attemptin milliseconds.
+	GetResponseDataReceivedTimeoutMillis() *int
 }

--- a/config/retry/retry.go
+++ b/config/retry/retry.go
@@ -20,7 +20,4 @@ type Strategy interface {
 	//
 	// Returns The time in milliseconds before the next retry should occur or nil if no retry should be attempted.
 	DetermineWhenToRetry(props StrategyProps) *int
-
-	// GetResponseDataReceivedTimeoutMillis returns the timeout for a retry attemptin milliseconds.
-	GetResponseDataReceivedTimeoutMillis() *int
 }

--- a/config/retry/retry.go
+++ b/config/retry/retry.go
@@ -7,9 +7,12 @@ import (
 )
 
 type StrategyProps struct {
-	GrpcStatusCode  codes.Code
-	GrpcMethod      string
-	AttemptNumber   int
+	GrpcStatusCode codes.Code
+	GrpcMethod     string
+	AttemptNumber  int
+
+	// OverallDeadline is the overall deadline for the request. It is currently only used
+	// by the FixedTimeoutRetryStrategy to determine when to stop retrying.
 	OverallDeadline time.Time
 }
 type Strategy interface {

--- a/internal/grpcmanagers/data_manager.go
+++ b/internal/grpcmanagers/data_manager.go
@@ -34,7 +34,7 @@ func NewUnaryDataGrpcManager(request *models.DataGrpcManagerRequest) (*DataGrpcM
 	}
 
 	headerInterceptors := []grpc.UnaryClientInterceptor{
-		interceptor.AddUnaryRetryInterceptor(request.RetryStrategy, onRequestCallback),
+		interceptor.AddUnaryRetryInterceptor(request.RetryStrategy, onRequestCallback, request.GrpcConfiguration.GetDeadline()),
 		interceptor.AddReadConcernHeaderInterceptor(request.ReadConcern),
 		interceptor.AddAuthHeadersInterceptor(authToken),
 	}

--- a/internal/interceptor/retry_interceptor.go
+++ b/internal/interceptor/retry_interceptor.go
@@ -31,12 +31,11 @@ func AddUnaryRetryInterceptor(s retry.Strategy, onRequest func(context.Context, 
 				onRequest(ctx, method)
 			}
 
-			// If the FixedTimeoutRetryStrategy is used, overwrite the deadline using
-			// the configured retry timeout. Otherwise, use the given context.
+			// If a retry strategy overwrites the deadline for a retry attempt, use the new deadline.
+			// Otherwise, use the given context and deadline.
 			retryCtx := ctx
-			if s, ok := s.(retry.FixedTimeoutRetryStrategy); ok {
-				retryDeadline := s.CalculateRetryDeadline(overallDeadline)
-				ctxWithRetryDeadline, cancel := context.WithDeadline(ctx, retryDeadline)
+			if retryDeadline := s.CalculateRetryDeadline(overallDeadline); retryDeadline != nil {
+				ctxWithRetryDeadline, cancel := context.WithDeadline(ctx, *retryDeadline)
 				defer cancel()
 				retryCtx = ctxWithRetryDeadline
 			}

--- a/internal/interceptor/retry_interceptor.go
+++ b/internal/interceptor/retry_interceptor.go
@@ -29,7 +29,7 @@ func AddUnaryRetryInterceptor(s retry.Strategy, onRequest func(context.Context, 
 			}
 
 			// If the FixedTimeoutRetryStrategy is used, overwrite the deadline using
-			// the retry attempt's timeout (responseDataReceivedTimeoutMillis).
+			// the configured retry timeout. Otherwise, use the given context.
 			retryCtx := ctx
 			if s, ok := s.(retry.FixedTimeoutRetryStrategy); ok {
 				retryDeadline := s.CalculateRetryDeadline(overallDeadline)

--- a/momento/retry_test.go
+++ b/momento/retry_test.go
@@ -29,6 +29,12 @@ import (
 	"google.golang.org/grpc/codes"
 )
 
+const (
+	CLIENT_TIMEOUT_MILLIS                 = 3 * time.Second
+	RESPONSE_DATA_RECEIVED_TIMEOUT_MILLIS = 1000
+	RETRY_DELAY_INTERVAL_MILLIS           = 100
+)
+
 var (
 	testCtx     context.Context
 	cacheName   string
@@ -429,7 +435,7 @@ var _ = Describe("retry eligibility-strategy", Label(RETRY_LABEL, MOMENTO_LOCAL_
 				Expect(getResponse).To(BeNil())
 
 				Expect(metricsCollector.GetTotalRetryCount(cacheName, "Get")).To(Equal(3))
-				Expect(metricsCollector.GetAverageTimeBetweenRetries(cacheName, "Get")).To(Equal(int64(0)))
+				Expect(metricsCollector.GetAverageTimeBetweenRetries(cacheName, "Get")).To(BeNumerically("<=", 10))
 			})
 
 			It("should not retry if the status code is not retryable", func() {
@@ -543,6 +549,277 @@ var _ = Describe("retry eligibility-strategy", Label(RETRY_LABEL, MOMENTO_LOCAL_
 				Expect(getResponse).To(Not(BeNil()))
 				Expect(getResponse.(*responses.GetHit).ValueString()).To(Equal("value"))
 				Expect(metricsCollector.GetTotalRetryCount(cacheName, "Get")).To(Equal(1))
+			})
+		})
+
+		Describe("cache-client retry fixedTimeoutRetryStrategy", Label(RETRY_LABEL, MOMENTO_LOCAL_LABEL), func() {
+			It("should not retry if the status code is not retryable", func() {
+				status := "unknown"
+				retryStrategy := retry.NewFixedTimeoutRetryStrategy(retry.FixedTimeoutRetryStrategyProps{
+					LoggerFactory:                     momento_default_logger.DefaultMomentoLoggerFactory{},
+					ResponseDataReceivedTimeoutMillis: RESPONSE_DATA_RECEIVED_TIMEOUT_MILLIS,
+					RetryDelayIntervalMillis:          RETRY_DELAY_INTERVAL_MILLIS,
+				})
+				retryMiddleware := helpers.NewMomentoLocalMiddleware(helpers.MomentoLocalMiddlewareProps{
+					MomentoLocalMiddlewareMetadataProps: helpers.MomentoLocalMiddlewareMetadataProps{
+						ReturnError:  &status,
+						ErrorRpcList: &[]string{"set"},
+					},
+				})
+				metricsCollector := *retryMiddleware.(helpers.MomentoLocalMiddleware).GetMetricsCollector()
+				clientConfig := config.LaptopLatest().WithMiddleware([]middleware.Middleware{
+					retryMiddleware,
+				}).WithRetryStrategy(retryStrategy).WithClientTimeout(CLIENT_TIMEOUT_MILLIS)
+				setupCacheClient(clientConfig)
+				setResponse, err := cacheClient.Set(context.Background(), &SetRequest{
+					CacheName: "cache",
+					Key:       String("key"),
+					Value:     String("value"),
+				})
+				Expect(setResponse).To(BeNil())
+				Expect(err).To(Not(BeNil()))
+				Expect(err).To(HaveMomentoErrorCode(UnknownServiceError))
+				Expect(metricsCollector.GetTotalRetryCount("cache", "Set")).To(Equal(0))
+			})
+
+			It("should not retry if the rpc is not retryable", func() {
+				status := "unavailable"
+				retryStrategy := retry.NewFixedTimeoutRetryStrategy(retry.FixedTimeoutRetryStrategyProps{
+					LoggerFactory:                     momento_default_logger.DefaultMomentoLoggerFactory{},
+					ResponseDataReceivedTimeoutMillis: RESPONSE_DATA_RECEIVED_TIMEOUT_MILLIS,
+					RetryDelayIntervalMillis:          RETRY_DELAY_INTERVAL_MILLIS,
+				})
+				retryMiddleware := helpers.NewMomentoLocalMiddleware(helpers.MomentoLocalMiddlewareProps{
+					MomentoLocalMiddlewareMetadataProps: helpers.MomentoLocalMiddlewareMetadataProps{
+						ReturnError:  &status,
+						ErrorRpcList: &[]string{"dictionary-increment"},
+					},
+				})
+				metricsCollector := *retryMiddleware.(helpers.MomentoLocalMiddleware).GetMetricsCollector()
+				clientConfig := config.LaptopLatest().WithMiddleware([]middleware.Middleware{
+					retryMiddleware,
+				}).WithRetryStrategy(retryStrategy).WithClientTimeout(CLIENT_TIMEOUT_MILLIS)
+				setupCacheClient(clientConfig)
+				incrResponse, err := cacheClient.DictionaryIncrement(context.Background(), &DictionaryIncrementRequest{
+					CacheName:      "cache",
+					DictionaryName: "dictionary",
+					Field:          String("field"),
+					Amount:         1,
+				})
+				Expect(incrResponse).To(BeNil())
+				Expect(err).To(Not(BeNil()))
+				Expect(err).To(HaveMomentoErrorCode(ServerUnavailableError))
+				Expect(metricsCollector.GetTotalRetryCount("cache", "DictionaryIncrement")).To(Equal(0))
+			})
+
+			It("should use default timeout values when not specified", func() {
+				status := "unavailable"
+				retryStrategy := retry.NewFixedTimeoutRetryStrategy(retry.FixedTimeoutRetryStrategyProps{
+					LoggerFactory: momento_default_logger.DefaultMomentoLoggerFactory{},
+				})
+				retryMiddleware := helpers.NewMomentoLocalMiddleware(helpers.MomentoLocalMiddlewareProps{
+					MomentoLocalMiddlewareMetadataProps: helpers.MomentoLocalMiddlewareMetadataProps{
+						ReturnError:  &status,
+						ErrorRpcList: &[]string{"get"},
+					},
+				})
+				metricsCollector := *retryMiddleware.(helpers.MomentoLocalMiddleware).GetMetricsCollector()
+				clientConfig := config.LaptopLatest().WithMiddleware([]middleware.Middleware{
+					retryMiddleware,
+				}).WithRetryStrategy(retryStrategy).WithClientTimeout(CLIENT_TIMEOUT_MILLIS)
+				setupCacheClient(clientConfig)
+
+				getResponse, err := cacheClient.Get(context.Background(), &GetRequest{
+					CacheName: "cache",
+					Key:       String("key"),
+				})
+				Expect(err).To(Not(BeNil()))
+				Expect(err).To(HaveMomentoErrorCode(TimeoutError))
+				Expect(getResponse).To(BeNil())
+
+				// Should immediately receive errors and retry every DefaultRetryDelayIntervalMillis
+				// until the client timeout is reached.
+				maxAttempts := CLIENT_TIMEOUT_MILLIS / retry.DefaultRetryDelayIntervalMillis
+				Expect(metricsCollector.GetTotalRetryCount("cache", "Get")).To(BeNumerically("<=", maxAttempts))
+				Expect(metricsCollector.GetTotalRetryCount("cache", "Get")).To(BeNumerically(">", 0))
+
+				// Jitter will be +/- 10% of the retry delay interval
+				Expect(metricsCollector.GetAverageTimeBetweenRetries("cache", "Get")).To(BeNumerically("<=", retry.DefaultRetryDelayIntervalMillis*1.1))
+				Expect(metricsCollector.GetAverageTimeBetweenRetries("cache", "Get")).To(BeNumerically(">=", retry.DefaultRetryDelayIntervalMillis*0.9))
+			})
+
+			It("should retry until client timeout when responses have no delays during full outage", func() {
+				status := "unavailable"
+				retryStrategy := retry.NewFixedTimeoutRetryStrategy(retry.FixedTimeoutRetryStrategyProps{
+					LoggerFactory:                     momento_default_logger.DefaultMomentoLoggerFactory{},
+					ResponseDataReceivedTimeoutMillis: RESPONSE_DATA_RECEIVED_TIMEOUT_MILLIS,
+					RetryDelayIntervalMillis:          RETRY_DELAY_INTERVAL_MILLIS,
+				})
+				retryMiddleware := helpers.NewMomentoLocalMiddleware(helpers.MomentoLocalMiddlewareProps{
+					MomentoLocalMiddlewareMetadataProps: helpers.MomentoLocalMiddlewareMetadataProps{
+						ReturnError:  &status,
+						ErrorRpcList: &[]string{"get"},
+					},
+				})
+				metricsCollector := *retryMiddleware.(helpers.MomentoLocalMiddleware).GetMetricsCollector()
+				clientConfig := config.LaptopLatest().WithMiddleware([]middleware.Middleware{
+					retryMiddleware,
+				}).WithRetryStrategy(retryStrategy).WithClientTimeout(CLIENT_TIMEOUT_MILLIS)
+				setupCacheClient(clientConfig)
+
+				getResponse, err := cacheClient.Get(context.Background(), &GetRequest{
+					CacheName: "cache",
+					Key:       String("key"),
+				})
+				Expect(getResponse).To(BeNil())
+				Expect(err).To(Not(BeNil()))
+				Expect(err).To(HaveMomentoErrorCode(TimeoutError))
+
+				// Should immediately receive errors and retry every DefaultRetryDelayIntervalMillis
+				// until the client timeout is reached.
+				maxAttempts := CLIENT_TIMEOUT_MILLIS / RETRY_DELAY_INTERVAL_MILLIS
+				Expect(metricsCollector.GetTotalRetryCount("cache", "Get")).To(BeNumerically("<=", maxAttempts))
+				Expect(metricsCollector.GetTotalRetryCount("cache", "Get")).To(BeNumerically(">", 0))
+
+				// Jitter will be +/- 10% of the retry delay interval
+				maxDelay := float64(RETRY_DELAY_INTERVAL_MILLIS) * 1.1
+				minDelay := float64(RETRY_DELAY_INTERVAL_MILLIS) * 0.9
+				average, err := metricsCollector.GetAverageTimeBetweenRetries("cache", "Get")
+				Expect(err).To(BeNil())
+				Expect(average).To(BeNumerically("<=", int64(maxDelay)))
+				Expect(average).To(BeNumerically(">=", int64(minDelay)))
+			})
+
+			It("should retry until client timeout when responses have short delays during full outage", func() {
+				status := "unavailable"
+				retryStrategy := retry.NewFixedTimeoutRetryStrategy(retry.FixedTimeoutRetryStrategyProps{
+					LoggerFactory:                     momento_default_logger.DefaultMomentoLoggerFactory{},
+					ResponseDataReceivedTimeoutMillis: RESPONSE_DATA_RECEIVED_TIMEOUT_MILLIS,
+					RetryDelayIntervalMillis:          RETRY_DELAY_INTERVAL_MILLIS,
+				})
+				shortDelay := RETRY_DELAY_INTERVAL_MILLIS + 100
+				retryMiddleware := helpers.NewMomentoLocalMiddleware(helpers.MomentoLocalMiddlewareProps{
+					MomentoLocalMiddlewareMetadataProps: helpers.MomentoLocalMiddlewareMetadataProps{
+						ReturnError:  &status,
+						ErrorRpcList: &[]string{"get"},
+						DelayRpcList: &[]string{"get"},
+						DelayMillis:  &shortDelay,
+					},
+				})
+				metricsCollector := *retryMiddleware.(helpers.MomentoLocalMiddleware).GetMetricsCollector()
+				clientConfig := config.LaptopLatest().WithMiddleware([]middleware.Middleware{
+					retryMiddleware,
+				}).WithRetryStrategy(retryStrategy).WithClientTimeout(CLIENT_TIMEOUT_MILLIS)
+				setupCacheClient(clientConfig)
+
+				getResponse, err := cacheClient.Get(context.Background(), &GetRequest{
+					CacheName: "cache",
+					Key:       String("key"),
+				})
+				Expect(getResponse).To(BeNil())
+				Expect(err).To(Not(BeNil()))
+				Expect(err).To(HaveMomentoErrorCode(TimeoutError))
+
+				// Should receive errors after shortDelay ms and retry every RETRY_DELAY_INTERVAL_MILLIS
+				// until the client timeout is reached.
+				delayBetweenAttempts := RETRY_DELAY_INTERVAL_MILLIS + shortDelay
+				maxAttempts := int(CLIENT_TIMEOUT_MILLIS.Milliseconds()) / delayBetweenAttempts
+				Expect(metricsCollector.GetTotalRetryCount("cache", "Get")).To(BeNumerically("<=", maxAttempts))
+				Expect(metricsCollector.GetTotalRetryCount("cache", "Get")).To(BeNumerically(">", 0))
+
+				// Jitter will be +/- 10% of the retry delay interval
+				maxDelay := float64(delayBetweenAttempts) * 1.1
+				minDelay := float64(delayBetweenAttempts) * 0.9
+				average, err := metricsCollector.GetAverageTimeBetweenRetries("cache", "Get")
+				Expect(err).To(BeNil())
+				Expect(float64(average)).To(BeNumerically("<=", maxDelay))
+				Expect(float64(average)).To(BeNumerically(">=", minDelay))
+			})
+
+			It("should retry until client timeout when responses have long delays during full outage", func() {
+				status := "unavailable"
+				retryStrategy := retry.NewFixedTimeoutRetryStrategy(retry.FixedTimeoutRetryStrategyProps{
+					LoggerFactory:                     momento_default_logger.DefaultMomentoLoggerFactory{},
+					ResponseDataReceivedTimeoutMillis: RESPONSE_DATA_RECEIVED_TIMEOUT_MILLIS,
+					RetryDelayIntervalMillis:          RETRY_DELAY_INTERVAL_MILLIS,
+				})
+				longDelay := RESPONSE_DATA_RECEIVED_TIMEOUT_MILLIS + 100
+				retryMiddleware := helpers.NewMomentoLocalMiddleware(helpers.MomentoLocalMiddlewareProps{
+					MomentoLocalMiddlewareMetadataProps: helpers.MomentoLocalMiddlewareMetadataProps{
+						ReturnError:  &status,
+						ErrorRpcList: &[]string{"get"},
+						DelayRpcList: &[]string{"get"},
+						DelayMillis:  &longDelay,
+					},
+				})
+				metricsCollector := *retryMiddleware.(helpers.MomentoLocalMiddleware).GetMetricsCollector()
+				clientConfig := config.LaptopLatest().WithMiddleware([]middleware.Middleware{
+					retryMiddleware,
+				}).WithRetryStrategy(retryStrategy).WithClientTimeout(CLIENT_TIMEOUT_MILLIS)
+				setupCacheClient(clientConfig)
+
+				getResponse, err := cacheClient.Get(context.Background(), &GetRequest{
+					CacheName: "cache",
+					Key:       String("key"),
+				})
+				Expect(getResponse).To(BeNil())
+				Expect(err).To(Not(BeNil()))
+				Expect(err).To(HaveMomentoErrorCode(TimeoutError))
+
+				// Should receive errors after longDelay ms and retry every RETRY_DELAY_INTERVAL_MILLIS
+				// until the client timeout is reached.
+				delayBetweenAttempts := RETRY_DELAY_INTERVAL_MILLIS + longDelay
+				maxAttempts := int(CLIENT_TIMEOUT_MILLIS.Milliseconds()) / delayBetweenAttempts
+				Expect(metricsCollector.GetTotalRetryCount("cache", "Get")).To(BeNumerically("<=", maxAttempts))
+				Expect(metricsCollector.GetTotalRetryCount("cache", "Get")).To(BeNumerically(">", 0))
+
+				// Jitter will be +/- 10% of the retry delay interval
+				maxDelay := float64(delayBetweenAttempts) * 1.1
+				minDelay := float64(delayBetweenAttempts) * 0.9
+				average, err := metricsCollector.GetAverageTimeBetweenRetries("cache", "Get")
+				Expect(err).To(BeNil())
+				Expect(float64(average)).To(BeNumerically("<=", maxDelay))
+				Expect(float64(average)).To(BeNumerically(">=", minDelay))
+			})
+
+			It("should retry until partial outage is resolved", func() {
+				status := "unavailable"
+				retryStrategy := retry.NewFixedTimeoutRetryStrategy(retry.FixedTimeoutRetryStrategyProps{
+					LoggerFactory:                     momento_default_logger.DefaultMomentoLoggerFactory{},
+					ResponseDataReceivedTimeoutMillis: RESPONSE_DATA_RECEIVED_TIMEOUT_MILLIS,
+					RetryDelayIntervalMillis:          RETRY_DELAY_INTERVAL_MILLIS,
+				})
+				errCount := 3
+				retryMiddleware := helpers.NewMomentoLocalMiddleware(helpers.MomentoLocalMiddlewareProps{
+					MomentoLocalMiddlewareMetadataProps: helpers.MomentoLocalMiddlewareMetadataProps{
+						ReturnError:  &status,
+						ErrorRpcList: &[]string{"get"},
+						ErrorCount:   &errCount,
+					},
+				})
+				metricsCollector := *retryMiddleware.(helpers.MomentoLocalMiddleware).GetMetricsCollector()
+				clientConfig := config.LaptopLatest().WithMiddleware([]middleware.Middleware{
+					retryMiddleware,
+				}).WithRetryStrategy(retryStrategy).WithClientTimeout(CLIENT_TIMEOUT_MILLIS)
+				setupCacheClient(clientConfig)
+
+				getResponse, err := cacheClient.Get(context.Background(), &GetRequest{
+					CacheName: "cache",
+					Key:       String("key"),
+				})
+				Expect(getResponse).To(Not(BeNil()))
+				Expect(err).To(BeNil())
+
+				// Should retry until the server stops returning errors
+				Expect(metricsCollector.GetTotalRetryCount("cache", "Get")).To(Equal(errCount))
+
+				// Jitter will be +/- 10% of the retry delay interval
+				maxDelay := float64(RETRY_DELAY_INTERVAL_MILLIS) * 1.1
+				minDelay := float64(RETRY_DELAY_INTERVAL_MILLIS) * 0.9
+				average, err := metricsCollector.GetAverageTimeBetweenRetries("cache", "Get")
+				Expect(err).To(BeNil())
+				Expect(average).To(BeNumerically("<=", int64(maxDelay)))
+				Expect(average).To(BeNumerically(">=", int64(minDelay)))
 			})
 		})
 	})

--- a/momento/retry_test.go
+++ b/momento/retry_test.go
@@ -782,45 +782,45 @@ var _ = Describe("retry eligibility-strategy", Label(RETRY_LABEL, MOMENTO_LOCAL_
 				Expect(float64(average)).To(BeNumerically(">=", minDelay))
 			})
 
-			// It("should retry until partial outage is resolved", func() {
-			// 	status := "unavailable"
-			// 	retryStrategy := retry.NewFixedTimeoutRetryStrategy(retry.FixedTimeoutRetryStrategyProps{
-			// 		LoggerFactory:                     momento_default_logger.DefaultMomentoLoggerFactory{},
-			// 		ResponseDataReceivedTimeoutMillis: RESPONSE_DATA_RECEIVED_TIMEOUT_MILLIS,
-			// 		RetryDelayIntervalMillis:          RETRY_DELAY_INTERVAL_MILLIS,
-			// 	})
-			// 	errCount := 3
-			// 	retryMiddleware := helpers.NewMomentoLocalMiddleware(helpers.MomentoLocalMiddlewareProps{
-			// 		MomentoLocalMiddlewareMetadataProps: helpers.MomentoLocalMiddlewareMetadataProps{
-			// 			ReturnError:  &status,
-			// 			ErrorRpcList: &[]string{"get"},
-			// 			ErrorCount:   &errCount,
-			// 		},
-			// 	})
-			// 	metricsCollector := *retryMiddleware.(helpers.MomentoLocalMiddleware).GetMetricsCollector()
-			// 	clientConfig := config.LaptopLatest().WithMiddleware([]middleware.Middleware{
-			// 		retryMiddleware,
-			// 	}).WithRetryStrategy(retryStrategy).WithClientTimeout(CLIENT_TIMEOUT_MILLIS)
-			// 	setupCacheClient(clientConfig)
+			It("should retry until partial outage is resolved", func() {
+				status := "unavailable"
+				retryStrategy := retry.NewFixedTimeoutRetryStrategy(retry.FixedTimeoutRetryStrategyProps{
+					LoggerFactory:                     momento_default_logger.DefaultMomentoLoggerFactory{},
+					ResponseDataReceivedTimeoutMillis: RESPONSE_DATA_RECEIVED_TIMEOUT_MILLIS,
+					RetryDelayIntervalMillis:          RETRY_DELAY_INTERVAL_MILLIS,
+				})
+				errCount := 3
+				retryMiddleware := helpers.NewMomentoLocalMiddleware(helpers.MomentoLocalMiddlewareProps{
+					MomentoLocalMiddlewareMetadataProps: helpers.MomentoLocalMiddlewareMetadataProps{
+						ReturnError:  &status,
+						ErrorRpcList: &[]string{"get"},
+						ErrorCount:   &errCount,
+					},
+				})
+				metricsCollector := *retryMiddleware.(helpers.MomentoLocalMiddleware).GetMetricsCollector()
+				clientConfig := config.LaptopLatest().WithMiddleware([]middleware.Middleware{
+					retryMiddleware,
+				}).WithRetryStrategy(retryStrategy).WithClientTimeout(CLIENT_TIMEOUT_MILLIS)
+				setupCacheClient(clientConfig)
 
-			// 	getResponse, err := cacheClient.Get(context.Background(), &GetRequest{
-			// 		CacheName: cacheName,
-			// 		Key:       String("key"),
-			// 	})
-			// 	Expect(getResponse).To(Not(BeNil()))
-			// 	Expect(err).To(BeNil())
+				getResponse, err := cacheClient.Get(context.Background(), &GetRequest{
+					CacheName: cacheName,
+					Key:       String("key"),
+				})
+				Expect(getResponse).To(Not(BeNil()))
+				Expect(err).To(BeNil())
 
-			// 	// Should retry until the server stops returning errors
-			// 	Expect(metricsCollector.GetTotalRetryCount(cacheName, "Get")).To(Equal(errCount))
+				// Should retry until the server stops returning errors
+				Expect(metricsCollector.GetTotalRetryCount(cacheName, "Get")).To(Equal(errCount))
 
-			// 	// Jitter will be +/- 10% of the retry delay interval
-			// 	maxDelay := float64(RETRY_DELAY_INTERVAL_MILLIS) * 1.1
-			// 	minDelay := float64(RETRY_DELAY_INTERVAL_MILLIS) * 0.9
-			// 	average, err := metricsCollector.GetAverageTimeBetweenRetries(cacheName, "Get")
-			// 	Expect(err).To(BeNil())
-			// 	Expect(average).To(BeNumerically("<=", int64(maxDelay)))
-			// 	Expect(average).To(BeNumerically(">=", int64(minDelay)))
-			// })
+				// Jitter will be +/- 10% of the retry delay interval
+				maxDelay := float64(RETRY_DELAY_INTERVAL_MILLIS) * 1.1
+				minDelay := float64(RETRY_DELAY_INTERVAL_MILLIS) * 0.9
+				average, err := metricsCollector.GetAverageTimeBetweenRetries(cacheName, "Get")
+				Expect(err).To(BeNil())
+				Expect(average).To(BeNumerically("<=", int64(maxDelay)))
+				Expect(average).To(BeNumerically(">=", int64(minDelay)))
+			})
 		})
 	})
 

--- a/momento/test_helpers/momento_local_middleware.go
+++ b/momento/test_helpers/momento_local_middleware.go
@@ -169,7 +169,7 @@ func (mw *momentoLocalMiddleware) OnInterceptorRequest(ctx context.Context, meth
 		mw.metricsChan <- &timestampPayload{
 			cacheName:   md.Get("cache")[0],
 			requestName: method,
-			timestamp:   time.Now().Unix(),
+			timestamp:   time.Now().UnixMilli(),
 		}
 	} else {
 		// Because this middleware is for test use only, we can panic here.

--- a/momento/test_helpers/momento_local_middleware_request_handler.go
+++ b/momento/test_helpers/momento_local_middleware_request_handler.go
@@ -46,7 +46,7 @@ func (rh *momentoLocalMiddlewareRequestHandler) OnMetadata(requestMetadata map[s
 	}
 
 	if rh.metadataProps.DelayMillis != nil {
-		requestMetadata["delay-millis"] = fmt.Sprintf("%d", *rh.metadataProps.DelayMillis)
+		requestMetadata["delay-ms"] = fmt.Sprintf("%d", *rh.metadataProps.DelayMillis)
 	}
 
 	if rh.metadataProps.DelayRpcList != nil {

--- a/momento/test_helpers/retry_metrics_collector.go
+++ b/momento/test_helpers/retry_metrics_collector.go
@@ -41,10 +41,8 @@ func (r *retryMetrics) GetTotalRetryCount(cacheName string, requestName string) 
 	return 0, fmt.Errorf("request name '%s' is not valid", requestName)
 }
 
-// GetAverageTimeBetweenRetries returns the average time between retries in seconds.
-//
-//	Limited to second resolution, but I can obviously change that if desired.
-//	This tracks with the JS implementation.
+// GetAverageTimeBetweenRetries returns the average time between retries in milliseconds.
+// OnInterceptorRequest in momento_local_middleware.go records Unix timestamps in milliseconds.
 func (r *retryMetrics) GetAverageTimeBetweenRetries(cacheName string, requestName string) (int64, error) {
 	if _, ok := r.data[cacheName]; !ok {
 		return int64(0), fmt.Errorf("cache name '%s' is not valid", cacheName)


### PR DESCRIPTION
Closes https://github.com/momentohq/dev-eco-issue-tracker/issues/1205

- Adds FixedTimeoutRetryStrategy and tests
- Updated timestamp collection to be unix time in milliseconds instead of seconds to better support the new tests
- Fix: momento-local middleware was sending metadata header `delay-millis` instead of `delay-ms`

Because go sdk uses context.WithTimeout / context.WithDeadline instead of a grpc call option, we are responsible for catching a retry's deadline exceeded error and passing along a new context object with updated deadline.
