### PR TITLE
fix: refreshApiKey changed to match Credential Provider API key"

### DIFF
--- a/momento/auth_client_test.go
+++ b/momento/auth_client_test.go
@@ -1734,9 +1734,13 @@ var _ = Describe("auth auth-client", Label(AUTH_SERVICE_LABEL), func() {
 				Expect(refreshResp).To(BeAssignableToTypeOf(&auth_responses.RefreshApiKeySuccess{}))
 
 				refreshSuccess := refreshResp.(*auth_responses.RefreshApiKeySuccess)
-
 				expiresAtDelta := refreshSuccess.ExpiresAt.Epoch() - success.ExpiresAt.Epoch()
 				Expect(expiresAtDelta).To(BeNumerically("~", delaySecondsBeforeRefresh.Seconds(), delaySecondsBeforeRefresh.Seconds()+10))
+				refreshAuthClient := authClientFromApiKey(sharedContext, refreshSuccess.ApiKey)
+				_, err = refreshAuthClient.RefreshApiKey(sharedContext.Ctx, &RefreshApiKeyRequest{
+					RefreshToken: refreshSuccess.RefreshToken,
+				})
+				Expect(err).To(BeNil())
 			})
 
 			It("should fail to refresh api key with expired refresh token", func() {

--- a/momento/internal_auth_client.go
+++ b/momento/internal_auth_client.go
@@ -49,9 +49,22 @@ func (client *authClient) RefreshApiKey(ctx context.Context, request *RefreshApi
 	if err != nil {
 		return nil, momentoerrors.ConvertSvcErr(err)
 	}
+	jsonObject := map[string]string{
+		"api_key":  resp.ApiKey,
+		"endpoint": resp.Endpoint,
+	}
+	jsonString, err := json.Marshal(jsonObject)
+	if err != nil {
+		return nil, NewMomentoError(
+			momentoerrors.ClientSdkError,
+			"Unable to map API key to necessary form",
+			err,
+		)
+	}
+	b64Encoded := b64.StdEncoding.EncodeToString([]byte(jsonString))
 
 	return &auth_responses.RefreshApiKeySuccess{
-		ApiKey:       resp.ApiKey,
+		ApiKey:       b64Encoded,
 		RefreshToken: resp.RefreshToken,
 		Endpoint:     resp.Endpoint,
 		ExpiresAt:    utils.ExpiresAtFromEpoch(int64(resp.ValidUntil)),


### PR DESCRIPTION
Solves the following [issue](https://github.com/momentohq/client-sdk-go/issues/571#issue-2769122473).

I changed the ApiKey that is returned by RefreshApiKey to be a 64-bit encoded JSON document in the same manner as GenerateApiKey.  