### PR TITLE
chore: reuse cache client in aws lambda example and update deps

### DIFF
--- a/examples/aws-lambda/README.md
+++ b/examples/aws-lambda/README.md
@@ -14,8 +14,8 @@ This directory contains an example Lambda function, built using AWS CDK, that se
 
 ## Prerequisites
 
-- Node version 14 or higher is required
-- To get started with Momento you will need a Momento Auth Token. You can get one from the [Momento Console](https://console.gomomento.com). Check out the [getting started](https://docs.momentohq.com/getting-started) guide for more information on obtaining an auth token.
+- Node version 20 or higher is required for deploying the CDK app.
+- To get started with Momento you will need a Momento API key. You can get one from the [Momento Console](https://console.gomomento.com). Check out the [getting started](https://docs.momentohq.com/getting-started) guide for more information on obtaining an auth token.
 
 ## Deploying the Simple Get Lambda
 

--- a/examples/aws-lambda/infrastructure/lib/momento-lambda-stack.ts
+++ b/examples/aws-lambda/infrastructure/lib/momento-lambda-stack.ts
@@ -22,7 +22,7 @@ export class MomentoLambdaStack extends cdk.Stack {
 
     const getLambda = new go.GoFunction(this, 'MomentoLambdaExample', {
       functionName: 'MomentoLambdaExample',
-      runtime: lambda.Runtime.GO_1_X,
+      runtime: lambda.Runtime.PROVIDED_AL2,
       entry: path.join(__dirname, '../../lambda'),
       timeout: cdk.Duration.seconds(30),
       memorySize: 128,

--- a/examples/aws-lambda/infrastructure/package-lock.json
+++ b/examples/aws-lambda/infrastructure/package-lock.json
@@ -8,7 +8,7 @@
       "name": "infrastructure",
       "version": "0.1.0",
       "dependencies": {
-        "@aws-cdk/aws-lambda-go-alpha": "^2.92.0-alpha.0",
+        "@aws-cdk/aws-lambda-go-alpha": "^2.190.0-alpha.0",
         "aws-cdk-lib": "^2.92.0",
         "constructs": "^10.0.0",
         "source-map-support": "^0.5.21"
@@ -20,7 +20,7 @@
         "@types/jest": "^29.4.0",
         "@types/node": "18.11.18",
         "@typescript-eslint/eslint-plugin": "5.59.11",
-        "aws-cdk": "^2.92.0",
+        "aws-cdk": "^2.1010.0",
         "eslint": "8.42.0",
         "eslint-config-prettier": "8.8.0",
         "eslint-plugin-import": "2.27.5",
@@ -56,30 +56,60 @@
       }
     },
     "node_modules/@aws-cdk/asset-awscli-v1": {
-      "version": "2.2.200",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.200.tgz",
-      "integrity": "sha512-Kf5J8DfJK4wZFWT2Myca0lhwke7LwHcHBo+4TvWOGJrFVVKVuuiLCkzPPRBQQVDj0Vtn2NBokZAz8pfMpAqAKg=="
-    },
-    "node_modules/@aws-cdk/asset-kubectl-v20": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-kubectl-v20/-/asset-kubectl-v20-2.1.2.tgz",
-      "integrity": "sha512-3M2tELJOxQv0apCIiuKQ4pAbncz9GuLwnKFqxifWfe77wuMxyTRPmxssYHs42ePqzap1LT6GDcPygGs+hHstLg=="
+      "version": "2.2.232",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.232.tgz",
+      "integrity": "sha512-x9aFQG9gA+RgGj9bGB+WC6y1Nq2/Y8R2yXFoKWoQZOet8PRFJ8M5/FeXoh9XmdWI4weJVctLU4WTIve6rOvPtA=="
     },
     "node_modules/@aws-cdk/asset-node-proxy-agent-v6": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v6/-/asset-node-proxy-agent-v6-2.0.1.tgz",
-      "integrity": "sha512-DDt4SLdLOwWCjGtltH4VCST7hpOI5DzieuhGZsBpZ+AgJdSI2GCjklCXm0GCTwJG/SolkL5dtQXyUKgg9luBDg=="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v6/-/asset-node-proxy-agent-v6-2.1.0.tgz",
+      "integrity": "sha512-7bY3J8GCVxLupn/kNmpPc5VJz8grx+4RKfnnJiO1LG+uxkZfANZG3RMHhE+qQxxwkyQ9/MfPtTpf748UhR425A=="
     },
     "node_modules/@aws-cdk/aws-lambda-go-alpha": {
-      "version": "2.92.0-alpha.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-lambda-go-alpha/-/aws-lambda-go-alpha-2.92.0-alpha.0.tgz",
-      "integrity": "sha512-EFUKNO/fCqhwbMeL9+hs5fIyFxOGmIPad171iU4SrizwAXX85JfKtbI7PQhMppFh0bg5BsNlHxU5vg0nUTGeSA==",
+      "version": "2.190.0-alpha.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-lambda-go-alpha/-/aws-lambda-go-alpha-2.190.0-alpha.0.tgz",
+      "integrity": "sha512-gNZflo5pEHmrfZOEBX1QgHJIGTjllSOkvip+/BNj9noE6G3TQ1JrEtI8/7VdwENGF02m5ocCGt2WiwrrQRqfzA==",
       "engines": {
         "node": ">= 14.15.0"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "2.92.0",
+        "aws-cdk-lib": "^2.190.0",
         "constructs": "^10.0.0"
+      }
+    },
+    "node_modules/@aws-cdk/cloud-assembly-schema": {
+      "version": "41.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-41.2.0.tgz",
+      "integrity": "sha512-JaulVS6z9y5+u4jNmoWbHZRs9uGOnmn/ktXygNWKNu1k6lF3ad4so3s18eRu15XCbUIomxN9WPYT6Ehh7hzONw==",
+      "bundleDependencies": [
+        "jsonschema",
+        "semver"
+      ],
+      "dependencies": {
+        "jsonschema": "~1.4.1",
+        "semver": "^7.7.1"
+      },
+      "engines": {
+        "node": ">= 14.15.0"
+      }
+    },
+    "node_modules/@aws-cdk/cloud-assembly-schema/node_modules/jsonschema": {
+      "version": "1.4.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@aws-cdk/cloud-assembly-schema/node_modules/semver": {
+      "version": "7.7.1",
+      "inBundle": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -2092,9 +2122,9 @@
       }
     },
     "node_modules/aws-cdk": {
-      "version": "2.92.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.92.0.tgz",
-      "integrity": "sha512-9aAWJvZWSBJQxcsDopXYUAm6/pGz6vOQy2zfkn+YBuBkNelvW+ok15KPY4xn5m76tYnN79W03Gnfp/nxZUlcww==",
+      "version": "2.1010.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.1010.0.tgz",
+      "integrity": "sha512-kYNzBXVUZoRrTuYxRRA2Loz/Uvay0MqHobg8KPZaWylIbw/meUDgtoATRNt+stOdJ9PHODTjWmlDKI+2/KoF+w==",
       "dev": true,
       "bin": {
         "cdk": "bin/cdk"
@@ -2107,9 +2137,9 @@
       }
     },
     "node_modules/aws-cdk-lib": {
-      "version": "2.92.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.92.0.tgz",
-      "integrity": "sha512-J+SUFSnOt9u2GbY5QIABgjGNiw8bL/v0S3zsPhhO1dVwK+G7oE+bhLcAi3iILrw2sIpirNWH9K3W0by9K+cyMw==",
+      "version": "2.190.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.190.0.tgz",
+      "integrity": "sha512-D6BGf0Gg4s3XCnNiXnCgH1NHXYjngizs676HeytI4ekrUMtsw1ZmH9dlFBattH1x9gYX/9A+UxMkid+P4bNZKA==",
       "bundleDependencies": [
         "@balena/dockerignore",
         "case",
@@ -2120,21 +2150,23 @@
         "punycode",
         "semver",
         "table",
-        "yaml"
+        "yaml",
+        "mime-types"
       ],
       "dependencies": {
-        "@aws-cdk/asset-awscli-v1": "^2.2.200",
-        "@aws-cdk/asset-kubectl-v20": "^2.1.2",
-        "@aws-cdk/asset-node-proxy-agent-v6": "^2.0.1",
+        "@aws-cdk/asset-awscli-v1": "^2.2.229",
+        "@aws-cdk/asset-node-proxy-agent-v6": "^2.1.0",
+        "@aws-cdk/cloud-assembly-schema": "^41.0.0",
         "@balena/dockerignore": "^1.0.2",
         "case": "1.6.3",
-        "fs-extra": "^11.1.1",
-        "ignore": "^5.2.4",
-        "jsonschema": "^1.4.1",
+        "fs-extra": "^11.3.0",
+        "ignore": "^5.3.2",
+        "jsonschema": "^1.5.0",
+        "mime-types": "^2.1.35",
         "minimatch": "^3.1.2",
-        "punycode": "^2.3.0",
-        "semver": "^7.5.4",
-        "table": "^6.8.1",
+        "punycode": "^2.3.1",
+        "semver": "^7.7.1",
+        "table": "^6.9.0",
         "yaml": "1.10.2"
       },
       "engines": {
@@ -2150,14 +2182,14 @@
       "license": "Apache-2.0"
     },
     "node_modules/aws-cdk-lib/node_modules/ajv": {
-      "version": "8.12.0",
+      "version": "8.17.1",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "fast-deep-equal": "^3.1.1",
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
         "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2",
-        "uri-js": "^4.2.2"
+        "require-from-string": "^2.0.2"
       },
       "funding": {
         "type": "github",
@@ -2247,8 +2279,23 @@
       "inBundle": true,
       "license": "MIT"
     },
+    "node_modules/aws-cdk-lib/node_modules/fast-uri": {
+      "version": "3.0.6",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "inBundle": true,
+      "license": "BSD-3-Clause"
+    },
     "node_modules/aws-cdk-lib/node_modules/fs-extra": {
-      "version": "11.1.1",
+      "version": "11.3.0",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -2266,7 +2313,7 @@
       "license": "ISC"
     },
     "node_modules/aws-cdk-lib/node_modules/ignore": {
-      "version": "5.2.4",
+      "version": "5.3.2",
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -2298,7 +2345,7 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/jsonschema": {
-      "version": "1.4.1",
+      "version": "1.5.0",
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -2310,15 +2357,23 @@
       "inBundle": true,
       "license": "MIT"
     },
-    "node_modules/aws-cdk-lib/node_modules/lru-cache": {
-      "version": "6.0.0",
+    "node_modules/aws-cdk-lib/node_modules/mime-db": {
+      "version": "1.52.0",
       "inBundle": true,
-      "license": "ISC",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/mime-types": {
+      "version": "2.1.35",
+      "inBundle": true,
+      "license": "MIT",
       "dependencies": {
-        "yallist": "^4.0.0"
+        "mime-db": "1.52.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">= 0.6"
       }
     },
     "node_modules/aws-cdk-lib/node_modules/minimatch": {
@@ -2333,7 +2388,7 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/punycode": {
-      "version": "2.3.0",
+      "version": "2.3.1",
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -2349,12 +2404,9 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/semver": {
-      "version": "7.5.4",
+      "version": "7.7.1",
       "inBundle": true,
       "license": "ISC",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -2403,7 +2455,7 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/table": {
-      "version": "6.8.1",
+      "version": "6.9.0",
       "inBundle": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -2418,25 +2470,12 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/universalify": {
-      "version": "2.0.0",
+      "version": "2.0.1",
       "inBundle": true,
       "license": "MIT",
       "engines": {
         "node": ">= 10.0.0"
       }
-    },
-    "node_modules/aws-cdk-lib/node_modules/uri-js": {
-      "version": "4.4.1",
-      "inBundle": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "punycode": "^2.1.0"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/yallist": {
-      "version": "4.0.0",
-      "inBundle": true,
-      "license": "ISC"
     },
     "node_modules/aws-cdk-lib/node_modules/yaml": {
       "version": "1.10.2",
@@ -3988,7 +4027,6 @@
       "version": "5.2.4",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
       "integrity": "sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==",
-      "dev": true,
       "engines": {
         "node": ">= 4"
       }
@@ -5635,7 +5673,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
       "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -5860,7 +5897,6 @@
       "version": "7.5.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
       "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-      "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -5875,7 +5911,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -5886,8 +5921,7 @@
     "node_modules/semver/node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",

--- a/examples/aws-lambda/infrastructure/package.json
+++ b/examples/aws-lambda/infrastructure/package.json
@@ -17,7 +17,7 @@
     "@types/jest": "^29.4.0",
     "@types/node": "18.11.18",
     "@typescript-eslint/eslint-plugin": "5.59.11",
-    "aws-cdk": "^2.92.0",
+    "aws-cdk": "^2.1010.0",
     "eslint": "8.42.0",
     "eslint-config-prettier": "8.8.0",
     "eslint-plugin-import": "2.27.5",
@@ -30,7 +30,7 @@
     "typescript": "~4.9.4"
   },
   "dependencies": {
-    "@aws-cdk/aws-lambda-go-alpha": "^2.92.0-alpha.0",
+    "@aws-cdk/aws-lambda-go-alpha": "^2.190.0-alpha.0",
     "aws-cdk-lib": "^2.92.0",
     "constructs": "^10.0.0",
     "source-map-support": "^0.5.21"

--- a/examples/aws-lambda/lambda/main.go
+++ b/examples/aws-lambda/lambda/main.go
@@ -25,6 +25,7 @@ const (
 var (
 	cachedAuthToken  string = ""
 	secretsClient, _        = secretcache.New()
+	cacheClient      momento.CacheClient
 )
 
 func handler() (string, error) {
@@ -87,6 +88,10 @@ func getSecret(secretName string) (string, error) {
 }
 
 func getCacheClient() (momento.CacheClient, error) {
+	if cacheClient != nil {
+		return cacheClient, nil
+	}
+
 	authToken, secretErr := getSecret("MOMENTO_API_KEY_SECRET_NAME")
 	if secretErr != nil {
 		panic(secretErr)

--- a/examples/aws-lambda/lambda/main.go
+++ b/examples/aws-lambda/lambda/main.go
@@ -23,9 +23,9 @@ const (
 )
 
 var (
-	cachedAuthToken  string = ""
-	secretsClient, _        = secretcache.New()
-	cacheClient      momento.CacheClient
+	cachedAuthToken    string = ""
+	secretsClient, _          = secretcache.New()
+	momentoCacheClient momento.CacheClient
 )
 
 func handler() (string, error) {
@@ -88,8 +88,9 @@ func getSecret(secretName string) (string, error) {
 }
 
 func getCacheClient() (momento.CacheClient, error) {
-	if cacheClient != nil {
-		return cacheClient, nil
+	if momentoCacheClient != nil {
+		fmt.Println("Using cached Momento cache client")
+		return momentoCacheClient, nil
 	}
 
 	authToken, secretErr := getSecret("MOMENTO_API_KEY_SECRET_NAME")
@@ -102,7 +103,7 @@ func getCacheClient() (momento.CacheClient, error) {
 		panic(err)
 	}
 
-	cacheClient, initErr := momento.NewCacheClientWithEagerConnectTimeout(
+	newCacheClient, initErr := momento.NewCacheClientWithEagerConnectTimeout(
 		config.Lambda(),
 		credentialProvider,
 		60*time.Second,
@@ -112,7 +113,9 @@ func getCacheClient() (momento.CacheClient, error) {
 		panic(initErr)
 	}
 
-	return cacheClient, nil
+	fmt.Println("New cache client created")
+	momentoCacheClient = newCacheClient
+	return momentoCacheClient, nil
 }
 
 // To measure the latency of 100 GET requests to your Momento cache,


### PR DESCRIPTION
Closes https://github.com/momentohq/dev-eco-issue-tracker/issues/1224

Updated the lambda example to re-use the cache client after initialization.

Tested locally and also had to upgrade some dependencies to avoid warnings / deprecation notices.