### PR TITLE
feat: add base momento request and response interfaces

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -83,7 +83,7 @@ type Configuration interface {
 	//   myConfig := config.LaptopLatest().WithMiddleware([]middleware.Middleware{
 	//     NewMyMiddleware(middleware.Props{
 	//       Logger: loggerFactory.GetLogger("MyMiddleware"),
-	//       IncludeTypes: []interface{}{momento.GetRequest{}, momento.SetRequest{}},
+	//       IncludeTypes: []momento_request_base.MomentoCacheRequest{momento.GetRequest{}, momento.SetRequest{}},
 	//     }),
 	//   })
 	WithMiddleware(middleware []middleware.Middleware) Configuration

--- a/config/middleware/impl/compression_middleware.go
+++ b/config/middleware/impl/compression_middleware.go
@@ -6,6 +6,7 @@ import (
 	"github.com/momentohq/client-sdk-go/config/compression"
 	"github.com/momentohq/client-sdk-go/config/middleware"
 	"github.com/momentohq/client-sdk-go/momento"
+	momento_request_base "github.com/momentohq/client-sdk-go/momento/request_base"
 	"github.com/momentohq/client-sdk-go/responses"
 )
 
@@ -17,7 +18,7 @@ type CompressionMiddleware struct {
 }
 
 type CompressionMiddlewareProps struct {
-	IncludeTypes             []interface{}
+	IncludeTypes             []momento_request_base.MomentoCacheRequest
 	CompressionStrategyProps compression.CompressionStrategyProps
 	CompressorFactory        compression.CompressionStrategyFactory
 }
@@ -68,7 +69,7 @@ func getValueBytes(value momento.Value) ([]byte, error) {
 // Set, SetIfAbsent, SetIfPresent, SetIfEqual, SetIfNotEqual, SetIfAbsentOrEqual, SetIfPresentAndNotEqual,
 // SetWithHash, SetIfPresentAndHashEqual, SetIfPresentAndHashNotEqual, SetIfAbsentOrHashEqual, SetIfAbsentOrHashNotEqual.
 // Specify IncludeTypes in CompressionMiddlewareProps if you wish to compress only a subset of these requests.
-func (rh *CompressionMiddlewareRequestHandler) OnRequest(req interface{}) (interface{}, error) {
+func (rh *CompressionMiddlewareRequestHandler) OnRequest(req momento_request_base.MomentoCacheRequest) (momento_request_base.MomentoCacheRequest, error) {
 	// We still need to use a switch statement to be able to access the request objects
 	// as the specific request types in order to access the Value field.
 	switch r := req.(type) {
@@ -212,7 +213,7 @@ func (rh *CompressionMiddlewareRequestHandler) OnRequest(req interface{}) (inter
 
 // We currently decompress only on these scalar read responses: Get, GetWithHash.
 // Specify IncludeTypes in CompressionMiddlewareProps if you wish to decompress only a subset of these responses.
-func (rh *CompressionMiddlewareRequestHandler) OnResponse(resp interface{}) (interface{}, error) {
+func (rh *CompressionMiddlewareRequestHandler) OnResponse(resp interface{}) (responses.MomentoCacheResponse, error) {
 	// We still need to use a switch statement to be able to access the response objects
 	// as the specific response types in order to access the Value field.
 	switch r := resp.(type) {

--- a/config/middleware/impl/compression_test.go
+++ b/config/middleware/impl/compression_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/momentohq/client-sdk-go/auth"
 	"github.com/momentohq/client-sdk-go/config"
+	momento_request_base "github.com/momentohq/client-sdk-go/momento/request_base"
 
 	"github.com/momentohq/client-sdk-go/config/compression"
 	"github.com/momentohq/client-sdk-go/config/logger/momento_default_logger"
@@ -236,7 +237,7 @@ var _ = Describe("gzip-compression-middleware", Label("cache-service"), func() {
 						CompressionLevel: compression.CompressionLevelDefault,
 						Logger:           momento_default_logger.NewDefaultMomentoLoggerFactory(momento_default_logger.TRACE).GetLogger("gzip-test"),
 					},
-					IncludeTypes: []interface{}{
+					IncludeTypes: []momento_request_base.MomentoCacheRequest{
 						SetWithHashRequest{},
 						GetWithHashRequest{},
 					},
@@ -292,7 +293,7 @@ var _ = Describe("gzip-compression-middleware", Label("cache-service"), func() {
 						CompressionLevel: compression.CompressionLevelDefault,
 						Logger:           momento_default_logger.NewDefaultMomentoLoggerFactory(momento_default_logger.TRACE).GetLogger("gzip-test"),
 					},
-					IncludeTypes: []interface{}{
+					IncludeTypes: []momento_request_base.MomentoCacheRequest{
 						GetRequest{}, // try to decompress without any compression
 					},
 				}),

--- a/config/middleware/impl/gzip_compression_middleware.go
+++ b/config/middleware/impl/gzip_compression_middleware.go
@@ -9,6 +9,7 @@ import (
 	"github.com/momentohq/client-sdk-go/config/compression"
 	"github.com/momentohq/client-sdk-go/config/logger"
 	"github.com/momentohq/client-sdk-go/config/middleware"
+	momento_request_base "github.com/momentohq/client-sdk-go/momento/request_base"
 )
 
 // GzipCompressorFactory implements the CompressionStrategyFactory interface.
@@ -98,7 +99,7 @@ func isGzipCompressed(data []byte) bool {
 }
 
 type GzipCompressionMiddlewareProps struct {
-	IncludeTypes             []interface{}
+	IncludeTypes             []momento_request_base.MomentoCacheRequest
 	CompressionStrategyProps compression.CompressionStrategyProps
 }
 

--- a/config/middleware/impl/in_flight_request_count_middleware.go
+++ b/config/middleware/impl/in_flight_request_count_middleware.go
@@ -5,6 +5,7 @@ import (
 	"sync/atomic"
 
 	"github.com/momentohq/client-sdk-go/config/middleware"
+	"github.com/momentohq/client-sdk-go/responses"
 )
 
 type inFlightRequestCountMiddleware struct {
@@ -48,7 +49,7 @@ func NewInFlightRequestCountMiddlewareRequestHandler(
 	return &inFlightRequestCountMiddlewareRequestHandler{rh, countAfterAdd, remover}
 }
 
-func (rh *inFlightRequestCountMiddlewareRequestHandler) OnResponse(_ interface{}) (interface{}, error) {
+func (rh *inFlightRequestCountMiddlewareRequestHandler) OnResponse(_ interface{}) (responses.MomentoCacheResponse, error) {
 	countAfterRemove := rh.remover()
 	rh.GetLogger().Info(
 		fmt.Sprintf(

--- a/momento/decrease_ttl.go
+++ b/momento/decrease_ttl.go
@@ -71,3 +71,7 @@ func (r *DecreaseTtlRequest) interpretGrpcResponse(theResponse interface{}) (int
 	}
 	return resp, nil
 }
+
+func (c DecreaseTtlRequest) GetRequestName() string {
+	return "DecreaseTtlRequest"
+}

--- a/momento/delete.go
+++ b/momento/delete.go
@@ -50,3 +50,7 @@ func (r *DeleteRequest) makeGrpcRequest(grpcRequest interface{}, requestMetadata
 func (r *DeleteRequest) interpretGrpcResponse(_ interface{}) (interface{}, error) {
 	return &responses.DeleteSuccess{}, nil
 }
+
+func (c DeleteRequest) GetRequestName() string {
+	return "DeleteRequest"
+}

--- a/momento/dictionary_fetch.go
+++ b/momento/dictionary_fetch.go
@@ -56,3 +56,7 @@ func (r *DictionaryFetchRequest) interpretGrpcResponse(resp interface{}) (interf
 		return nil, errUnexpectedGrpcResponse(r, myResp)
 	}
 }
+
+func (c DictionaryFetchRequest) GetRequestName() string {
+	return "DictionaryFetchRequest"
+}

--- a/momento/dictionary_get_field.go
+++ b/momento/dictionary_get_field.go
@@ -7,3 +7,7 @@ type DictionaryGetFieldRequest struct {
 }
 
 func (r *DictionaryGetFieldRequest) cacheName() string { return r.CacheName }
+
+func (c DictionaryGetFieldRequest) GetRequestName() string {
+	return "DictionaryGetFieldRequest"
+}

--- a/momento/dictionary_get_fields.go
+++ b/momento/dictionary_get_fields.go
@@ -78,3 +78,7 @@ func (r *DictionaryGetFieldsRequest) interpretGrpcResponse(resp interface{}) (in
 		return nil, errUnexpectedGrpcResponse(r, r.grpcResponse)
 	}
 }
+
+func (c DictionaryGetFieldsRequest) GetRequestName() string {
+	return "DictionaryGetFieldsRequest"
+}

--- a/momento/dictionary_increment.go
+++ b/momento/dictionary_increment.go
@@ -83,3 +83,7 @@ func (r *DictionaryIncrementRequest) interpretGrpcResponse(resp interface{}) (in
 	myResp := resp.(*pb.XDictionaryIncrementResponse)
 	return responses.NewDictionaryIncrementSuccess(myResp.Value), nil
 }
+
+func (c DictionaryIncrementRequest) GetRequestName() string {
+	return "DictionaryIncrementRequest"
+}

--- a/momento/dictionary_length.go
+++ b/momento/dictionary_length.go
@@ -52,3 +52,7 @@ func (r *DictionaryLengthRequest) interpretGrpcResponse(resp interface{}) (inter
 		return nil, errUnexpectedGrpcResponse(r, myResp)
 	}
 }
+
+func (c DictionaryLengthRequest) GetRequestName() string {
+	return "DictionaryLengthRequest"
+}

--- a/momento/dictionary_remove_field.go
+++ b/momento/dictionary_remove_field.go
@@ -7,3 +7,7 @@ type DictionaryRemoveFieldRequest struct {
 }
 
 func (r *DictionaryRemoveFieldRequest) cacheName() string { return r.CacheName }
+
+func (c DictionaryRemoveFieldRequest) GetRequestName() string {
+	return "DictionaryRemoveFieldRequest"
+}

--- a/momento/dictionary_remove_fields.go
+++ b/momento/dictionary_remove_fields.go
@@ -54,3 +54,7 @@ func (r *DictionaryRemoveFieldsRequest) makeGrpcRequest(grpcRequest interface{},
 func (r *DictionaryRemoveFieldsRequest) interpretGrpcResponse(_ interface{}) (interface{}, error) {
 	return &responses.DictionaryRemoveFieldsSuccess{}, nil
 }
+
+func (c DictionaryRemoveFieldsRequest) GetRequestName() string {
+	return "DictionaryRemoveFieldsRequest"
+}

--- a/momento/dictionary_set_field.go
+++ b/momento/dictionary_set_field.go
@@ -13,3 +13,7 @@ type DictionarySetFieldRequest struct {
 }
 
 func (r *DictionarySetFieldRequest) cacheName() string { return r.CacheName }
+
+func (c DictionarySetFieldRequest) GetRequestName() string {
+	return "DictionarySetFieldRequest"
+}

--- a/momento/dictionary_set_fields.go
+++ b/momento/dictionary_set_fields.go
@@ -81,3 +81,7 @@ func (r *DictionarySetFieldsRequest) makeGrpcRequest(grpcRequest interface{}, re
 func (r *DictionarySetFieldsRequest) interpretGrpcResponse(_ interface{}) (interface{}, error) {
 	return &responses.DictionarySetFieldsSuccess{}, nil
 }
+
+func (c DictionarySetFieldsRequest) GetRequestName() string {
+	return "DictionarySetFieldsRequest"
+}

--- a/momento/get.go
+++ b/momento/get.go
@@ -58,3 +58,7 @@ func (r *GetRequest) interpretGrpcResponse(resp interface{}) (interface{}, error
 		return nil, errUnexpectedGrpcResponse(r, myResp)
 	}
 }
+
+func (c GetRequest) GetRequestName() string {
+	return "GetRequest"
+}

--- a/momento/get_batch.go
+++ b/momento/get_batch.go
@@ -90,3 +90,7 @@ func (r *GetBatchRequest) interpretGrpcResponse(_ interface{}) (interface{}, err
 
 	return *responses.NewGetBatchSuccess(getResponses, r.byteKeys), nil
 }
+
+func (c GetBatchRequest) GetRequestName() string {
+	return "GetBatchRequest"
+}

--- a/momento/get_with_hash.go
+++ b/momento/get_with_hash.go
@@ -64,3 +64,7 @@ func (r *GetWithHashRequest) interpretGrpcResponse(resp interface{}) (interface{
 		return nil, errUnexpectedGrpcResponse(r, grpcResponse)
 	}
 }
+
+func (c GetWithHashRequest) GetRequestName() string {
+	return "GetWithHashRequest"
+}

--- a/momento/increase_ttl.go
+++ b/momento/increase_ttl.go
@@ -71,3 +71,7 @@ func (r *IncreaseTtlRequest) interpretGrpcResponse(resp interface{}) (interface{
 
 	return theResponse, nil
 }
+
+func (c IncreaseTtlRequest) GetRequestName() string {
+	return "IncreaseTtlRequest"
+}

--- a/momento/increment.go
+++ b/momento/increment.go
@@ -65,3 +65,7 @@ func (r *IncrementRequest) interpretGrpcResponse(resp interface{}) (interface{},
 	myResp := resp.(*pb.XIncrementResponse)
 	return responses.NewIncrementSuccess(myResp.Value), nil
 }
+
+func (c IncrementRequest) GetRequestName() string {
+	return "IncrementRequest"
+}

--- a/momento/item_get_ttl.go
+++ b/momento/item_get_ttl.go
@@ -54,3 +54,7 @@ func (r *ItemGetTtlRequest) interpretGrpcResponse(resp interface{}) (interface{}
 		return nil, errUnexpectedGrpcResponse(r, myResp)
 	}
 }
+
+func (c ItemGetTtlRequest) GetRequestName() string {
+	return "ItemGetTtlRequest"
+}

--- a/momento/item_get_type.go
+++ b/momento/item_get_type.go
@@ -55,3 +55,7 @@ func (r *ItemGetTypeRequest) interpretGrpcResponse(resp interface{}) (interface{
 		return nil, errUnexpectedGrpcResponse(r, myResp)
 	}
 }
+
+func (c ItemGetTypeRequest) GetRequestName() string {
+	return "ItemGetTypeRequest"
+}

--- a/momento/keys_exist.go
+++ b/momento/keys_exist.go
@@ -49,3 +49,7 @@ func (r *KeysExistRequest) interpretGrpcResponse(resp interface{}) (interface{},
 	myResp := resp.(*pb.XKeysExistResponse)
 	return responses.NewKeysExistSuccess(myResp.Exists), nil
 }
+
+func (c KeysExistRequest) GetRequestName() string {
+	return "KeysExistRequest"
+}

--- a/momento/list_caches.go
+++ b/momento/list_caches.go
@@ -1,3 +1,7 @@
 package momento
 
 type ListCachesRequest struct{}
+
+func (c ListCachesRequest) GetRequestName() string {
+	return "ListCachesRequest"
+}

--- a/momento/list_concatenate_back.go
+++ b/momento/list_concatenate_back.go
@@ -73,3 +73,7 @@ func (r *ListConcatenateBackRequest) interpretGrpcResponse(resp interface{}) (in
 	myResp := resp.(*pb.XListConcatenateBackResponse)
 	return responses.NewListConcatenateBackSuccess(myResp.ListLength), nil
 }
+
+func (c ListConcatenateBackRequest) GetRequestName() string {
+	return "ListConcatenateBackRequest"
+}

--- a/momento/list_concatenate_front.go
+++ b/momento/list_concatenate_front.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	pb "github.com/momentohq/client-sdk-go/internal/protos"
+	momento_request_base "github.com/momentohq/client-sdk-go/momento/request_base"
 	"github.com/momentohq/client-sdk-go/responses"
 	"github.com/momentohq/client-sdk-go/utils"
 	"google.golang.org/grpc"
@@ -71,4 +72,15 @@ func (r *ListConcatenateFrontRequest) makeGrpcRequest(grpcRequest interface{}, r
 func (r *ListConcatenateFrontRequest) interpretGrpcResponse(resp interface{}) (interface{}, error) {
 	myResp := resp.(*pb.XListConcatenateFrontResponse)
 	return responses.NewListConcatenateFrontSuccess(myResp.ListLength), nil
+}
+
+type BaseListConcatenateFrontRequest interface {
+	momento_request_base.MomentoCacheRequest
+	isBaseListConcatenateFrontRequest()
+}
+
+func (c ListConcatenateFrontRequest) isBaseListConcatenateFrontRequest() {}
+
+func (c ListConcatenateFrontRequest) GetRequestName() string {
+	return "ListConcatenateFrontRequest"
 }

--- a/momento/list_fetch.go
+++ b/momento/list_fetch.go
@@ -70,3 +70,7 @@ func (r *ListFetchRequest) interpretGrpcResponse(resp interface{}) (interface{},
 		return nil, errUnexpectedGrpcResponse(r, myResp)
 	}
 }
+
+func (c ListFetchRequest) GetRequestName() string {
+	return "ListFetchRequest"
+}

--- a/momento/list_length.go
+++ b/momento/list_length.go
@@ -52,3 +52,7 @@ func (r *ListLengthRequest) interpretGrpcResponse(resp interface{}) (interface{}
 		return nil, errUnexpectedGrpcResponse(r, myResp)
 	}
 }
+
+func (c ListLengthRequest) GetRequestName() string {
+	return "ListLengthRequest"
+}

--- a/momento/list_pop_back.go
+++ b/momento/list_pop_back.go
@@ -50,3 +50,7 @@ func (r *ListPopBackRequest) interpretGrpcResponse(resp interface{}) (interface{
 		return nil, errUnexpectedGrpcResponse(r, myResp)
 	}
 }
+
+func (c ListPopBackRequest) GetRequestName() string {
+	return "ListPopBackRequest"
+}

--- a/momento/list_pop_front.go
+++ b/momento/list_pop_front.go
@@ -50,3 +50,7 @@ func (r *ListPopFrontRequest) interpretGrpcResponse(resp interface{}) (interface
 		return nil, errUnexpectedGrpcResponse(r, myResp)
 	}
 }
+
+func (c ListPopFrontRequest) GetRequestName() string {
+	return "ListPopFrontRequest"
+}

--- a/momento/list_push_back.go
+++ b/momento/list_push_back.go
@@ -73,3 +73,7 @@ func (r *ListPushBackRequest) interpretGrpcResponse(resp interface{}) (interface
 	myResp := resp.(*pb.XListPushBackResponse)
 	return responses.NewListPushBackSuccess(myResp.ListLength), nil
 }
+
+func (c ListPushBackRequest) GetRequestName() string {
+	return "ListPushBackRequest"
+}

--- a/momento/list_push_front.go
+++ b/momento/list_push_front.go
@@ -73,3 +73,7 @@ func (r *ListPushFrontRequest) interpretGrpcResponse(resp interface{}) (interfac
 	myResp := resp.(*pb.XListPushFrontResponse)
 	return responses.NewListPushFrontSuccess(myResp.ListLength), nil
 }
+
+func (c ListPushFrontRequest) GetRequestName() string {
+	return "ListPushFrontRequest"
+}

--- a/momento/list_remove_value.go
+++ b/momento/list_remove_value.go
@@ -55,3 +55,7 @@ func (r *ListRemoveValueRequest) makeGrpcRequest(grpcRequest interface{}, reques
 func (r *ListRemoveValueRequest) interpretGrpcResponse(_ interface{}) (interface{}, error) {
 	return &responses.ListRemoveValueSuccess{}, nil
 }
+
+func (c ListRemoveValueRequest) GetRequestName() string {
+	return "ListRemoveValueRequest"
+}

--- a/momento/request_base/base_request_types.go
+++ b/momento/request_base/base_request_types.go
@@ -1,0 +1,7 @@
+package momento_request_base
+
+type MomentoCacheRequest interface {
+	GetRequestName() string
+}
+
+type MomentoTopicRequest interface{}

--- a/momento/requester.go
+++ b/momento/requester.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	momento_request_base "github.com/momentohq/client-sdk-go/momento/request_base"
 	"github.com/momentohq/client-sdk-go/utils"
 	"google.golang.org/grpc/metadata"
 
@@ -27,6 +28,7 @@ func errUnexpectedGrpcResponse(r requester, grpcResp grpcResponse) momentoerrors
 }
 
 type requester interface {
+	momento_request_base.MomentoCacheRequest
 	hasCacheName
 	initGrpcRequest(client scsDataClient) (interface{}, error)
 	makeGrpcRequest(grpcRequest interface{}, requestMetadata context.Context, client scsDataClient) (grpcResponse, []metadata.MD, error)

--- a/momento/retry_test.go
+++ b/momento/retry_test.go
@@ -715,6 +715,7 @@ var _ = Describe("retry eligibility-strategy", Label(RETRY_LABEL, MOMENTO_LOCAL_
 				})
 				Expect(getResponse).To(BeNil())
 				Expect(err).To(Not(BeNil()))
+				Expect(err.Error()).To(ContainSubstring("TimeoutError"))
 				Expect(err).To(HaveMomentoErrorCode(TimeoutError))
 
 				// Should receive errors after shortDelay ms and retry every RETRY_DELAY_INTERVAL_MILLIS
@@ -763,6 +764,7 @@ var _ = Describe("retry eligibility-strategy", Label(RETRY_LABEL, MOMENTO_LOCAL_
 				})
 				Expect(getResponse).To(BeNil())
 				Expect(err).To(Not(BeNil()))
+				Expect(err.Error()).To(ContainSubstring("TimeoutError"))
 				Expect(err).To(HaveMomentoErrorCode(TimeoutError))
 
 				// Should receive errors after longDelay ms and retry every RETRY_DELAY_INTERVAL_MILLIS

--- a/momento/set.go
+++ b/momento/set.go
@@ -73,3 +73,7 @@ func (r *SetRequest) makeGrpcRequest(grpcRequest interface{}, requestMetadata co
 func (r *SetRequest) interpretGrpcResponse(_ interface{}) (interface{}, error) {
 	return &responses.SetSuccess{}, nil
 }
+
+func (c SetRequest) GetRequestName() string {
+	return "SetRequest"
+}

--- a/momento/set_add_element.go
+++ b/momento/set_add_element.go
@@ -12,3 +12,7 @@ type SetAddElementRequest struct {
 }
 
 func (r *SetAddElementRequest) cacheName() string { return r.CacheName }
+
+func (c SetAddElementRequest) GetRequestName() string {
+	return "SetAddElementRequest"
+}

--- a/momento/set_add_elements.go
+++ b/momento/set_add_elements.go
@@ -70,3 +70,7 @@ func (r *SetAddElementsRequest) makeGrpcRequest(grpcRequest interface{}, request
 func (r *SetAddElementsRequest) interpretGrpcResponse(_ interface{}) (interface{}, error) {
 	return &responses.SetAddElementsSuccess{}, nil
 }
+
+func (c SetAddElementsRequest) GetRequestName() string {
+	return "SetAddElementsRequest"
+}

--- a/momento/set_batch.go
+++ b/momento/set_batch.go
@@ -92,3 +92,7 @@ func (r *SetBatchRequest) interpretGrpcResponse(_ interface{}) (interface{}, err
 
 	return *responses.NewSetBatchSuccess(setResponses), nil
 }
+
+func (c SetBatchRequest) GetRequestName() string {
+	return "SetBatchRequest"
+}

--- a/momento/set_contains_elements.go
+++ b/momento/set_contains_elements.go
@@ -61,3 +61,7 @@ func (r *SetContainsElementsRequest) interpretGrpcResponse(resp interface{}) (in
 		return nil, errUnexpectedGrpcResponse(r, myResp)
 	}
 }
+
+func (c SetContainsElementsRequest) GetRequestName() string {
+	return "SetContainsElementsRequest"
+}

--- a/momento/set_fetch.go
+++ b/momento/set_fetch.go
@@ -52,3 +52,7 @@ func (r *SetFetchRequest) interpretGrpcResponse(resp interface{}) (interface{}, 
 		return nil, errUnexpectedGrpcResponse(r, myResp)
 	}
 }
+
+func (c SetFetchRequest) GetRequestName() string {
+	return "SetFetchRequest"
+}

--- a/momento/set_if_absent.go
+++ b/momento/set_if_absent.go
@@ -89,3 +89,7 @@ func (r *SetIfAbsentRequest) interpretGrpcResponse(resp interface{}) (interface{
 		return nil, errUnexpectedGrpcResponse(r, myResp)
 	}
 }
+
+func (c SetIfAbsentRequest) GetRequestName() string {
+	return "SetIfAbsentRequest"
+}

--- a/momento/set_if_absent_or_equal.go
+++ b/momento/set_if_absent_or_equal.go
@@ -97,3 +97,7 @@ func (r *SetIfAbsentOrEqualRequest) interpretGrpcResponse(resp interface{}) (int
 		return nil, errUnexpectedGrpcResponse(r, myResp)
 	}
 }
+
+func (c SetIfAbsentOrEqualRequest) GetRequestName() string {
+	return "SetIfAbsentOrEqualRequest"
+}

--- a/momento/set_if_absent_or_hash_equal.go
+++ b/momento/set_if_absent_or_hash_equal.go
@@ -101,3 +101,7 @@ func (r *SetIfAbsentOrHashEqualRequest) interpretGrpcResponse(resp interface{}) 
 		return nil, errUnexpectedGrpcResponse(r, grpcResponse)
 	}
 }
+
+func (c SetIfAbsentOrHashEqualRequest) GetRequestName() string {
+	return "SetIfAbsentOrHashEqualRequest"
+}

--- a/momento/set_if_absent_or_hash_not_equal.go
+++ b/momento/set_if_absent_or_hash_not_equal.go
@@ -101,3 +101,7 @@ func (r *SetIfAbsentOrHashNotEqualRequest) interpretGrpcResponse(resp interface{
 		return nil, errUnexpectedGrpcResponse(r, grpcResponse)
 	}
 }
+
+func (c SetIfAbsentOrHashNotEqualRequest) GetRequestName() string {
+	return "SetIfAbsentOrHashNotEqualRequest"
+}

--- a/momento/set_if_equal.go
+++ b/momento/set_if_equal.go
@@ -96,3 +96,7 @@ func (r *SetIfEqualRequest) interpretGrpcResponse(resp interface{}) (interface{}
 		return nil, errUnexpectedGrpcResponse(r, myResp)
 	}
 }
+
+func (c SetIfEqualRequest) GetRequestName() string {
+	return "SetIfEqualRequest"
+}

--- a/momento/set_if_not_equal.go
+++ b/momento/set_if_not_equal.go
@@ -97,3 +97,7 @@ func (r *SetIfNotEqualRequest) interpretGrpcResponse(resp interface{}) (interfac
 		return nil, errUnexpectedGrpcResponse(r, myResp)
 	}
 }
+
+func (c SetIfNotEqualRequest) GetRequestName() string {
+	return "SetIfNotEqualRequest"
+}

--- a/momento/set_if_not_exists.go
+++ b/momento/set_if_not_exists.go
@@ -86,3 +86,7 @@ func (r *SetIfNotExistsRequest) interpretGrpcResponse(resp interface{}) (interfa
 		return nil, errUnexpectedGrpcResponse(r, myResp)
 	}
 }
+
+func (c SetIfNotExistsRequest) GetRequestName() string {
+	return "SetIfNotExistsRequest"
+}

--- a/momento/set_if_present.go
+++ b/momento/set_if_present.go
@@ -81,3 +81,7 @@ func (r *SetIfPresentRequest) interpretGrpcResponse(resp interface{}) (interface
 		return nil, errUnexpectedGrpcResponse(r, myResp)
 	}
 }
+
+func (c SetIfPresentRequest) GetRequestName() string {
+	return "SetIfPresentRequest"
+}

--- a/momento/set_if_present_and_hash_equal.go
+++ b/momento/set_if_present_and_hash_equal.go
@@ -101,3 +101,7 @@ func (r *SetIfPresentAndHashEqualRequest) interpretGrpcResponse(resp interface{}
 		return nil, errUnexpectedGrpcResponse(r, grpcResponse)
 	}
 }
+
+func (c SetIfPresentAndHashEqualRequest) GetRequestName() string {
+	return "SetIfPresentAndHashEqualRequest"
+}

--- a/momento/set_if_present_and_hash_not_equal.go
+++ b/momento/set_if_present_and_hash_not_equal.go
@@ -103,3 +103,7 @@ func (r *SetIfPresentAndHashNotEqualRequest) interpretGrpcResponse(resp interfac
 		return nil, errUnexpectedGrpcResponse(r, grpcResponse)
 	}
 }
+
+func (c SetIfPresentAndHashNotEqualRequest) GetRequestName() string {
+	return "SetIfPresentAndHashNotEqualRequest"
+}

--- a/momento/set_if_present_and_not_equal.go
+++ b/momento/set_if_present_and_not_equal.go
@@ -96,3 +96,7 @@ func (r *SetIfPresentAndNotEqualRequest) interpretGrpcResponse(resp interface{})
 		return nil, errUnexpectedGrpcResponse(r, myResp)
 	}
 }
+
+func (c SetIfPresentAndNotEqualRequest) GetRequestName() string {
+	return "SetIfPresentAndNotEqualRequest"
+}

--- a/momento/set_length.go
+++ b/momento/set_length.go
@@ -52,3 +52,7 @@ func (r *SetLengthRequest) interpretGrpcResponse(resp interface{}) (interface{},
 		return nil, errUnexpectedGrpcResponse(r, myResp)
 	}
 }
+
+func (c SetLengthRequest) GetRequestName() string {
+	return "SetLengthRequest"
+}

--- a/momento/set_pop.go
+++ b/momento/set_pop.go
@@ -61,3 +61,7 @@ func (r *SetPopRequest) interpretGrpcResponse(resp interface{}) (interface{}, er
 		return nil, errUnexpectedGrpcResponse(r, myResp)
 	}
 }
