### PR TITLE
fix: revise retry strategy interface additions to maintain backwards compatibility

### DIFF
--- a/config/retry/exponential_backoff_retry_strategy.go
+++ b/config/retry/exponential_backoff_retry_strategy.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"math"
 	"math/rand"
-	"time"
 
 	"github.com/momentohq/client-sdk-go/config/logger"
 )
@@ -157,8 +156,4 @@ func randInRange(min, max int) int {
 		return min
 	}
 	return rand.Intn(max-min) + min
-}
-
-func (r *exponentialBackoffRetryStrategy) CalculateRetryDeadline(overallDeadline time.Time) *time.Time {
-	return nil
 }

--- a/config/retry/fixed_count_retry_strategy.go
+++ b/config/retry/fixed_count_retry_strategy.go
@@ -3,7 +3,6 @@ package retry
 import (
 	"fmt"
 	"strconv"
-	"time"
 
 	"github.com/momentohq/client-sdk-go/config/logger"
 )
@@ -102,8 +101,4 @@ func (r *fixedCountRetryStrategy) String() string {
 		r.maxAttempts,
 		r.log,
 	)
-}
-
-func (r *fixedCountRetryStrategy) CalculateRetryDeadline(overallDeadline time.Time) *time.Time {
-	return nil
 }

--- a/config/retry/fixed_timeout_retry_strategy.go
+++ b/config/retry/fixed_timeout_retry_strategy.go
@@ -29,7 +29,7 @@ type fixedTimeoutRetryStrategy struct {
 // is reached. After the initial request fails, the next retry will be scheduled for retryDelayIntervalMillis
 // from the current time, and the retried request will timeout after retryTimeoutMillis if there is no response.
 type FixedTimeoutRetryStrategy interface {
-	Strategy
+	DeadlineAwareRetryStrategy
 	WithRetryTimeoutMillis(timeout int) Strategy
 	WithRetryDelayIntervalMillis(delay int) Strategy
 	WithEligibilityStrategy(s EligibilityStrategy) Strategy
@@ -99,13 +99,13 @@ func (r *fixedTimeoutRetryStrategy) WithEligibilityStrategy(strategy Eligibility
 
 // CalculateRetryDeadline calculates the deadline for a retry attempt using the retry timeout,
 // but clips it to the overall deadline if the overall deadline is sooner.
-func (r *fixedTimeoutRetryStrategy) CalculateRetryDeadline(overallDeadline time.Time) *time.Time {
+func (r *fixedTimeoutRetryStrategy) CalculateRetryDeadline(overallDeadline time.Time) time.Time {
 	deadlineOffset := time.Duration(r.retryTimeoutMillis) * time.Millisecond
 	deadline := time.Now().Add(deadlineOffset)
 	if deadline.After(overallDeadline) {
 		deadline = overallDeadline
 	}
-	return &deadline
+	return deadline
 }
 
 func (r *fixedTimeoutRetryStrategy) DetermineWhenToRetry(props StrategyProps) *int {

--- a/config/retry/legacy_topic_subscription_retry_strategy.go
+++ b/config/retry/legacy_topic_subscription_retry_strategy.go
@@ -2,7 +2,6 @@ package retry
 
 import (
 	"fmt"
-	"time"
 
 	"github.com/momentohq/client-sdk-go/config/logger"
 )
@@ -70,8 +69,4 @@ func NewLegacyTopicSubscriptionRetryStrategy(props LegacyTopicSubscriptionRetryS
 		log:     log,
 		retryMs: retryMs,
 	}
-}
-
-func (r *legacyTopicSubscriptionRetryStrategy) CalculateRetryDeadline(overallDeadline time.Time) *time.Time {
-	return nil
 }

--- a/config/retry/never_retry_strategy.go
+++ b/config/retry/never_retry_strategy.go
@@ -1,7 +1,5 @@
 package retry
 
-import "time"
-
 type neverRetryStrategy struct{}
 
 func (r *neverRetryStrategy) DetermineWhenToRetry(_ StrategyProps) *int {
@@ -15,8 +13,4 @@ func (r *neverRetryStrategy) String() string {
 // NewNeverRetryStrategy is a retry strategy that never retries any request
 func NewNeverRetryStrategy() Strategy {
 	return &neverRetryStrategy{}
-}
-
-func (r *neverRetryStrategy) CalculateRetryDeadline(_ time.Time) *time.Time {
-	return nil
 }

--- a/config/retry/retry.go
+++ b/config/retry/retry.go
@@ -23,8 +23,12 @@ type Strategy interface {
 	//
 	// Returns The time in milliseconds before the next retry should occur or nil if no retry should be attempted.
 	DetermineWhenToRetry(props StrategyProps) *int
+}
+
+type DeadlineAwareRetryStrategy interface {
+	Strategy
 
 	// CalculateRetryDeadline calculates the deadline for a retry attempt.
 	// Returns nil if there is no adjustment to the deadline.
-	CalculateRetryDeadline(overallDeadline time.Time) *time.Time
+	CalculateRetryDeadline(overallDeadline time.Time) time.Time
 }

--- a/internal/interceptor/retry_interceptor.go
+++ b/internal/interceptor/retry_interceptor.go
@@ -31,12 +31,13 @@ func AddUnaryRetryInterceptor(s retry.Strategy, onRequest func(context.Context, 
 				onRequest(ctx, method)
 			}
 
-			// If a retry strategy overwrites the deadline for a retry attempt, use the new deadline.
+			// If a DeadlineAwareRetryStrategy overwrites the deadline for a retry attempt, use the new deadline.
 			// Otherwise, use the given context and deadline.
 			retryCtx := ctx
 			if attempt > 1 {
-				if retryDeadline := s.CalculateRetryDeadline(overallDeadline); retryDeadline != nil {
-					ctxWithRetryDeadline, cancel := context.WithDeadline(ctx, *retryDeadline)
+				if deadlineAwareStrategy, ok := s.(retry.DeadlineAwareRetryStrategy); ok {
+					retryDeadline := deadlineAwareStrategy.CalculateRetryDeadline(overallDeadline)
+					ctxWithRetryDeadline, cancel := context.WithDeadline(ctx, retryDeadline)
 					defer cancel()
 					retryCtx = ctxWithRetryDeadline
 				}


### PR DESCRIPTION
Realized that adding [`CalculateRetryDeadline`](https://github.com/momentohq/client-sdk-go/blob/main/config/retry/retry.go#L29) to the retry strategy interface would break backwards compatibility. 
We haven't cut a release with this addition yet; this PR will fix the breaking change so that we avoid a release with a breaking change.

The safer thing to do is to make a new `DeadlineAwareRetryStrategy` interface that the retry interceptor can check for and that the `FixedTimeoutRetryStrategy` can implement instead.