### PR TITLE
chore: improved gzip compression tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -150,6 +150,10 @@ test-retry: install-ginkgo
 	#  so the test suite can know we need a momento-local credential provider
 	@CONSISTENT_READS=1 ginkgo ${GINKGO_OPTS} --label-filter "retry && momento-local" ${TEST_DIRS}
 
+test-middleware: install-ginkgo
+	@echo "Testing middleware..."
+	@CONSISTENT_READS=1 ginkgo ${GINKGO_OPTS} --focus "middleware" --label-filter cache-service ${TEST_DIRS}	
+
 test-http-service:
 	@echo "No tests for http service."
 

--- a/config/middleware/impl/compression_test.go
+++ b/config/middleware/impl/compression_test.go
@@ -9,11 +9,9 @@ import (
 	"github.com/google/uuid"
 	"github.com/momentohq/client-sdk-go/auth"
 	"github.com/momentohq/client-sdk-go/config"
-
 	"github.com/momentohq/client-sdk-go/config/compression"
 	"github.com/momentohq/client-sdk-go/config/logger/momento_default_logger"
-	"github.com/momentohq/client-sdk-go/config/middleware"
-	"github.com/momentohq/client-sdk-go/config/middleware/impl"
+	impl_test_helpers "github.com/momentohq/client-sdk-go/config/middleware/impl/test_helpers"
 	. "github.com/momentohq/client-sdk-go/momento"
 	"github.com/momentohq/client-sdk-go/responses"
 	. "github.com/onsi/ginkgo/v2"
@@ -55,7 +53,7 @@ func getCompressableString() string {
 	return fmt.Sprintf("%s %s", longString, uuid.NewString())
 }
 
-var _ = Describe("gzip-compression-middleware", Label("cache-service"), func() {
+var _ = Describe("gzip compression middleware", Label("cache-service"), func() {
 	BeforeEach(func() {
 		testCtx = context.Background()
 		cacheName = fmt.Sprintf("golang-%s", uuid.NewString())
@@ -70,16 +68,18 @@ var _ = Describe("gzip-compression-middleware", Label("cache-service"), func() {
 	// and no IncludeTypes are specified to narrow down the types of requests that should be compressed.
 	Describe("when IncludeTypes is not specified", func() {
 		It("should successfully set and get a value", func() {
-			createCacheClient(config.LaptopLatest().WithMiddleware([]middleware.Middleware{
-				impl.NewGzipCompressionMiddleware(impl.GzipCompressionMiddlewareProps{
-					CompressionStrategyProps: compression.CompressionStrategyProps{
-						CompressionLevel: compression.CompressionLevelDefault,
-						Logger:           momento_default_logger.NewDefaultMomentoLoggerFactory(momento_default_logger.TRACE).GetLogger("gzip-test"),
-					},
-				}),
-			}))
+			compressedDataChannel := make(chan int, 1)
+			decompressedDataChannel := make(chan int, 1)
+			middleware := impl_test_helpers.NewGzipCompressionTestMiddleware(impl_test_helpers.GzipCompressionTestMiddlewareProps{
+				CompressionLevel:        compression.CompressionLevelDefault,
+				Logger:                  momento_default_logger.NewDefaultMomentoLoggerFactory(momento_default_logger.TRACE).GetLogger("gzip-test"),
+				CompressedDataChannel:   compressedDataChannel,
+				DecompressedDataChannel: decompressedDataChannel,
+			})
+			createCacheClient(config.LaptopLatest().AddMiddleware(middleware))
 
 			value := getCompressableString()
+			originalSize := len(value)
 			_, err := cacheClient.Set(testCtx, &SetRequest{
 				CacheName: cacheName,
 				Key:       String("key"),
@@ -94,19 +94,30 @@ var _ = Describe("gzip-compression-middleware", Label("cache-service"), func() {
 			Expect(err).To(BeNil())
 			Expect(resp).To(BeAssignableToTypeOf(&responses.GetHit{}))
 			Expect(resp.(*responses.GetHit).ValueString()).To(Equal(value))
+
+			// Verify the channels received data
+			compressedSize, ok := <-compressedDataChannel
+			Expect(ok).To(BeTrue())
+			Expect(compressedSize).To(BeNumerically(">", 0))
+			Expect(compressedSize).To(BeNumerically("<", originalSize))
+			decompressedSize, ok := <-decompressedDataChannel
+			Expect(ok).To(BeTrue())
+			Expect(decompressedSize).To(Equal(originalSize))
 		})
 
 		It("should successfully setIf and get a value", func() {
-			createCacheClient(config.LaptopLatest().WithMiddleware([]middleware.Middleware{
-				impl.NewGzipCompressionMiddleware(impl.GzipCompressionMiddlewareProps{
-					CompressionStrategyProps: compression.CompressionStrategyProps{
-						CompressionLevel: compression.CompressionLevelDefault,
-						Logger:           momento_default_logger.NewDefaultMomentoLoggerFactory(momento_default_logger.TRACE).GetLogger("gzip-test"),
-					},
-				}),
-			}))
+			compressedDataChannel := make(chan int, 1)
+			decompressedDataChannel := make(chan int, 1)
+			middleware := impl_test_helpers.NewGzipCompressionTestMiddleware(impl_test_helpers.GzipCompressionTestMiddlewareProps{
+				CompressionLevel:        compression.CompressionLevelDefault,
+				Logger:                  momento_default_logger.NewDefaultMomentoLoggerFactory(momento_default_logger.TRACE).GetLogger("gzip-test"),
+				CompressedDataChannel:   compressedDataChannel,
+				DecompressedDataChannel: decompressedDataChannel,
+			})
+			createCacheClient(config.LaptopLatest().AddMiddleware(middleware))
 
 			setIfAbsentValue := getCompressableString()
+			originalSize := len(setIfAbsentValue)
 			_, err := cacheClient.SetIfAbsent(testCtx, &SetIfAbsentRequest{
 				CacheName: cacheName,
 				Key:       String("key"),
@@ -122,7 +133,17 @@ var _ = Describe("gzip-compression-middleware", Label("cache-service"), func() {
 			Expect(resp).To(BeAssignableToTypeOf(&responses.GetHit{}))
 			Expect(resp.(*responses.GetHit).ValueString()).To(Equal(setIfAbsentValue))
 
+			// Verify the channels received data
+			compressedSize, ok := <-compressedDataChannel
+			Expect(ok).To(BeTrue())
+			Expect(compressedSize).To(BeNumerically(">", 0))
+			Expect(compressedSize).To(BeNumerically("<", originalSize))
+			decompressedSize, ok := <-decompressedDataChannel
+			Expect(ok).To(BeTrue())
+			Expect(decompressedSize).To(Equal(originalSize))
+
 			setIfPresentValue := getCompressableString()
+			originalSize = len(setIfPresentValue)
 			_, err = cacheClient.SetIfPresentAndNotEqual(testCtx, &SetIfPresentAndNotEqualRequest{
 				CacheName: cacheName,
 				Key:       String("key"),
@@ -138,19 +159,30 @@ var _ = Describe("gzip-compression-middleware", Label("cache-service"), func() {
 			Expect(err).To(BeNil())
 			Expect(resp).To(BeAssignableToTypeOf(&responses.GetHit{}))
 			Expect(resp.(*responses.GetHit).ValueString()).To(Equal(setIfPresentValue))
+
+			// Verify the channels received data
+			compressedSize, ok = <-compressedDataChannel
+			Expect(ok).To(BeTrue())
+			Expect(compressedSize).To(BeNumerically(">", 0))
+			Expect(compressedSize).To(BeNumerically("<", originalSize))
+			decompressedSize, ok = <-decompressedDataChannel
+			Expect(ok).To(BeTrue())
+			Expect(decompressedSize).To(Equal(originalSize))
 		})
 
 		It("should successfully setWithHash and getWithHash", func() {
-			createCacheClient(config.LaptopLatest().WithMiddleware([]middleware.Middleware{
-				impl.NewGzipCompressionMiddleware(impl.GzipCompressionMiddlewareProps{
-					CompressionStrategyProps: compression.CompressionStrategyProps{
-						CompressionLevel: compression.CompressionLevelDefault,
-						Logger:           momento_default_logger.NewDefaultMomentoLoggerFactory(momento_default_logger.TRACE).GetLogger("gzip-test"),
-					},
-				}),
-			}))
+			compressedDataChannel := make(chan int, 1)
+			decompressedDataChannel := make(chan int, 1)
+			middleware := impl_test_helpers.NewGzipCompressionTestMiddleware(impl_test_helpers.GzipCompressionTestMiddlewareProps{
+				CompressionLevel:        compression.CompressionLevelDefault,
+				Logger:                  momento_default_logger.NewDefaultMomentoLoggerFactory(momento_default_logger.TRACE).GetLogger("gzip-test"),
+				CompressedDataChannel:   compressedDataChannel,
+				DecompressedDataChannel: decompressedDataChannel,
+			})
+			createCacheClient(config.LaptopLatest().AddMiddleware(middleware))
 
 			value := getCompressableString()
+			originalSize := len(value)
 			setResp, err := cacheClient.SetWithHash(testCtx, &SetWithHashRequest{
 				CacheName: cacheName,
 				Key:       String("key"),
@@ -169,19 +201,30 @@ var _ = Describe("gzip-compression-middleware", Label("cache-service"), func() {
 			Expect(resp).To(BeAssignableToTypeOf(&responses.GetWithHashHit{}))
 			Expect(resp.(*responses.GetWithHashHit).ValueString()).To(Equal(value))
 			Expect(resp.(*responses.GetWithHashHit).HashByte()).To(Equal(hash))
+
+			// Verify the channels received data
+			compressedSize, ok := <-compressedDataChannel
+			Expect(ok).To(BeTrue())
+			Expect(compressedSize).To(BeNumerically(">", 0))
+			Expect(compressedSize).To(BeNumerically("<", originalSize))
+			decompressedSize, ok := <-decompressedDataChannel
+			Expect(ok).To(BeTrue())
+			Expect(decompressedSize).To(Equal(originalSize))
 		})
 
 		It("should successfully setIfHash and getWithHash", func() {
-			createCacheClient(config.LaptopLatest().WithMiddleware([]middleware.Middleware{
-				impl.NewGzipCompressionMiddleware(impl.GzipCompressionMiddlewareProps{
-					CompressionStrategyProps: compression.CompressionStrategyProps{
-						CompressionLevel: compression.CompressionLevelDefault,
-						Logger:           momento_default_logger.NewDefaultMomentoLoggerFactory(momento_default_logger.TRACE).GetLogger("gzip-test"),
-					},
-				}),
-			}))
+			compressedDataChannel := make(chan int, 1)
+			decompressedDataChannel := make(chan int, 1)
+			middleware := impl_test_helpers.NewGzipCompressionTestMiddleware(impl_test_helpers.GzipCompressionTestMiddlewareProps{
+				CompressionLevel:        compression.CompressionLevelDefault,
+				Logger:                  momento_default_logger.NewDefaultMomentoLoggerFactory(momento_default_logger.TRACE).GetLogger("gzip-test"),
+				CompressedDataChannel:   compressedDataChannel,
+				DecompressedDataChannel: decompressedDataChannel,
+			})
+			createCacheClient(config.LaptopLatest().AddMiddleware(middleware))
 
 			setIfAbsentValue := getCompressableString()
+			originalSize := len(setIfAbsentValue)
 			setAbsentResp, err := cacheClient.SetIfAbsentOrHashEqual(testCtx, &SetIfAbsentOrHashEqualRequest{
 				CacheName: cacheName,
 				Key:       String("key"),
@@ -202,7 +245,17 @@ var _ = Describe("gzip-compression-middleware", Label("cache-service"), func() {
 			Expect(resp.(*responses.GetWithHashHit).ValueString()).To(Equal(setIfAbsentValue))
 			Expect(resp.(*responses.GetWithHashHit).HashByte()).To(Equal(hash))
 
+			// Verify the channels received data
+			compressedSize, ok := <-compressedDataChannel
+			Expect(ok).To(BeTrue())
+			Expect(compressedSize).To(BeNumerically(">", 0))
+			Expect(compressedSize).To(BeNumerically("<", originalSize))
+			decompressedSize, ok := <-decompressedDataChannel
+			Expect(ok).To(BeTrue())
+			Expect(decompressedSize).To(Equal(originalSize))
+
 			setIfPresentValue := getCompressableString()
+			originalSize = len(setIfPresentValue)
 			setPresentResp, err := cacheClient.SetIfPresentAndHashEqual(testCtx, &SetIfPresentAndHashEqualRequest{
 				CacheName: cacheName,
 				Key:       String("key"),
@@ -222,26 +275,35 @@ var _ = Describe("gzip-compression-middleware", Label("cache-service"), func() {
 			Expect(resp).To(BeAssignableToTypeOf(&responses.GetWithHashHit{}))
 			Expect(resp.(*responses.GetWithHashHit).ValueString()).To(Equal(setIfPresentValue))
 			Expect(resp.(*responses.GetWithHashHit).HashByte()).To(Equal(hash))
-		})
 
+			// Verify the channels received data
+			compressedSize, ok = <-compressedDataChannel
+			Expect(ok).To(BeTrue())
+			Expect(compressedSize).To(BeNumerically(">", 0))
+			Expect(compressedSize).To(BeNumerically("<", originalSize))
+			decompressedSize, ok = <-decompressedDataChannel
+			Expect(ok).To(BeTrue())
+			Expect(decompressedSize).To(Equal(originalSize))
+		})
 	})
 
 	// Some tests to verify set/get methods still work even when compression middleware is enabled and
 	// IncludeTypes is specified to narrow down the types of requests that should be compressed.
 	Describe("when IncludeTypes is specified", func() {
 		It("should successfully set and get a value without compression when not included", func() {
-			createCacheClient(config.LaptopLatest().WithMiddleware([]middleware.Middleware{
-				impl.NewGzipCompressionMiddleware(impl.GzipCompressionMiddlewareProps{
-					CompressionStrategyProps: compression.CompressionStrategyProps{
-						CompressionLevel: compression.CompressionLevelDefault,
-						Logger:           momento_default_logger.NewDefaultMomentoLoggerFactory(momento_default_logger.TRACE).GetLogger("gzip-test"),
-					},
-					IncludeTypes: []interface{}{
-						SetWithHashRequest{},
-						GetWithHashRequest{},
-					},
-				}),
-			}))
+			compressedDataChannel := make(chan int, 1)
+			decompressedDataChannel := make(chan int, 1)
+			middleware := impl_test_helpers.NewGzipCompressionTestMiddleware(impl_test_helpers.GzipCompressionTestMiddlewareProps{
+				CompressionLevel:        compression.CompressionLevelDefault,
+				Logger:                  momento_default_logger.NewDefaultMomentoLoggerFactory(momento_default_logger.TRACE).GetLogger("gzip-test"),
+				CompressedDataChannel:   compressedDataChannel,
+				DecompressedDataChannel: decompressedDataChannel,
+				IncludeTypes: []interface{}{
+					SetWithHashRequest{},
+					GetWithHashRequest{},
+				},
+			})
+			createCacheClient(config.LaptopLatest().AddMiddleware(middleware))
 
 			// Should not see Get or Set mentioned in compression logs
 
@@ -265,6 +327,7 @@ var _ = Describe("gzip-compression-middleware", Label("cache-service"), func() {
 			// Should see SetWithHash and GetWithHash mentioned in compression logs
 
 			hashKey := getCompressableString()
+			originalSize := len(value)
 			setResp, err := cacheClient.SetWithHash(testCtx, &SetWithHashRequest{
 				CacheName: cacheName,
 				Key:       String(hashKey),
@@ -283,20 +346,26 @@ var _ = Describe("gzip-compression-middleware", Label("cache-service"), func() {
 			Expect(getResp).To(BeAssignableToTypeOf(&responses.GetWithHashHit{}))
 			Expect(getResp.(*responses.GetWithHashHit).ValueString()).To(Equal(value))
 			Expect(getResp.(*responses.GetWithHashHit).HashByte()).To(Equal(hash))
+
+			// Verify the channels received data
+			compressedSize, ok := <-compressedDataChannel
+			Expect(ok).To(BeTrue())
+			Expect(compressedSize).To(BeNumerically(">", 0))
+			Expect(compressedSize).To(BeNumerically("<", originalSize))
+			decompressedSize, ok := <-decompressedDataChannel
+			Expect(ok).To(BeTrue())
+			Expect(decompressedSize).To(Equal(originalSize))
 		})
 
 		It("should not decompress when response was not compressed", func() {
-			createCacheClient(config.LaptopLatest().WithMiddleware([]middleware.Middleware{
-				impl.NewGzipCompressionMiddleware(impl.GzipCompressionMiddlewareProps{
-					CompressionStrategyProps: compression.CompressionStrategyProps{
-						CompressionLevel: compression.CompressionLevelDefault,
-						Logger:           momento_default_logger.NewDefaultMomentoLoggerFactory(momento_default_logger.TRACE).GetLogger("gzip-test"),
-					},
-					IncludeTypes: []interface{}{
-						GetRequest{}, // try to decompress without any compression
-					},
-				}),
-			}))
+			middleware := impl_test_helpers.NewGzipCompressionTestMiddleware(impl_test_helpers.GzipCompressionTestMiddlewareProps{
+				CompressionLevel: compression.CompressionLevelDefault,
+				Logger:           momento_default_logger.NewDefaultMomentoLoggerFactory(momento_default_logger.TRACE).GetLogger("gzip-test"),
+				IncludeTypes: []interface{}{
+					GetRequest{},
+				},
+			})
+			createCacheClient(config.LaptopLatest().AddMiddleware(middleware))
 
 			value := "some-value"
 			_, err := cacheClient.Set(testCtx, &SetRequest{

--- a/config/middleware/impl/compression_test.go
+++ b/config/middleware/impl/compression_test.go
@@ -53,7 +53,7 @@ func getCompressableString() string {
 	return fmt.Sprintf("%s %s", longString, uuid.NewString())
 }
 
-var _ = Describe("gzip compression middleware", Label("cache-service"), func() {
+var _ = Describe("gzip-compression-middleware", Label("cache-service"), func() {
 	BeforeEach(func() {
 		testCtx = context.Background()
 		cacheName = fmt.Sprintf("golang-%s", uuid.NewString())

--- a/config/middleware/impl/compression_test.go
+++ b/config/middleware/impl/compression_test.go
@@ -11,6 +11,8 @@ import (
 	"github.com/momentohq/client-sdk-go/config"
 	"github.com/momentohq/client-sdk-go/config/compression"
 	"github.com/momentohq/client-sdk-go/config/logger/momento_default_logger"
+	"github.com/momentohq/client-sdk-go/config/middleware"
+	"github.com/momentohq/client-sdk-go/config/middleware/impl"
 	impl_test_helpers "github.com/momentohq/client-sdk-go/config/middleware/impl/test_helpers"
 	. "github.com/momentohq/client-sdk-go/momento"
 	"github.com/momentohq/client-sdk-go/responses"

--- a/config/middleware/impl/test_helpers/compression_test_helpers.go
+++ b/config/middleware/impl/test_helpers/compression_test_helpers.go
@@ -1,0 +1,90 @@
+package impl_test_helpers
+
+import (
+	"fmt"
+
+	"github.com/momentohq/client-sdk-go/config/compression"
+	"github.com/momentohq/client-sdk-go/config/logger"
+	"github.com/momentohq/client-sdk-go/config/middleware"
+	impl "github.com/momentohq/client-sdk-go/config/middleware/impl"
+)
+
+// GzipTestCompressorFactory is a wrapper around the GzipCompressorFactory that allows us to test the
+// gzip compression middleware more thoroughly to confirm compression is working as expected.
+type GzipTestCompressorFactory struct {
+	testHelper              gzipTestCompressor
+	CompressedDataChannel   chan int // receive data size in bytes
+	DecompressedDataChannel chan int // receive data size in bytes
+}
+
+func (f GzipTestCompressorFactory) NewCompressionStrategy(props compression.CompressionStrategyProps) compression.CompressionStrategy {
+	compressionStrategy := gzipTestCompressor{
+		compressor:              impl.GzipCompressorFactory{}.NewCompressionStrategy(props),
+		logger:                  props.Logger,
+		CompressedDataChannel:   f.CompressedDataChannel,
+		DecompressedDataChannel: f.DecompressedDataChannel,
+	}
+	return compressionStrategy
+}
+
+func (f GzipTestCompressorFactory) GetTestHelper() gzipTestCompressor {
+	return f.testHelper
+}
+
+type gzipTestCompressor struct {
+	compressor              compression.CompressionStrategy
+	logger                  logger.MomentoLogger
+	CompressedDataChannel   chan int // receive data size in bytes
+	DecompressedDataChannel chan int // receive data size in bytes
+}
+
+func (h gzipTestCompressor) Compress(data []byte) ([]byte, error) {
+	compressed, err := h.compressor.Compress(data)
+	if err != nil {
+		return nil, fmt.Errorf("failed to compress data: %v", err)
+	}
+
+	h.logger.Trace("Compressed data: %d bytes -> %d bytes", len(data), len(compressed))
+	if h.CompressedDataChannel != nil {
+		h.CompressedDataChannel <- len(compressed)
+	}
+	return compressed, nil
+}
+
+func (h gzipTestCompressor) Decompress(data []byte) ([]byte, error) {
+	decompressed, err := h.compressor.Decompress(data)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decompress data: %v", err)
+	}
+
+	h.logger.Trace("Decompressed data: %d bytes -> %d bytes", len(data), len(decompressed))
+	if h.DecompressedDataChannel != nil {
+		h.DecompressedDataChannel <- len(decompressed)
+	}
+	return decompressed, nil
+}
+
+type GzipCompressionTestMiddlewareProps struct {
+	IncludeTypes            []interface{}
+	CompressionLevel        compression.CompressionLevel
+	Logger                  logger.MomentoLogger
+	CompressedDataChannel   chan int // receive data size in bytes
+	DecompressedDataChannel chan int // receive data size in bytes
+}
+
+// NewGzipCompressionTestMiddleware creates a new compression middleware as a test helper
+// for verifying compression is working as expected.
+func NewGzipCompressionTestMiddleware(props GzipCompressionTestMiddlewareProps) middleware.Middleware {
+	compressionMiddlewareProps := impl.CompressionMiddlewareProps{
+		CompressorFactory: GzipTestCompressorFactory{
+			CompressedDataChannel:   props.CompressedDataChannel,
+			DecompressedDataChannel: props.DecompressedDataChannel,
+		},
+		CompressionStrategyProps: compression.CompressionStrategyProps{
+			CompressionLevel: props.CompressionLevel,
+			Logger:           props.Logger,
+		},
+		IncludeTypes: props.IncludeTypes,
+	}
+	return impl.NewCompressionMiddleware(compressionMiddlewareProps)
+}


### PR DESCRIPTION
Work towards https://github.com/momentohq/dev-eco-issue-tracker/issues/1223
Follow-up work to adding compression middleware in the sdk.

Created a test-specific gzip middleware that uses channels to verify data is actually getting compressed and decompressed in tests.