+
+func (c SetPopRequest) GetRequestName() string {
+	return "SetPopRequest"
+}

--- a/momento/set_remove_element.go
+++ b/momento/set_remove_element.go
@@ -7,3 +7,7 @@ type SetRemoveElementRequest struct {
 }
 
 func (r *SetRemoveElementRequest) cacheName() string { return r.CacheName }
+
+func (c SetRemoveElementRequest) GetRequestName() string {
+	return "SetRemoveElementRequest"
+}

--- a/momento/set_remove_elements.go
+++ b/momento/set_remove_elements.go
@@ -61,3 +61,7 @@ func (r *SetRemoveElementsRequest) makeGrpcRequest(grpcRequest interface{}, requ
 func (r *SetRemoveElementsRequest) interpretGrpcResponse(_ interface{}) (interface{}, error) {
 	return &responses.SetRemoveElementsSuccess{}, nil
 }
+
+func (c SetRemoveElementsRequest) GetRequestName() string {
+	return "SetRemoveElementsRequest"
+}

--- a/momento/set_with_hash.go
+++ b/momento/set_with_hash.go
@@ -89,3 +89,7 @@ func (r *SetWithHashRequest) interpretGrpcResponse(resp interface{}) (interface{
 		return nil, errUnexpectedGrpcResponse(r, grpcResponse)
 	}
 }
+
+func (c SetWithHashRequest) GetRequestName() string {
+	return "SetWithHashRequest"
+}

--- a/momento/sorted_set_fetch_by_rank.go
+++ b/momento/sorted_set_fetch_by_rank.go
@@ -98,3 +98,7 @@ func sortedSetByRankGrpcElementToModel(grpcSetElements []*pb.XSortedSetElement) 
 	}
 	return returnList
 }
