### PR TITLE
fix: make sure cache client closes all underlying clients upon close

### DIFF
--- a/momento/cache_client.go
+++ b/momento/cache_client.go
@@ -1069,6 +1069,9 @@ func (c defaultScsClient) Ping(ctx context.Context) (responses.PingResponse, err
 func (c defaultScsClient) Close() {
 	defer c.controlClient.Close()
 	defer c.getNextDataClient().Close()
+	for _, client := range c.dataClients {
+		defer client.Close()
+	}
 }
 
 func convertMomentoSvcErrorToCustomerError(e momentoerrors.MomentoSvcErr) MomentoError {

--- a/momento/cache_client.go
+++ b/momento/cache_client.go
@@ -1067,6 +1067,7 @@ func (c defaultScsClient) Ping(ctx context.Context) (responses.PingResponse, err
 }
 
 func (c defaultScsClient) Close() {
+	defer c.pingClient.Close()
 	defer c.controlClient.Close()
 	defer c.getNextDataClient().Close()
 	for _, client := range c.dataClients {

--- a/momento/cache_client.go
+++ b/momento/cache_client.go
@@ -1069,7 +1069,6 @@ func (c defaultScsClient) Ping(ctx context.Context) (responses.PingResponse, err
 func (c defaultScsClient) Close() {
 	defer c.pingClient.Close()
 	defer c.controlClient.Close()
-	defer c.getNextDataClient().Close()
 	for _, client := range c.dataClients {
 		defer client.Close()
 	}


### PR DESCRIPTION
This will prevent leaked goroutines from the cache client