### PR TITLE
chore: Adding Debug Logs

### DIFF
--- a/momento/scs_data_client.go
+++ b/momento/scs_data_client.go
@@ -28,6 +28,7 @@ type scsDataClient struct {
 	endpoint            string
 	eagerConnectTimeout time.Duration
 	loggerFactory       logger.MomentoLoggerFactory
+	logger              logger.MomentoLogger
 	middleware          []middleware.Middleware
 }
 
@@ -48,6 +49,10 @@ func newScsDataClient(request *models.DataClientRequest, eagerConnectTimeout tim
 	} else {
 		timeout = request.Configuration.GetClientSideTimeout()
 	}
+	lf := request.Configuration.GetLoggerFactory()
+
+	var lg = lf.GetLogger("data-client")
+
 	return &scsDataClient{
 		grpcManager:         dataManager,
 		grpcClient:          pb.NewScsClient(dataManager.Conn),
@@ -55,7 +60,8 @@ func newScsDataClient(request *models.DataClientRequest, eagerConnectTimeout tim
 		requestTimeout:      timeout,
 		endpoint:            request.CredentialProvider.GetCacheEndpoint(),
 		eagerConnectTimeout: eagerConnectTimeout,
-		loggerFactory:       request.Configuration.GetLoggerFactory(),
+		loggerFactory:       lf,
+		logger:              lg,
 		middleware:          request.Configuration.GetMiddleware(),
 	}, nil
 }
@@ -143,10 +149,8 @@ func (client scsDataClient) applyMiddlewareResponseHandlers(
 }
 
 func (client scsDataClient) makeRequest(ctx context.Context, r requester) (interface{}, error) {
-	logger := client.loggerFactory.GetLogger("data-client")
-	logger.Debug("%v request made on cache %v", r.requestName(), r.cacheName())
+	client.logger.Debug("%v request made on cache %v", r.requestName(), r.cacheName())
 	if _, err := prepareCacheName(r); err != nil {
-		logger.Error("failed to prepare cache name due to error", err)
 		return nil, err
 	}
 
@@ -155,44 +159,36 @@ func (client scsDataClient) makeRequest(ctx context.Context, r requester) (inter
 	var err error
 	middlewareRequestHandlers, r, requestMetadata, err = client.applyMiddlewareRequestHandlers(r, requestMetadata)
 	if err != nil {
-		logger.Error("failed to apply middleware request handlers: %v", err)
+		client.logger.Error("failed to apply middleware request handlers: %v", err)
 		return nil, err
 	}
-	logger.Debug("applied middleware request handlers, metadata=%v", requestMetadata)
 	req, err := r.initGrpcRequest(client)
 	if err != nil {
-		logger.Error("failed to init gRPC request: %v", err)
+		client.logger.Error("failed to init gRPC request: %v", err)
 		return nil, err
 	}
-	logger.Debug("gRPC request initialized")
 
 	ctx, cancel := context.WithTimeout(ctx, client.requestTimeout)
 	defer cancel()
-	logger.Debug("context created with timeout=%s", client.requestTimeout)
 
 	requestContext := internal.CreateCacheRequestContextFromMetadataMap(ctx, r.cacheName(), requestMetadata)
 	resp, responseMetadata, err := r.makeGrpcRequest(req, requestContext, client)
 	if err != nil {
-		logger.Error("gRPC request failed: %v, responseMetadata=%v", err, responseMetadata)
+		client.logger.Error("gRPC request failed: %v, responseMetadata=%v", err, responseMetadata)
 		return nil, momentoerrors.ConvertSvcErr(err, responseMetadata...)
 	}
-	logger.Debug("gRPC request succeeded, responseMetadata=%v", responseMetadata)
 
 	momentoResp, err := r.interpretGrpcResponse(resp)
 	if err != nil {
-		logger.Error("failed to interpret gRPC response: %v", err)
+		client.logger.Error("failed to interpret gRPC response: %v", err)
 		return nil, err
 	}
-	logger.Debug("interpreted gRPC response")
 
 	momentoResp, err = client.applyMiddlewareResponseHandlers(middlewareRequestHandlers, momentoResp, responseMetadata)
 	if err != nil {
-		logger.Error("failed to apply middleware response handlers: %v", err)
+		client.logger.Error("failed to apply middleware response handlers: %v", err)
 		return nil, err
 	}
-	logger.Debug("applied middleware response handlers successfully")
-
-	logger.Debug("%v request succeeded with response=%v", r.requestName(), momentoResp)
 	return momentoResp, nil
 }
 


### PR DESCRIPTION
Added debug logs to makeRequest so that all methods report any errors they see. 

Log output looks like this: 
`[2025-09-04T21:59:30Z] DEBUG (data-client): context created with timeout=5s`
`[2025-09-04T21:59:31Z] DEBUG (fixed-count-retry-strategy): Request is not retryable: [method: /cache_client.Scs/DictionarySet, status: NotFound]`
`[2025-09-04T21:59:31Z] ERROR (data-client): gRPC request failed: rpc error: code = NotFound desc = Cache not found, responseMetadata=[map[] map[access-control-allow-credentials:[true] access-control-expose-headers:[grpc-status,grpc-message,grpc-encoding,grpc-accept-encoding,err] content-type:[application/grpc] date:[Thu, 04 Sep 2025 21:59:30 GMT] err:[momento_general_err] vary:[origin, access-control-request-method, access-control-request-headers]]]
panic: NotFoundError: Cache not found
        rpc error: code = NotFound desc = Cache not found`