+
+func (c SortedSetFetchByRankRequest) GetRequestName() string {
+	return "SortedSetFetchByRankRequest"
+}

--- a/momento/sorted_set_fetch_by_score.go
+++ b/momento/sorted_set_fetch_by_score.go
@@ -108,3 +108,7 @@ func sortedSetByScoreGrpcElementToModel(grpcSetElements []*pb.XSortedSetElement)
 	}
 	return returnList
 }
+
+func (c SortedSetFetchByScoreRequest) GetRequestName() string {
+	return "SortedSetFetchByScoreRequest"
+}

--- a/momento/sorted_set_get_rank.go
+++ b/momento/sorted_set_get_rank.go
@@ -71,3 +71,7 @@ func (r *SortedSetGetRankRequest) interpretGrpcResponse(resp interface{}) (inter
 		return nil, errUnexpectedGrpcResponse(r, myResp)
 	}
 }
+
+func (c SortedSetGetRankRequest) GetRequestName() string {
+	return "SortedSetGetRankRequest"
+}

--- a/momento/sorted_set_get_score.go
+++ b/momento/sorted_set_get_score.go
@@ -7,3 +7,7 @@ type SortedSetGetScoreRequest struct {
 }
 
 func (r *SortedSetGetScoreRequest) cacheName() string { return r.CacheName }
+
+func (c SortedSetGetScoreRequest) GetRequestName() string {
+	return "SortedSetGetScoreRequest"
+}

--- a/momento/sorted_set_get_scores.go
+++ b/momento/sorted_set_get_scores.go
@@ -83,3 +83,7 @@ func convertSortedSetScoreElement(grpcSetElements []*pb.XSortedSetGetScoreRespon
 	}
 	return rList
 }
+
+func (c SortedSetGetScoresRequest) GetRequestName() string {
+	return "SortedSetGetScoresRequest"
+}

--- a/momento/sorted_set_increment_score.go
+++ b/momento/sorted_set_increment_score.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/momentohq/client-sdk-go/internal/momentoerrors"
 	pb "github.com/momentohq/client-sdk-go/internal/protos"
-
 	"github.com/momentohq/client-sdk-go/utils"
 )
 
@@ -82,4 +81,8 @@ func (r *SortedSetIncrementScoreRequest) makeGrpcRequest(grpcRequest interface{}
 func (r *SortedSetIncrementScoreRequest) interpretGrpcResponse(resp interface{}) (interface{}, error) {
 	myResp := resp.(*pb.XSortedSetIncrementResponse)
 	return responses.SortedSetIncrementScoreSuccess(myResp.Score), nil
+}
+
+func (c SortedSetIncrementScoreRequest) GetRequestName() string {
+	return "SortedSetIncrementScoreRequest"
 }

--- a/momento/sorted_set_length.go
+++ b/momento/sorted_set_length.go
@@ -52,3 +52,7 @@ func (r *SortedSetLengthRequest) interpretGrpcResponse(resp interface{}) (interf
 		return nil, errUnexpectedGrpcResponse(r, myResp)
 	}
 }
+
+func (c SortedSetLengthRequest) GetRequestName() string {
+	return "SortedSetLengthRequest"
+}

--- a/momento/sorted_set_length_by_score.go
+++ b/momento/sorted_set_length_by_score.go
@@ -75,3 +75,7 @@ func (r *SortedSetLengthByScoreRequest) interpretGrpcResponse(resp interface{}) 
 		return nil, errUnexpectedGrpcResponse(r, myResp)
 	}
 }
+
+func (c SortedSetLengthByScoreRequest) GetRequestName() string {
+	return "SortedSetLengthByScoreRequest"
+}

--- a/momento/sorted_set_put_element.go
+++ b/momento/sorted_set_put_element.go
@@ -13,3 +13,7 @@ type SortedSetPutElementRequest struct {
 }
 
 func (r *SortedSetPutElementRequest) cacheName() string { return r.CacheName }
+
+func (c SortedSetPutElementRequest) GetRequestName() string {
+	return "SortedSetPutElementRequest"
+}

--- a/momento/sorted_set_put_elements.go
+++ b/momento/sorted_set_put_elements.go
@@ -89,3 +89,7 @@ func convertSortedSetElementsToGrpc(modelSetElements []SortedSetElement) ([]*pb.
 	}
 	return returnList, nil
 }
+
+func (c SortedSetPutElementsRequest) GetRequestName() string {
+	return "SortedSetPutElementsRequest"
+}

--- a/momento/sorted_set_remove_element.go
+++ b/momento/sorted_set_remove_element.go
@@ -7,3 +7,7 @@ type SortedSetRemoveElementRequest struct {
 }
 
 func (r *SortedSetRemoveElementRequest) cacheName() string { return r.CacheName }
+
+func (c SortedSetRemoveElementRequest) GetRequestName() string {
+	return "SortedSetRemoveElementRequest"
+}

--- a/momento/sorted_set_remove_elements.go
+++ b/momento/sorted_set_remove_elements.go
@@ -57,3 +57,7 @@ func (r *SortedSetRemoveElementsRequest) makeGrpcRequest(grpcRequest interface{}
 func (r *SortedSetRemoveElementsRequest) interpretGrpcResponse(_ interface{}) (interface{}, error) {
 	return &responses.SortedSetRemoveElementsSuccess{}, nil
 }
+
+func (c SortedSetRemoveElementsRequest) GetRequestName() string {
+	return "SortedSetRemoveElementsRequest"
+}

--- a/momento/topic_subscribe.go
+++ b/momento/topic_subscribe.go
@@ -1,6 +1,8 @@
 package momento
 
-import "github.com/momentohq/client-sdk-go/config/retry"
+import (
+	"github.com/momentohq/client-sdk-go/config/retry"
+)
 
 type TopicSubscribeRequest struct {
 	CacheName                   string

--- a/momento/update_ttl.go
+++ b/momento/update_ttl.go
@@ -66,3 +66,7 @@ func (r *UpdateTtlRequest) interpretGrpcResponse(resp interface{}) (interface{},
 		return nil, errUnexpectedGrpcResponse(r, myResp)
 	}
 }
+
+func (c UpdateTtlRequest) GetRequestName() string {
+	return "UpdateTtlRequest"
+}

--- a/responses/auth/generate_api_key.go
+++ b/responses/auth/generate_api_key.go
@@ -1,9 +1,13 @@
 package responses
 
-import "github.com/momentohq/client-sdk-go/utils"
+import (
+	"github.com/momentohq/client-sdk-go/responses"
+	"github.com/momentohq/client-sdk-go/utils"
+)
 
 // GenerateApiKeyResponse is the base response type for a generate api key request.
 type GenerateApiKeyResponse interface {
+	responses.MomentoAuthResponse
 	isGenerateApiKeyResponse()
 }
 

--- a/responses/auth/generate_disposable_token.go
+++ b/responses/auth/generate_disposable_token.go
@@ -1,7 +1,10 @@
 package responses
 
+import "github.com/momentohq/client-sdk-go/responses"
+
 // GenerateDisposableTokenResponse is the base response type for a generate disposable token request.
 type GenerateDisposableTokenResponse interface {
+	responses.MomentoAuthResponse
 	isGenerateDisposableTokenResponse()
 }
 

--- a/responses/auth/refresh_api_key.go
+++ b/responses/auth/refresh_api_key.go
@@ -1,9 +1,13 @@
 package responses
 
-import "github.com/momentohq/client-sdk-go/utils"
+import (
+	"github.com/momentohq/client-sdk-go/responses"
+	"github.com/momentohq/client-sdk-go/utils"
+)
 
 // RefreshApiKeyResponse is the base response type for a refresh api key request.
 type RefreshApiKeyResponse interface {
+	responses.MomentoAuthResponse
 	isRefreshApiKeyResponse()
 }
 

--- a/responses/base_response_types.go
+++ b/responses/base_response_types.go
@@ -1,0 +1,9 @@
+package responses
+
+type MomentoCacheResponse interface{}
+
+type MomentoTopicResponse interface{}
+
+type MomentoLeaderboardResponse interface{}
+
+type MomentoAuthResponse interface{}

--- a/responses/create_cache.go
+++ b/responses/create_cache.go
@@ -2,6 +2,7 @@ package responses
 
 // CreateCacheResponse is the base response type for a create cache request.
 type CreateCacheResponse interface {
+	MomentoCacheResponse
 	isCreateCacheResponse()
 }
 

--- a/responses/decrease_ttl.go
+++ b/responses/decrease_ttl.go
@@ -2,6 +2,7 @@ package responses
 
 // DecreaseTtlResponse is the base response type for a decrease ttl request.
 type DecreaseTtlResponse interface {
+	MomentoCacheResponse
 	isDecreaseTtlResponse()
 }
 

--- a/responses/delete.go
+++ b/responses/delete.go
@@ -2,6 +2,7 @@ package responses
 
 // DeleteResponse is the base response type for a delete request.
 type DeleteResponse interface {
+	MomentoCacheResponse
 	isDeleteResponse()
 }
 

--- a/responses/delete_cache.go
+++ b/responses/delete_cache.go
@@ -2,6 +2,7 @@ package responses
 
 // DeleteCacheResponse is the base response type for a delete cache request.
 type DeleteCacheResponse interface {
+	MomentoCacheResponse
 	isDeleteCacheResponse()
 }
 

--- a/responses/dictionary_fetch.go
+++ b/responses/dictionary_fetch.go
@@ -2,6 +2,7 @@ package responses
 
 // DictionaryFetchResponse is the base response type for a dictionary fetch request.
 type DictionaryFetchResponse interface {
+	MomentoCacheResponse
 	isDictionaryFetchResponse()
 }
 

--- a/responses/dictionary_get_field.go
+++ b/responses/dictionary_get_field.go
@@ -2,6 +2,7 @@ package responses
 
 // DictionaryGetFieldResponse is the base response type for a dictionary get field request.
 type DictionaryGetFieldResponse interface {
+	MomentoCacheResponse
 	isDictionaryGetFieldResponse()
 }
 

--- a/responses/dictionary_get_fields.go
+++ b/responses/dictionary_get_fields.go
@@ -4,6 +4,7 @@ import pb "github.com/momentohq/client-sdk-go/internal/protos"
 
 // DictionaryGetFieldsResponse is the base response type for a dictionary fields request.
 type DictionaryGetFieldsResponse interface {
+	MomentoCacheResponse
 	isDictionaryGetFieldsResponse()
 }
 

--- a/responses/dictionary_increment.go
+++ b/responses/dictionary_increment.go
@@ -2,6 +2,7 @@ package responses
 
 // DictionaryIncrementResponse is the base response type for a dictionary increment request.
 type DictionaryIncrementResponse interface {
+	MomentoCacheResponse
 	isDictionaryIncrementResponse()
 }
 

--- a/responses/dictionary_length.go
+++ b/responses/dictionary_length.go
@@ -2,6 +2,7 @@ package responses
 
 // DictionaryLengthResponse is the base response type for a dictionary length request.
 type DictionaryLengthResponse interface {
+	MomentoCacheResponse
 	isDictionaryLengthResponse()
 }
 

--- a/responses/dictionary_remove_field.go
+++ b/responses/dictionary_remove_field.go
@@ -2,6 +2,7 @@ package responses
 
 // DictionaryRemoveFieldResponse is the base response type for a dictionary remove field request.
 type DictionaryRemoveFieldResponse interface {
+	MomentoCacheResponse
 	isDictionaryRemoveFieldResponse()
 }
 

--- a/responses/dictionary_remove_fields.go
+++ b/responses/dictionary_remove_fields.go
@@ -2,6 +2,7 @@ package responses
 
 // DictionaryRemoveFieldsResponse is the base response type for a dictionary remove fields request.
 type DictionaryRemoveFieldsResponse interface {
+	MomentoCacheResponse
 	isDictionaryRemoveFieldsResponse()
 }
 

--- a/responses/dictionary_set_field.go
+++ b/responses/dictionary_set_field.go
@@ -2,6 +2,7 @@ package responses
 
 // DictionarySetFieldResponse is the base response type for a dictionary set field request.
 type DictionarySetFieldResponse interface {
+	MomentoCacheResponse
 	isDictionarySetFieldResponse()
 }
 

--- a/responses/dictionary_set_fields.go
+++ b/responses/dictionary_set_fields.go
@@ -2,6 +2,7 @@ package responses
 
 // DictionarySetFieldsResponse is the base response type for a dictionary set fields request.
 type DictionarySetFieldsResponse interface {
+	MomentoCacheResponse
 	isDictionarySetFieldsResponse()
 }
 

--- a/responses/get.go
+++ b/responses/get.go
@@ -2,6 +2,7 @@ package responses
 
 // GetResponse is the base response type for a get request.
 type GetResponse interface {
+	MomentoCacheResponse
 	isGetResponse()
 }
 

--- a/responses/get_batch.go
+++ b/responses/get_batch.go
@@ -2,6 +2,7 @@ package responses
 
 // GetBatchResponse is the base response type for a batch get request.
 type GetBatchResponse interface {
+	MomentoCacheResponse
 	isGetBatchResponse()
 }
 

--- a/responses/get_with_hash.go
+++ b/responses/get_with_hash.go
@@ -2,6 +2,7 @@ package responses
 
 // GetWithHashResponse is the base response type for a get with hash request.
 type GetWithHashResponse interface {
+	MomentoCacheResponse
 	isGetWithHashResponse()
 }
 

--- a/responses/increase_ttl.go
+++ b/responses/increase_ttl.go
@@ -2,6 +2,7 @@ package responses
 
 // IncreaseTtlResponse is the base response type for an increase ttl request.
 type IncreaseTtlResponse interface {
+	MomentoCacheResponse
 	isIncreaseTtlResponse()
 }
 

--- a/responses/increment.go
+++ b/responses/increment.go
@@ -2,6 +2,7 @@ package responses
 
 // IncrementResponse is the base response type for a  increment request.
 type IncrementResponse interface {
+	MomentoCacheResponse
 	isIncrementResponse()
 }
 

--- a/responses/item_get_ttl.go
+++ b/responses/item_get_ttl.go
@@ -4,6 +4,7 @@ import "time"
 
 // ItemGetTtlResponse is the base type for item get TTL requests.
 type ItemGetTtlResponse interface {
+	MomentoCacheResponse
 	isItemGetTtlResponse()
 }
 

--- a/responses/item_get_type.go
+++ b/responses/item_get_type.go
@@ -16,6 +16,7 @@ const (
 
 // ItemGetTypeResponse is the base response type for an item get type request.
 type ItemGetTypeResponse interface {
+	MomentoCacheResponse
 	isItemGetTypeResponse()
 }
 

--- a/responses/keys_exist.go
+++ b/responses/keys_exist.go
@@ -2,6 +2,7 @@ package responses
 
 // KeysExistResponse is the base response type for a key exist request.
 type KeysExistResponse interface {
+	MomentoCacheResponse
 	isKeysExistResponse()
 }
 

--- a/responses/leaderboard_delete.go
+++ b/responses/leaderboard_delete.go
@@ -1,6 +1,7 @@
 package responses
 
 type LeaderboardDeleteResponse interface {
+	MomentoLeaderboardResponse
 	isLeaderboardDeleteResponse()
 }
 

--- a/responses/leaderboard_fetch.go
+++ b/responses/leaderboard_fetch.go
@@ -1,6 +1,7 @@
 package responses
 
 type LeaderboardFetchResponse interface {
+	MomentoLeaderboardResponse
 	isLeaderboardFetchResponse()
 }
 

--- a/responses/leaderboard_length.go
+++ b/responses/leaderboard_length.go
@@ -1,6 +1,7 @@
 package responses
 
 type LeaderboardLengthResponse interface {
+	MomentoLeaderboardResponse
 	isLeaderboardLengthResponse()
 }
 

--- a/responses/leaderboard_remove_elements.go
+++ b/responses/leaderboard_remove_elements.go
@@ -1,6 +1,7 @@
 package responses
 
 type LeaderboardRemoveElementsResponse interface {
+	MomentoLeaderboardResponse
 	isLeaderboardRemoveElementsResponse()
 }
 

--- a/responses/leaderboard_upsert.go
+++ b/responses/leaderboard_upsert.go
@@ -1,6 +1,7 @@
 package responses
 
 type LeaderboardUpsertResponse interface {
+	MomentoLeaderboardResponse
 	isLeaderboardUpsertResponse()
 }
 

--- a/responses/list_caches.go
+++ b/responses/list_caches.go
@@ -2,6 +2,7 @@ package responses
 
 // ListCachesResponse is the base response type for a list caches request.
 type ListCachesResponse interface {
+	MomentoCacheResponse
 	isListCachesResponse()
 }
 

--- a/responses/list_concatenate_back.go
+++ b/responses/list_concatenate_back.go
@@ -2,6 +2,7 @@ package responses
 
 // ListConcatenateBackResponse is the base response type for a list concatenate back request.
 type ListConcatenateBackResponse interface {
+	MomentoCacheResponse
 	isListConcatenateBackResponse()
 }
 

--- a/responses/list_concatenate_front.go
+++ b/responses/list_concatenate_front.go
@@ -2,6 +2,7 @@ package responses
 
 // ListConcatenateFrontResponse is the base response for a list concatenate front request.
 type ListConcatenateFrontResponse interface {
+	MomentoCacheResponse
 	isListConcatenateFrontResponse()
 }
 

--- a/responses/list_fetch.go
+++ b/responses/list_fetch.go
@@ -2,6 +2,7 @@ package responses
 
 // ListFetchResponse is the base response type for a list fetch request.
 type ListFetchResponse interface {
+	MomentoCacheResponse
 	isListFetchResponse()
 }
 

--- a/responses/list_length.go
+++ b/responses/list_length.go
@@ -2,6 +2,7 @@ package responses
 
 // ListLengthResponse is the base response type for a list length request.
 type ListLengthResponse interface {
+	MomentoCacheResponse
 	isListLengthResponse()
 }
 

--- a/responses/list_pop_back.go
+++ b/responses/list_pop_back.go
@@ -2,6 +2,7 @@ package responses
 
 // ListPopBackResponse is the base response type for a list pop back request.
 type ListPopBackResponse interface {
+	MomentoCacheResponse
 	isListPopBackResponse()
 }
 

--- a/responses/list_pop_front.go
+++ b/responses/list_pop_front.go
@@ -2,6 +2,7 @@ package responses
 
 // ListPopFrontResponse is the base response type for a list pop front request.
 type ListPopFrontResponse interface {
+	MomentoCacheResponse
 	isListPopFrontResponse()
 }
 

--- a/responses/list_push_back.go
+++ b/responses/list_push_back.go
@@ -2,6 +2,7 @@ package responses
 
 // ListPushBackResponse is the base response type for a list push back request.
 type ListPushBackResponse interface {
+	MomentoCacheResponse
 	isListPushBackResponse()
 }
 

--- a/responses/list_push_front.go
+++ b/responses/list_push_front.go
@@ -2,6 +2,7 @@ package responses
 
 // ListPushFrontResponse is the base type for a list push front request.
 type ListPushFrontResponse interface {
+	MomentoCacheResponse
 	isListPushFrontResponse()
 }
 

--- a/responses/list_remove_value.go
+++ b/responses/list_remove_value.go
@@ -2,6 +2,7 @@ package responses
 
 // ListRemoveValueResponse is the base type for a list remove value request.
 type ListRemoveValueResponse interface {
+	MomentoCacheResponse
 	isListRemoveValueResponse()
 }
 

--- a/responses/ping.go
+++ b/responses/ping.go
@@ -2,6 +2,7 @@ package responses
 
 // PingResponse is the base response type for a ping request.
 type PingResponse interface {
+	MomentoCacheResponse
 	isPingResponse()
 }
 

--- a/responses/set.go
+++ b/responses/set.go
@@ -2,6 +2,7 @@ package responses
 
 // SetResponse is the base response type for a set request.
 type SetResponse interface {
+	MomentoCacheResponse
 	isSetResponse()
 }
 

--- a/responses/set_add_element.go
+++ b/responses/set_add_element.go
@@ -2,6 +2,7 @@ package responses
 
 // SetAddElementResponse is the base response type for a set add element request.
 type SetAddElementResponse interface {
+	MomentoCacheResponse
 	isSetAddElementResponse()
 }
 

--- a/responses/set_add_elements.go
+++ b/responses/set_add_elements.go
@@ -2,6 +2,7 @@ package responses
 
 // SetAddElementsResponse is the base response type for a set add elements request.
 type SetAddElementsResponse interface {
+	MomentoCacheResponse
 	isSetAddElementResponse()
 }
 

--- a/responses/set_batch.go
+++ b/responses/set_batch.go
@@ -2,6 +2,7 @@ package responses
 
 // SetBatchResponse is the base response type for a batch set request.
 type SetBatchResponse interface {
+	MomentoCacheResponse
 	isSetBatchResponse()
 }
 

--- a/responses/set_contains_elements.go
+++ b/responses/set_contains_elements.go
@@ -2,6 +2,7 @@ package responses
 
 // SetContainsElementsResponse is the base response type for a set contains elements request.
 type SetContainsElementsResponse interface {
+	MomentoCacheResponse
 	isSetContainsElementsResponse()
 }
 

--- a/responses/set_fetch.go
+++ b/responses/set_fetch.go
@@ -2,6 +2,7 @@ package responses
 
 // SetFetchResponse is the base response type for a set fetch request.
 type SetFetchResponse interface {
+	MomentoCacheResponse
 	isSetFetchResponse()
 }
 

--- a/responses/set_if_absent.go
+++ b/responses/set_if_absent.go
@@ -2,6 +2,7 @@ package responses
 
 // SetIfAbsentResponse is the base response type for a SetIfAbsent request
 type SetIfAbsentResponse interface {
+	MomentoCacheResponse
 	isSetIfAbsentResponse()
 }
 

--- a/responses/set_if_absent_or_equal.go
+++ b/responses/set_if_absent_or_equal.go
@@ -2,6 +2,7 @@ package responses
 
 // SetIfAbsentOrEqualResponse is the base response type for a SetIfAbsentOrEqual request
 type SetIfAbsentOrEqualResponse interface {
+	MomentoCacheResponse
 	isSetIfAbsentOrEqualResponse()
 }
 

--- a/responses/set_if_absent_or_hash_equal.go
+++ b/responses/set_if_absent_or_hash_equal.go
@@ -3,6 +3,7 @@ package responses
 // SetIfAbsentOrHashEqualResponse is the base response type
 // for a set if absent or hash equal request.
 type SetIfAbsentOrHashEqualResponse interface {
+	MomentoCacheResponse
 	isSetIfAbsentOrHashEqualResponse()
 }
 

--- a/responses/set_if_absent_or_hash_not_equal.go
+++ b/responses/set_if_absent_or_hash_not_equal.go
@@ -3,6 +3,7 @@ package responses
 // SetIfAbsentOrHashNotEqualResponse is the base response type
 // for a set if absent or hash not equal request.
 type SetIfAbsentOrHashNotEqualResponse interface {
+	MomentoCacheResponse
 	isSetIfAbsentOrHashNotEqualResponse()
 }
 

--- a/responses/set_if_equal.go
+++ b/responses/set_if_equal.go
@@ -2,6 +2,7 @@ package responses
 
 // SetIfEqualResponse is the base response type for a SetIfEqual request
 type SetIfEqualResponse interface {
+	MomentoCacheResponse
 	isSetIfEqualResponse()
 }
 

--- a/responses/set_if_not_equal.go
+++ b/responses/set_if_not_equal.go
@@ -2,6 +2,7 @@ package responses
 
 // SetIfNotEqualResponse is the base response type for a SetIfNotEqual request
 type SetIfNotEqualResponse interface {
+	MomentoCacheResponse
 	isSetIfNotEqualResponse()
 }
 

--- a/responses/set_if_not_exists.go
+++ b/responses/set_if_not_exists.go
@@ -2,6 +2,7 @@ package responses
 
 // SetIfNotExistsResponse is the base response type for a SetIfNotExists request
 type SetIfNotExistsResponse interface {
+	MomentoCacheResponse
 	isSetIfNotExistsResponse()
 }
 

--- a/responses/set_if_present.go
+++ b/responses/set_if_present.go
@@ -2,6 +2,7 @@ package responses
 
 // SetIfPresentResponse is the base response type for a SetIfPresent request
 type SetIfPresentResponse interface {
+	MomentoCacheResponse
 	isSetIfPresentResponse()
 }
 

--- a/responses/set_if_present_and_hash_equal.go
+++ b/responses/set_if_present_and_hash_equal.go
@@ -3,6 +3,7 @@ package responses
 // SetIfPresentAndHashEqualResponse is the base response type
 // for a set if present and hash equal request.
 type SetIfPresentAndHashEqualResponse interface {
+	MomentoCacheResponse
 	isSetIfPresentAndHashEqualResponse()
 }
 

--- a/responses/set_if_present_and_hash_not_equal.go
+++ b/responses/set_if_present_and_hash_not_equal.go
@@ -3,6 +3,7 @@ package responses
 // SetIfPresentAndHashNotEqualResponse is the base response type
 // for a set if present and hash not equal request.
 type SetIfPresentAndHashNotEqualResponse interface {
+	MomentoCacheResponse
 	isSetIfPresentAndHashNotEqualResponse()
 }
 

--- a/responses/set_if_present_and_not_equal.go
+++ b/responses/set_if_present_and_not_equal.go
@@ -2,6 +2,7 @@ package responses
 
 // SetIfPresentAndNotEqualResponse is the base response type for a SetIfPresentAndNotEqual request
 type SetIfPresentAndNotEqualResponse interface {
+	MomentoCacheResponse
 	isSetIfPresentAndNotEqualResponse()
 }
 

--- a/responses/set_length.go
+++ b/responses/set_length.go
@@ -2,6 +2,7 @@ package responses
 
 // SetLengthResponse is the base response type for a set length request.
 type SetLengthResponse interface {
+	MomentoCacheResponse
 	isSetLengthResponse()
 }
 

--- a/responses/set_pop.go
+++ b/responses/set_pop.go
@@ -2,6 +2,7 @@ package responses
 
 // SetPopResponse is the base response type for a set fetch request.
 type SetPopResponse interface {
+	MomentoCacheResponse
 	isSetPopResponse()
 }
 

--- a/responses/set_remove_element.go
+++ b/responses/set_remove_element.go
@@ -2,6 +2,7 @@ package responses
 
 // SetRemoveElementResponse is the base response type for a set remobe element request.
 type SetRemoveElementResponse interface {
+	MomentoCacheResponse
 	isSetRemoveElementResponse()
 }
 

--- a/responses/set_remove_elements.go
+++ b/responses/set_remove_elements.go
@@ -2,6 +2,7 @@ package responses
 
 // SetRemoveElementsResponse is the base response type for a set remove elements request.
 type SetRemoveElementsResponse interface {
+	MomentoCacheResponse
 	isSetRemoveElementsResponse()
 }
 

--- a/responses/set_with_hash.go
+++ b/responses/set_with_hash.go
@@ -2,6 +2,7 @@ package responses
 
 // SetWithHashResponse is the base response type for a set with hash request.
 type SetWithHashResponse interface {
+	MomentoCacheResponse
 	isSetWithHashResponse()
 }
 

--- a/responses/sorted_set_fetch.go
+++ b/responses/sorted_set_fetch.go
@@ -10,6 +10,7 @@ type SortedSetStringElement struct {
 	Score float64
 }
 type SortedSetFetchResponse interface {
+	MomentoCacheResponse
 	isSortedSetFetchResponse()
 }
 

--- a/responses/sorted_set_get_rank.go
+++ b/responses/sorted_set_get_rank.go
@@ -2,6 +2,7 @@ package responses
 
 // SortedSetGetRankResponse is the base response type for a sorted set get rank request.
 type SortedSetGetRankResponse interface {
+	MomentoCacheResponse
 	isSortedSetGetRankResponse()
 }
 

--- a/responses/sorted_set_get_score.go
+++ b/responses/sorted_set_get_score.go
@@ -2,6 +2,7 @@ package responses
 
 // SortedSetGetScoreResponse is the base response type for a sorted set get score request.
 type SortedSetGetScoreResponse interface {
+	MomentoCacheResponse
 	isSortedSetGetScoreResponse()
 }
 

--- a/responses/sorted_set_get_scores.go
+++ b/responses/sorted_set_get_scores.go
@@ -2,6 +2,7 @@ package responses
 
 // SortedSetGetScoresResponse is the base response type for a sorted set get responses request.
 type SortedSetGetScoresResponse interface {
+	MomentoCacheResponse
 	isSortedSetGetScoresResponse()
 }
 

--- a/responses/sorted_set_increment_score.go
+++ b/responses/sorted_set_increment_score.go
@@ -2,6 +2,7 @@ package responses
 
 // SortedSetIncrementScoreResponse is the base response type for a sorted set increment score request.
 type SortedSetIncrementScoreResponse interface {
+	MomentoCacheResponse
 	isSortedSetIncrementResponse()
 }
 

--- a/responses/sorted_set_length.go
+++ b/responses/sorted_set_length.go
@@ -2,6 +2,7 @@ package responses
 
 // SortedSetLengthResponse is the base response type for a sorted set length request.
 type SortedSetLengthResponse interface {
+	MomentoCacheResponse
 	isSortedSetLengthResponse()
 }
 

--- a/responses/sorted_set_length_by_score.go
+++ b/responses/sorted_set_length_by_score.go
@@ -2,6 +2,7 @@ package responses
 
 // SortedSetLengthByScoreResponse is the base response type for a sorted set length request.
 type SortedSetLengthByScoreResponse interface {
+	MomentoCacheResponse
 	isSortedSetLengthByScoreResponse()
 }
 

--- a/responses/sorted_set_put_element.go
+++ b/responses/sorted_set_put_element.go
@@ -2,6 +2,7 @@ package responses
 
 // SortedSetPutElementResponse is the base response type for a sorted set put element request.
 type SortedSetPutElementResponse interface {
+	MomentoCacheResponse
 	isSortedSetPutElementResponse()
 }
 

--- a/responses/sorted_set_put_elements.go
+++ b/responses/sorted_set_put_elements.go
@@ -2,6 +2,7 @@ package responses
 
 // SortedSetPutElementsResponse is the base response type for a sorted set put elements request.
 type SortedSetPutElementsResponse interface {
+	MomentoCacheResponse
 	isSortedSetPutElementsResponse()
 }
 

--- a/responses/sorted_set_remove_element.go
+++ b/responses/sorted_set_remove_element.go
@@ -2,6 +2,7 @@ package responses
 
 // SortedSetRemoveElementResponse is the base response type for a sorted set remove element request.
 type SortedSetRemoveElementResponse interface {
+	MomentoCacheResponse
 	isSortedSetRemoveElementResponse()
 }
 

--- a/responses/sorted_set_remove_elements.go
+++ b/responses/sorted_set_remove_elements.go
@@ -2,6 +2,7 @@ package responses
 
 // SortedSetRemoveElementsResponse is the base response type for a sorted set put elements request.
 type SortedSetRemoveElementsResponse interface {
+	MomentoCacheResponse
 	isSortedSetRemoveElementsResponse()
 }
 

--- a/responses/topic_publish.go
+++ b/responses/topic_publish.go
@@ -2,6 +2,7 @@ package responses
 
 // TopicPublishResponse is the base response type for a publish request.
 type TopicPublishResponse interface {
+	MomentoTopicResponse
 	isTopicPublishResponse()
 }
 

--- a/responses/update_ttl.go
+++ b/responses/update_ttl.go
@@ -2,6 +2,7 @@ package responses
 
 // UpdateTtlResponse is the base response type for an update ttl request.
 type UpdateTtlResponse interface {
+	MomentoCacheResponse
 	isUpdateTtlResponse()
 }
 


### PR DESCRIPTION
Work towards https://github.com/momentohq/dev-eco-issue-tracker/issues/1221

Opening this draft for early review!

Goal: add base type for momento request and response objects to minimize usage of `interface{}` (basically an `any` type), including when specifying what requests middlewares should act on (`IncludeTypes` parameter).

- Added new interfaces in `base_response_types.go` and updated the response objects' interfaces to include the base interface too. Excluded storage-related objects from this effort since it's being deprecated.
- Added new interfaces in new package `momento_request_base` in `momento/request_base` to avoid circular import issues. Added the `MomentoCacheRequest` base interface to the internal `requester` interface and updated cache data client request objects accordingly. 
- Updated middleware interface to accept `IncludeTypes` parameter as type `[]momento_response_base.MomentoCacheRequest`, but I think this is a breaking change. I don't think anyone is passing in this argument yet to their middlewares (if they're even using middlewares), but per recent team discussions, I don't want to cavalierly make unnecessary breaking changes.
- Updated middleware interface so that `OnRequest` and `OnResponse` can also make use of the new base types where appropriate to reduce usage of `interface{}`.

Tested locally with the middlewares-related examples and verified that updating the type of `IncludeTypes` works.