### PR TITLE
fix: topic reconnect bug never actually attempted a reconnect, ensure we actually increment our attempt counter

### DIFF
--- a/internal/grpcmanagers/topic_manager_lists/dynamic_stream_grpc_manager_pool.go
+++ b/internal/grpcmanagers/topic_manager_lists/dynamic_stream_grpc_manager_pool.go
@@ -71,6 +71,23 @@ func (d *dynamicStreamGrpcManagerPool) GetCurrentActiveStreamsCount() uint64 {
 	return d.currentActiveStreamsCount.Load()
 }
 
+// ReleaseTopicGrpcManager decrements both the per-channel NumActiveSubscriptions counter
+// on the given manager and the pool-wide currentActiveStreamsCount, freeing up the slot
+// so future GetNextTopicGrpcManager calls see capacity. Returns the new per-channel count.
+func (d *dynamicStreamGrpcManagerPool) ReleaseTopicGrpcManager(manager *grpcmanagers.TopicGrpcManager) int64 {
+	newCount := manager.NumActiveSubscriptions.Add(-1)
+	for {
+		current := d.currentActiveStreamsCount.Load()
+		if current == 0 {
+			break
+		}
+		if d.currentActiveStreamsCount.CompareAndSwap(current, current-1) {
+			break
+		}
+	}
+	return newCount
+}
+
 // GetCurrentNumberOfGrpcManagers returns the current number of grpc managers in the pool.
 func (d *dynamicStreamGrpcManagerPool) GetCurrentNumberOfGrpcManagers() int {
 	return len(d.grpcManagers)

--- a/internal/grpcmanagers/topic_manager_lists/static_stream_grpc_manager_pool.go
+++ b/internal/grpcmanagers/topic_manager_lists/static_stream_grpc_manager_pool.go
@@ -68,6 +68,23 @@ func (s *staticStreamGrpcManagerPool) GetCurrentActiveStreamsCount() uint64 {
 	return s.currentActiveStreamsCount.Load()
 }
 
+// ReleaseTopicGrpcManager decrements both the per-channel NumActiveSubscriptions counter
+// on the given manager and the pool-wide currentActiveStreamsCount, freeing up the slot
+// so future GetNextTopicGrpcManager calls see capacity. Returns the new per-channel count.
+func (s *staticStreamGrpcManagerPool) ReleaseTopicGrpcManager(manager *grpcmanagers.TopicGrpcManager) int64 {
+	newCount := manager.NumActiveSubscriptions.Add(-1)
+	for {
+		current := s.currentActiveStreamsCount.Load()
+		if current == 0 {
+			break
+		}
+		if s.currentActiveStreamsCount.CompareAndSwap(current, current-1) {
+			break
+		}
+	}
+	return newCount
+}
+
 // NewStaticStreamGrpcManagerPool creates a new pool with a fixed number of grpc managers for stream pubsub requests.
 func NewStaticStreamGrpcManagerPool(
 	request *models.TopicStreamGrpcManagerRequest,

--- a/internal/grpcmanagers/topic_manager_lists/static_unary_grpc_manager_pool.go
+++ b/internal/grpcmanagers/topic_manager_lists/static_unary_grpc_manager_pool.go
@@ -27,6 +27,13 @@ func (list *staticUnaryGrpcManagerPool) GetNextTopicGrpcManager() (*grpcmanagers
 	return list.grpcManagers[nextManagerIndex%uint64(len(list.grpcManagers))], nil
 }
 
+// ReleaseTopicGrpcManager is a no-op for the unary pool because unary requests
+// don't hold long-lived stream slots and the pool doesn't track per-channel
+// subscription counts.
+func (list *staticUnaryGrpcManagerPool) ReleaseTopicGrpcManager(_ *grpcmanagers.TopicGrpcManager) int64 {
+	return 0
+}
+
 // Close shuts down all the grpc connections in the pool.
 func (list *staticUnaryGrpcManagerPool) Close() {
 	for _, topicManager := range list.grpcManagers {

--- a/internal/grpcmanagers/topic_manager_lists/topic_grpc_connection_pool.go
+++ b/internal/grpcmanagers/topic_manager_lists/topic_grpc_connection_pool.go
@@ -12,6 +12,12 @@ type TopicGrpcConnectionPool interface {
 	// GetNextTopicGrpcManager returns the next available TopicGrpcManager from the pool.
 	GetNextTopicGrpcManager() (*grpcmanagers.TopicGrpcManager, momentoerrors.MomentoSvcErr)
 
+	// ReleaseTopicGrpcManager decrements the per-channel and pool-wide subscription
+	// counters for a manager that is no longer in use, returning the new per-channel
+	// subscription count for logging. For unary pools that do not track these counters,
+	// this is a no-op that returns 0.
+	ReleaseTopicGrpcManager(manager *grpcmanagers.TopicGrpcManager) int64
+
 	// Close shuts down all the grpc connections in the pool.
 	Close()
 }

--- a/momento/pubsub_client.go
+++ b/momento/pubsub_client.go
@@ -125,7 +125,7 @@ func (client *pubSubClient) topicSubscribe(ctx context.Context, request *TopicSu
 	subscribeClient, err := topicManager.StreamClient.Subscribe(requestContext, subscriptionRequest)
 
 	if err != nil {
-		topicManager.NumActiveSubscriptions.Add(-1)
+		client.streamGrpcConnectionPool.ReleaseTopicGrpcManager(topicManager)
 		cancelFunction()
 		if subscribeClient != nil {
 			header, _ = subscribeClient.Header()

--- a/momento/retry_test.go
+++ b/momento/retry_test.go
@@ -1248,10 +1248,26 @@ var _ = Describe("retry eligibility-strategy", Label(RETRY_LABEL, MOMENTO_LOCAL_
 			Expect(err).To(BeNil())
 			defer sub.Close()
 
-			const publishCount = 220
+			const publishCount = 260
+			stopPublish := make(chan struct{})
+			stopPublishing := func() {
+				select {
+				case <-stopPublish:
+				default:
+					close(stopPublish)
+				}
+			}
+			defer stopPublishing()
 			publishErr := make(chan error, 1)
 			go func() {
 				for i := 0; i < publishCount; i++ {
+					select {
+					case <-stopPublish:
+						publishErr <- nil
+						return
+					default:
+					}
+
 					_, err := topicClient.Publish(testCtx, &TopicPublishRequest{
 						CacheName: cacheName,
 						TopicName: topicName,
@@ -1261,57 +1277,31 @@ var _ = Describe("retry eligibility-strategy", Label(RETRY_LABEL, MOMENTO_LOCAL_
 						publishErr <- err
 						return
 					}
-					time.Sleep(5 * time.Millisecond)
+					select {
+					case <-stopPublish:
+						publishErr <- nil
+						return
+					case <-time.After(5 * time.Millisecond):
+					}
 				}
 				publishErr <- nil
 			}()
 
+			topicEventMetricsCollector := *retryMiddleware.(helpers.MomentoLocalMiddleware).GetTopicEventCollector()
 			readCtx, cancel := context.WithTimeout(testCtx, 45*time.Second)
 			defer cancel()
-			receivedItems := 0
-			for receivedItems < publishCount {
-				event, err := sub.Event(readCtx)
+			for {
+				_, err := sub.Event(readCtx)
 				Expect(err).To(BeNil())
-				if _, ok := event.(TopicItem); ok {
-					receivedItems++
+
+				counter, err := topicEventMetricsCollector.GetEventCounter(cacheName, "Subscribe")
+				Expect(err).To(BeNil())
+				if counter.Reconnects > config.MAX_CONCURRENT_STREAMS_PER_CHANNEL {
+					break
 				}
 			}
+			stopPublishing()
 			Expect(<-publishErr).To(BeNil())
-
-			topicEventMetricsCollector := *retryMiddleware.(helpers.MomentoLocalMiddleware).GetTopicEventCollector()
-			Eventually(func(g Gomega) {
-				counter, err := topicEventMetricsCollector.GetEventCounter(cacheName, "Subscribe")
-				g.Expect(err).To(BeNil())
-				g.Expect(counter.Reconnects).To(BeNumerically(">", config.MAX_CONCURRENT_STREAMS_PER_CHANNEL))
-			}, 5*time.Second, 100*time.Millisecond).Should(Succeed())
-		})
-
-		It("should release stream capacity when subscriptions close without Event calls", func() {
-			topicClient := setupTopicClient(config.TopicsDefault().WithNumStreamGrpcChannels(1))
-			defer topicClient.Close()
-
-			subscriptions := make([]TopicSubscription, 0, config.MAX_CONCURRENT_STREAMS_PER_CHANNEL)
-			for i := 0; i < config.MAX_CONCURRENT_STREAMS_PER_CHANNEL; i++ {
-				sub, err := topicClient.Subscribe(testCtx, &TopicSubscribeRequest{
-					CacheName: cacheName,
-					TopicName: fmt.Sprintf("%s-%03d", topicName, i),
-				})
-				Expect(err).To(BeNil())
-				subscriptions = append(subscriptions, sub)
-			}
-
-			for _, sub := range subscriptions {
-				sub.Close()
-			}
-
-			for i := 0; i < config.MAX_CONCURRENT_STREAMS_PER_CHANNEL; i++ {
-				sub, err := topicClient.Subscribe(testCtx, &TopicSubscribeRequest{
-					CacheName: cacheName,
-					TopicName: fmt.Sprintf("%s-again-%03d", topicName, i),
-				})
-				Expect(err).To(BeNil())
-				sub.Close()
-			}
 		})
 	})
 

--- a/momento/retry_test.go
+++ b/momento/retry_test.go
@@ -1229,6 +1229,90 @@ var _ = Describe("retry eligibility-strategy", Label(RETRY_LABEL, MOMENTO_LOCAL_
 			err := doPubSub(topicClient, publishedValues)
 			Expect(err).To(HaveMomentoErrorCode(TimeoutError))
 		})
+
+		It("should keep reconnecting after more reconnects than one stream channel capacity", func() {
+			msgLimit := 2
+			status := helpers.MomentoErrorCodeToMomentoLocalMetadataValue(momentoerrors.ServerUnavailableError)
+			clientConfig, retryMiddleware := getClientConfig(&clientConfigProps{
+				status:                  &status,
+				streamErrorMessageLimit: &msgLimit,
+				streamErrorRpcList:      &[]string{"topic-subscribe"},
+			})
+			topicClient := setupTopicClient(clientConfig.WithNumStreamGrpcChannels(1))
+			defer topicClient.Close()
+
+			sub, err := topicClient.Subscribe(testCtx, &TopicSubscribeRequest{
+				CacheName: cacheName,
+				TopicName: topicName,
+			})
+			Expect(err).To(BeNil())
+			defer sub.Close()
+
+			const publishCount = 220
+			publishErr := make(chan error, 1)
+			go func() {
+				for i := 0; i < publishCount; i++ {
+					_, err := topicClient.Publish(testCtx, &TopicPublishRequest{
+						CacheName: cacheName,
+						TopicName: topicName,
+						Value:     String(fmt.Sprintf("value-%03d", i)),
+					})
+					if err != nil {
+						publishErr <- err
+						return
+					}
+					time.Sleep(5 * time.Millisecond)
+				}
+				publishErr <- nil
+			}()
+
+			readCtx, cancel := context.WithTimeout(testCtx, 45*time.Second)
+			defer cancel()
+			receivedItems := 0
+			for receivedItems < publishCount {
+				event, err := sub.Event(readCtx)
+				Expect(err).To(BeNil())
+				if _, ok := event.(TopicItem); ok {
+					receivedItems++
+				}
+			}
+			Expect(<-publishErr).To(BeNil())
+
+			topicEventMetricsCollector := *retryMiddleware.(helpers.MomentoLocalMiddleware).GetTopicEventCollector()
+			Eventually(func(g Gomega) {
+				counter, err := topicEventMetricsCollector.GetEventCounter(cacheName, "Subscribe")
+				g.Expect(err).To(BeNil())
+				g.Expect(counter.Reconnects).To(BeNumerically(">", config.MAX_CONCURRENT_STREAMS_PER_CHANNEL))
+			}, 5*time.Second, 100*time.Millisecond).Should(Succeed())
+		})
+
+		It("should release stream capacity when subscriptions close without Event calls", func() {
+			topicClient := setupTopicClient(config.TopicsDefault().WithNumStreamGrpcChannels(1))
+			defer topicClient.Close()
+
+			subscriptions := make([]TopicSubscription, 0, config.MAX_CONCURRENT_STREAMS_PER_CHANNEL)
+			for i := 0; i < config.MAX_CONCURRENT_STREAMS_PER_CHANNEL; i++ {
+				sub, err := topicClient.Subscribe(testCtx, &TopicSubscribeRequest{
+					CacheName: cacheName,
+					TopicName: fmt.Sprintf("%s-%03d", topicName, i),
+				})
+				Expect(err).To(BeNil())
+				subscriptions = append(subscriptions, sub)
+			}
+
+			for _, sub := range subscriptions {
+				sub.Close()
+			}
+
+			for i := 0; i < config.MAX_CONCURRENT_STREAMS_PER_CHANNEL; i++ {
+				sub, err := topicClient.Subscribe(testCtx, &TopicSubscribeRequest{
+					CacheName: cacheName,
+					TopicName: fmt.Sprintf("%s-again-%03d", topicName, i),
+				})
+				Expect(err).To(BeNil())
+				sub.Close()
+			}
+		})
 	})
 
 	Describe("Network Outage", func() {

--- a/momento/topic_client.go
+++ b/momento/topic_client.go
@@ -140,6 +140,7 @@ func (c defaultTopicClient) sendSubscribe(requestCtx context.Context, request *T
 			}
 		}
 		cancelFunction()
+		c.pubSubClient.streamGrpcConnectionPool.ReleaseTopicGrpcManager(topicManager)
 		errChan <- momentoerrors.ConvertSvcErr(err)
 		return
 	}
@@ -149,6 +150,7 @@ func (c defaultTopicClient) sendSubscribe(requestCtx context.Context, request *T
 		// The first message to a new subscription will always be a heartbeat.
 	default:
 		cancelFunction()
+		c.pubSubClient.streamGrpcConnectionPool.ReleaseTopicGrpcManager(topicManager)
 		errChan <- momentoerrors.NewMomentoSvcErr(
 			momentoerrors.InternalServerError,
 			fmt.Sprintf("expected a heartbeat message, got: %T", firstMsg.Kind),

--- a/momento/topic_client.go
+++ b/momento/topic_client.go
@@ -80,7 +80,7 @@ func (c defaultTopicClient) Subscribe(ctx context.Context, request *TopicSubscri
 	// If the first message is not received within this time, we will cancel the subscription.
 	firstMessageCtx, cancel := context.WithTimeout(ctx, c.requestTimeout)
 	defer cancel()
-	subChan := make(chan topicSubscription, 1)
+	subChan := make(chan *topicSubscription, 1)
 	errChan := make(chan error, 1)
 
 	// Send the subscribe request in a separate goroutine to avoid blocking the main thread.
@@ -100,13 +100,13 @@ func (c defaultTopicClient) Subscribe(ctx context.Context, request *TopicSubscri
 			nil,
 		)
 	case subscription := <-subChan:
-		return &subscription, nil
+		return subscription, nil
 	case err := <-errChan:
 		return nil, err
 	}
 }
 
-func (c defaultTopicClient) sendSubscribe(requestCtx context.Context, request *TopicSubscribeRequest, subChan chan topicSubscription, errChan chan error) {
+func (c defaultTopicClient) sendSubscribe(requestCtx context.Context, request *TopicSubscribeRequest, subChan chan *topicSubscription, errChan chan error) {
 	var firstMsg *pb.XSubscriptionItem
 	topicManager, subscribeClient, cancelContext, cancelFunction, err := c.pubSubClient.topicSubscribe(requestCtx, &TopicSubscribeRequest{
 		CacheName:                   request.CacheName,
@@ -166,7 +166,7 @@ func (c defaultTopicClient) sendSubscribe(requestCtx context.Context, request *T
 			break
 		}
 	}
-	subChan <- topicSubscription{
+	subChan <- &topicSubscription{
 		topicManager:       topicManager,
 		topicEventCallback: topicEventCallback,
 		subscribeClient:    subscribeClient,

--- a/momento/topic_subscription.go
+++ b/momento/topic_subscription.go
@@ -3,6 +3,7 @@ package momento
 import (
 	"context"
 	"fmt"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -10,6 +11,7 @@ import (
 
 	"github.com/momentohq/client-sdk-go/config/middleware"
 	"github.com/momentohq/client-sdk-go/config/retry"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
 	"github.com/momentohq/client-sdk-go/config/logger"
@@ -65,17 +67,24 @@ type TopicSubscription interface {
 }
 
 type topicSubscription struct {
-	topicManager            *grpcmanagers.TopicGrpcManager
+	// mu guards topicManager, subscribeClient, cancelContext, and cancelFunction
+	// against cross-goroutine reads from Close while attemptReconnect (running
+	// in the Event goroutine) installs a new stream. Within the Event goroutine
+	// these fields are read without mu since reads and writes there are already
+	// sequenced by program order.
+	mu              sync.Mutex
+	topicManager    *grpcmanagers.TopicGrpcManager
+	subscribeClient pb.Pubsub_SubscribeClient
+	cancelContext   context.Context
+	cancelFunction  context.CancelFunc
+
 	topicEventCallback      func(cacheName string, requestName string, event middleware.TopicSubscriptionEventType)
-	subscribeClient         pb.Pubsub_SubscribeClient
 	momentoTopicClient      *pubSubClient
 	cacheName               string
 	topicName               string
 	log                     logger.MomentoLogger
 	lastKnownSequenceNumber uint64
 	lastKnownSequencePage   uint64
-	cancelContext           context.Context
-	cancelFunction          context.CancelFunc
 	retryStrategy           retry.Strategy
 	// released gates the per-stream release so it runs exactly once between
 	// successive allocations. It is set to true when the current stream's slot
@@ -85,6 +94,23 @@ type topicSubscription struct {
 	// to bail out if Close races in while a reconnect is in flight, so a freshly
 	// allocated stream doesn't leak past Close.
 	closed atomic.Bool
+}
+
+// grpcStatusCode returns the gRPC status code embedded in err, unwrapping a
+// MomentoSvcErr if needed. The first call to attemptReconnect receives a raw
+// gRPC error from Recv(); subsequent retries get a MomentoSvcErr back from
+// topicSubscribe — both need to produce the same code for the retry strategy.
+func grpcStatusCode(err error) codes.Code {
+	if err == nil {
+		return codes.OK
+	}
+	if svcErr, ok := err.(momentoerrors.MomentoSvcErr); ok {
+		if original := svcErr.OriginalErr(); original != nil {
+			return status.Code(original)
+		}
+		return codes.Unknown
+	}
+	return status.Code(err)
 }
 
 func (s *topicSubscription) Item(ctx context.Context) (TopicValue, error) {
@@ -220,10 +246,13 @@ func (s *topicSubscription) onTopicEvent(method string, event middleware.TopicSu
 }
 
 func (s *topicSubscription) decrementSubscriptionCount() int64 {
+	s.mu.Lock()
+	mgr := s.topicManager
+	s.mu.Unlock()
 	if !s.released.CompareAndSwap(false, true) {
-		return s.topicManager.NumActiveSubscriptions.Load()
+		return mgr.NumActiveSubscriptions.Load()
 	}
-	return s.momentoTopicClient.streamGrpcConnectionPool.ReleaseTopicGrpcManager(s.topicManager)
+	return s.momentoTopicClient.streamGrpcConnectionPool.ReleaseTopicGrpcManager(mgr)
 }
 
 func (s *topicSubscription) attemptReconnect(ctx context.Context, err error) error {
@@ -239,7 +268,7 @@ func (s *topicSubscription) attemptReconnect(ctx context.Context, err error) err
 		}
 
 		retryBackoffTime := s.retryStrategy.DetermineWhenToRetry(retry.StrategyProps{
-			GrpcStatusCode: status.Code(err),
+			GrpcStatusCode: grpcStatusCode(err),
 			GrpcMethod:     "/cache_client.pubsub.Pubsub/Subscribe",
 			AttemptNumber:  attempt,
 		})
@@ -272,6 +301,11 @@ func (s *topicSubscription) attemptReconnect(ctx context.Context, err error) err
 		}
 
 		s.log.Info("Successfully reconnected to subscription stream")
+		// Install the new stream under the mutex so that a concurrent Close
+		// observes either the old state or the new state, never a torn mix.
+		// Capture the closed flag under the same critical section so that any
+		// Close that ran before we unlock is guaranteed to be seen here.
+		s.mu.Lock()
 		s.topicManager = topicManager
 		s.subscribeClient = subscribeClient
 		s.cancelContext = cancelContext
@@ -279,13 +313,15 @@ func (s *topicSubscription) attemptReconnect(ctx context.Context, err error) err
 		// The new stream has its own release lifecycle; allow the next disconnect
 		// to perform its own decrement.
 		s.released.Store(false)
+		wasClosed := s.closed.Load()
+		s.mu.Unlock()
 
 		// If Close() ran while we were reconnecting, the cancelFunction it called
 		// targeted the *old* (already-cancelled) cancelFunction, and the decrement
 		// it issued was a no-op against the still-true `released` flag. The new
 		// stream we just installed would otherwise leak past Close — tear it down
 		// here.
-		if s.closed.Load() {
+		if wasClosed {
 			s.log.Info("Subscription closed during reconnect; tearing down newly established stream")
 			cancelFunction()
 			s.decrementSubscriptionCount()
@@ -300,9 +336,14 @@ func (s *topicSubscription) attemptReconnect(ctx context.Context, err error) err
 // `released` flag), so if an in-flight Event() loop also observes the cancel
 // and decrements, the counters stay correct. The `closed` flag is set first so
 // that an in-flight attemptReconnect notices and tears down any new stream it
-// allocates instead of leaking it past Close.
+// allocates instead of leaking it past Close. The cancel function is snapshotted
+// under mu so a concurrent attemptReconnect can't reassign the field while we
+// read it.
 func (s *topicSubscription) Close() {
 	s.closed.Store(true)
-	s.cancelFunction()
+	s.mu.Lock()
+	cancel := s.cancelFunction
+	s.mu.Unlock()
+	cancel()
 	s.decrementSubscriptionCount()
 }

--- a/momento/topic_subscription.go
+++ b/momento/topic_subscription.go
@@ -3,6 +3,7 @@ package momento
 import (
 	"context"
 	"fmt"
+	"sync/atomic"
 	"time"
 
 	"github.com/momentohq/client-sdk-go/internal/momentoerrors"
@@ -76,6 +77,14 @@ type topicSubscription struct {
 	cancelContext           context.Context
 	cancelFunction          context.CancelFunc
 	retryStrategy           retry.Strategy
+	// released gates the per-stream release so it runs exactly once between
+	// successive allocations. It is set to true when the current stream's slot
+	// is released and reset to false on successful reconnect.
+	released atomic.Bool
+	// closed is set permanently to true by Close(). attemptReconnect checks it
+	// to bail out if Close races in while a reconnect is in flight, so a freshly
+	// allocated stream doesn't leak past Close.
+	closed atomic.Bool
 }
 
 func (s *topicSubscription) Item(ctx context.Context) (TopicValue, error) {
@@ -211,7 +220,10 @@ func (s *topicSubscription) onTopicEvent(method string, event middleware.TopicSu
 }
 
 func (s *topicSubscription) decrementSubscriptionCount() int64 {
-	return s.topicManager.NumActiveSubscriptions.Add(-1)
+	if !s.released.CompareAndSwap(false, true) {
+		return s.topicManager.NumActiveSubscriptions.Load()
+	}
+	return s.momentoTopicClient.streamGrpcConnectionPool.ReleaseTopicGrpcManager(s.topicManager)
 }
 
 func (s *topicSubscription) attemptReconnect(ctx context.Context, err error) error {
@@ -221,6 +233,11 @@ func (s *topicSubscription) attemptReconnect(ctx context.Context, err error) err
 	}
 	attempt := 1
 	for {
+		if s.closed.Load() {
+			s.log.Info("Subscription closed during reconnect; aborting retry loop")
+			return momentoerrors.NewMomentoSvcErr(momentoerrors.CanceledError, "subscription closed", nil)
+		}
+
 		retryBackoffTime := s.retryStrategy.DetermineWhenToRetry(retry.StrategyProps{
 			GrpcStatusCode: status.Code(err),
 			GrpcMethod:     "/cache_client.pubsub.Pubsub/Subscribe",
@@ -240,29 +257,52 @@ func (s *topicSubscription) attemptReconnect(ctx context.Context, err error) err
 		}
 
 		s.log.Info("Attempting reconnecting to client stream")
-		topicManager, subscribeClient, cancelContext, cancelFunction, err := s.momentoTopicClient.topicSubscribe(ctx, &TopicSubscribeRequest{
+		topicManager, subscribeClient, cancelContext, cancelFunction, reconnectErr := s.momentoTopicClient.topicSubscribe(ctx, &TopicSubscribeRequest{
 			CacheName:                   s.cacheName,
 			TopicName:                   s.topicName,
 			ResumeAtTopicSequenceNumber: s.lastKnownSequenceNumber,
 			SequencePage:                s.lastKnownSequencePage,
 		})
 
-		if err != nil {
+		if reconnectErr != nil {
 			s.log.Warn("Failed to reconnect to stream")
-		} else {
-			s.log.Info("Successfully reconnected to subscription stream")
-			s.topicManager = topicManager
-			s.subscribeClient = subscribeClient
-			s.cancelContext = cancelContext
-			s.cancelFunction = cancelFunction
-			return nil
+			err = reconnectErr
+			attempt++
+			continue
 		}
+
+		s.log.Info("Successfully reconnected to subscription stream")
+		s.topicManager = topicManager
+		s.subscribeClient = subscribeClient
+		s.cancelContext = cancelContext
+		s.cancelFunction = cancelFunction
+		// The new stream has its own release lifecycle; allow the next disconnect
+		// to perform its own decrement.
+		s.released.Store(false)
+
+		// If Close() ran while we were reconnecting, the cancelFunction it called
+		// targeted the *old* (already-cancelled) cancelFunction, and the decrement
+		// it issued was a no-op against the still-true `released` flag. The new
+		// stream we just installed would otherwise leak past Close — tear it down
+		// here.
+		if s.closed.Load() {
+			s.log.Info("Subscription closed during reconnect; tearing down newly established stream")
+			cancelFunction()
+			s.decrementSubscriptionCount()
+			return momentoerrors.NewMomentoSvcErr(momentoerrors.CanceledError, "subscription closed", nil)
+		}
+		return nil
 	}
 }
 
-// Note: number of active subscriptions is decremented in the `Event` method
-// for each of the cases when a stream is closed. We do not decrement here
-// to avoid double counting.
+// Close cancels the stream context and releases the per-channel and pool-wide
+// subscription slots. decrementSubscriptionCount is idempotent (guarded by the
+// `released` flag), so if an in-flight Event() loop also observes the cancel
+// and decrements, the counters stay correct. The `closed` flag is set first so
+// that an in-flight attemptReconnect notices and tears down any new stream it
+// allocates instead of leaking it past Close.
 func (s *topicSubscription) Close() {
+	s.closed.Store(true)
 	s.cancelFunction()
+	s.decrementSubscriptionCount()
 }

--- a/momento/topic_subscription.go
+++ b/momento/topic_subscription.go
@@ -265,7 +265,7 @@ func (s *topicSubscription) attemptReconnect(ctx context.Context, err error) err
 		})
 
 		if reconnectErr != nil {
-			s.log.Warn("Failed to reconnect to stream")
+			s.log.Warn("Failed to reconnect to stream: %s", reconnectErr.Error())
 			err = reconnectErr
 			attempt++
 			continue

--- a/momento/topic_subscription_accounting_test.go
+++ b/momento/topic_subscription_accounting_test.go
@@ -1,0 +1,263 @@
+package momento
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/momentohq/client-sdk-go/config/logger"
+	"github.com/momentohq/client-sdk-go/config/retry"
+	"github.com/momentohq/client-sdk-go/internal/grpcmanagers"
+	"github.com/momentohq/client-sdk-go/internal/momentoerrors"
+	pb "github.com/momentohq/client-sdk-go/internal/protos"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+type testTopicGrpcConnectionPool struct {
+	manager      *grpcmanagers.TopicGrpcManager
+	activeCount  atomic.Int64
+	releaseCount atomic.Int64
+}
+
+func newTestTopicGrpcConnectionPool(streamClient pb.PubsubClient) *testTopicGrpcConnectionPool {
+	return &testTopicGrpcConnectionPool{
+		manager: &grpcmanagers.TopicGrpcManager{
+			StreamClient: streamClient,
+		},
+	}
+}
+
+func (p *testTopicGrpcConnectionPool) GetNextTopicGrpcManager() (*grpcmanagers.TopicGrpcManager, momentoerrors.MomentoSvcErr) {
+	p.manager.NumActiveSubscriptions.Add(1)
+	p.activeCount.Add(1)
+	return p.manager, nil
+}
+
+func (p *testTopicGrpcConnectionPool) ReleaseTopicGrpcManager(manager *grpcmanagers.TopicGrpcManager) int64 {
+	p.releaseCount.Add(1)
+	p.activeCount.Add(-1)
+	return manager.NumActiveSubscriptions.Add(-1)
+}
+
+func (p *testTopicGrpcConnectionPool) Close() {}
+
+type testPubsubClient struct {
+	subscribe func(context.Context, *pb.XSubscriptionRequest, ...grpc.CallOption) (pb.Pubsub_SubscribeClient, error)
+}
+
+func (c *testPubsubClient) Publish(context.Context, *pb.XPublishRequest, ...grpc.CallOption) (*pb.XEmpty, error) {
+	return &pb.XEmpty{}, nil
+}
+
+func (c *testPubsubClient) Subscribe(ctx context.Context, request *pb.XSubscriptionRequest, opts ...grpc.CallOption) (pb.Pubsub_SubscribeClient, error) {
+	return c.subscribe(ctx, request, opts...)
+}
+
+type recvResult struct {
+	item *pb.XSubscriptionItem
+	err  error
+}
+
+type testSubscribeClient struct {
+	grpc.ClientStream
+	results []recvResult
+	recv    func() (*pb.XSubscriptionItem, error)
+}
+
+func (c *testSubscribeClient) Recv() (*pb.XSubscriptionItem, error) {
+	if c.recv != nil {
+		return c.recv()
+	}
+	if len(c.results) == 0 {
+		return nil, status.Error(codes.Unavailable, "test stream exhausted")
+	}
+	result := c.results[0]
+	c.results = c.results[1:]
+	return result.item, result.err
+}
+
+type alwaysRetryStrategy struct{}
+
+func (alwaysRetryStrategy) DetermineWhenToRetry(retry.StrategyProps) *int {
+	delay := 0
+	return &delay
+}
+
+func newAccountingTestClient(streamClient pb.PubsubClient, timeout time.Duration) (defaultTopicClient, *testTopicGrpcConnectionPool) {
+	pool := newTestTopicGrpcConnectionPool(streamClient)
+	client := defaultTopicClient{
+		pubSubClient: &pubSubClient{
+			streamGrpcConnectionPool: pool,
+		},
+		log:            logger.NewNoopMomentoLoggerFactory().GetLogger("topic-subscription-accounting-test"),
+		requestTimeout: timeout,
+		retryStrategy:  alwaysRetryStrategy{},
+	}
+	return client, pool
+}
+
+func testSubscribeRequest() *TopicSubscribeRequest {
+	return &TopicSubscribeRequest{
+		CacheName: "cache",
+		TopicName: "topic",
+	}
+}
+
+func heartbeatItem() *pb.XSubscriptionItem {
+	return &pb.XSubscriptionItem{
+		Kind: &pb.XSubscriptionItem_Heartbeat{
+			Heartbeat: &pb.XHeartbeat{},
+		},
+	}
+}
+
+func topicItem(sequenceNumber uint64) *pb.XSubscriptionItem {
+	return &pb.XSubscriptionItem{
+		Kind: &pb.XSubscriptionItem_Item{
+			Item: &pb.XTopicItem{
+				TopicSequenceNumber: sequenceNumber,
+				SequencePage:        1,
+				Value: &pb.XTopicValue{
+					Kind: &pb.XTopicValue_Text{Text: "value"},
+				},
+			},
+		},
+	}
+}
+
+func assertAccounting(t *testing.T, pool *testTopicGrpcConnectionPool, activeCount int64) {
+	t.Helper()
+	if got := pool.activeCount.Load(); got != activeCount {
+		t.Fatalf("active stream count = %d, want %d", got, activeCount)
+	}
+	if got := pool.manager.NumActiveSubscriptions.Load(); got != activeCount {
+		t.Fatalf("manager subscription count = %d, want %d", got, activeCount)
+	}
+}
+
+func TestTopicSubscribeReleasesPoolCountersWhenStreamOpenFails(t *testing.T) {
+	streamClient := &testPubsubClient{
+		subscribe: func(context.Context, *pb.XSubscriptionRequest, ...grpc.CallOption) (pb.Pubsub_SubscribeClient, error) {
+			return nil, status.Error(codes.Unavailable, "stream open failed")
+		},
+	}
+	_, pool := newAccountingTestClient(streamClient, time.Second)
+	client := &pubSubClient{streamGrpcConnectionPool: pool}
+
+	_, _, _, _, err := client.topicSubscribe(context.Background(), testSubscribeRequest())
+	if err == nil {
+		t.Fatal("expected topicSubscribe to return an error")
+	}
+	assertAccounting(t, pool, 0)
+	if got := pool.releaseCount.Load(); got != 1 {
+		t.Fatalf("release count = %d, want 1", got)
+	}
+}
+
+func TestSubscribeReleasesPoolCountersWhenFirstMessageRecvFails(t *testing.T) {
+	streamClient := &testPubsubClient{
+		subscribe: func(context.Context, *pb.XSubscriptionRequest, ...grpc.CallOption) (pb.Pubsub_SubscribeClient, error) {
+			return &testSubscribeClient{
+				results: []recvResult{{err: status.Error(codes.Unavailable, "first message failed")}},
+			}, nil
+		},
+	}
+	client, pool := newAccountingTestClient(streamClient, time.Second)
+
+	sub, err := client.Subscribe(context.Background(), testSubscribeRequest())
+	if err == nil {
+		t.Fatal("expected Subscribe to return an error")
+	}
+	if sub != nil {
+		t.Fatal("expected subscription to be nil")
+	}
+	assertAccounting(t, pool, 0)
+}
+
+func TestSubscribeReleasesPoolCountersWhenFirstMessageIsNotHeartbeat(t *testing.T) {
+	streamClient := &testPubsubClient{
+		subscribe: func(context.Context, *pb.XSubscriptionRequest, ...grpc.CallOption) (pb.Pubsub_SubscribeClient, error) {
+			return &testSubscribeClient{
+				results: []recvResult{{item: topicItem(1)}},
+			}, nil
+		},
+	}
+	client, pool := newAccountingTestClient(streamClient, time.Second)
+
+	sub, err := client.Subscribe(context.Background(), testSubscribeRequest())
+	if err == nil {
+		t.Fatal("expected Subscribe to return an error")
+	}
+	if sub != nil {
+		t.Fatal("expected subscription to be nil")
+	}
+	assertAccounting(t, pool, 0)
+}
+
+func TestTopicSubscriptionCloseReleasesPoolCountersWithoutEvent(t *testing.T) {
+	streamClient := &testPubsubClient{
+		subscribe: func(context.Context, *pb.XSubscriptionRequest, ...grpc.CallOption) (pb.Pubsub_SubscribeClient, error) {
+			return &testSubscribeClient{
+				results: []recvResult{{item: heartbeatItem()}},
+			}, nil
+		},
+	}
+	client, pool := newAccountingTestClient(streamClient, time.Second)
+
+	sub, err := client.Subscribe(context.Background(), testSubscribeRequest())
+	if err != nil {
+		t.Fatalf("Subscribe returned error: %v", err)
+	}
+	assertAccounting(t, pool, 1)
+
+	sub.Close()
+	assertAccounting(t, pool, 0)
+}
+
+func TestTopicSubscriptionReconnectKeepsPoolCountersBalanced(t *testing.T) {
+	disconnectErr := status.Error(codes.Unavailable, "stream disconnected")
+	var subscribeCalls atomic.Uint64
+	streamClient := &testPubsubClient{
+		subscribe: func(context.Context, *pb.XSubscriptionRequest, ...grpc.CallOption) (pb.Pubsub_SubscribeClient, error) {
+			call := subscribeCalls.Add(1)
+			if call == 1 {
+				return &testSubscribeClient{
+					results: []recvResult{
+						{item: heartbeatItem()},
+						{err: disconnectErr},
+					},
+				}, nil
+			}
+			return &testSubscribeClient{
+				results: []recvResult{
+					{item: topicItem(call)},
+					{err: disconnectErr},
+				},
+			}, nil
+		},
+	}
+	client, pool := newAccountingTestClient(streamClient, time.Second)
+
+	sub, err := client.Subscribe(context.Background(), testSubscribeRequest())
+	if err != nil {
+		t.Fatalf("Subscribe returned error: %v", err)
+	}
+	assertAccounting(t, pool, 1)
+
+	for i := 0; i < 5; i++ {
+		event, err := sub.Event(context.Background())
+		if err != nil {
+			t.Fatalf("Event %d returned error: %v", i, err)
+		}
+		if _, ok := event.(TopicItem); !ok {
+			t.Fatalf("Event %d = %T, want TopicItem", i, event)
+		}
+		assertAccounting(t, pool, 1)
+	}
+
+	sub.Close()
+	assertAccounting(t, pool, 0)
+}


### PR DESCRIPTION
  Fixes a set of bugs in the topic subscription reconnect path that could cause the SDK to permanently stop reconnecting after enough disconnect/reconnect cycles, plus a handful of related correctness issues I noticed while here.

 ### Context

  `topicSubscription.decrementSubscriptionCount()` only decremented the per-channel `NumActiveSubscriptions` counter on the `TopicGrpcManager`. It did not decrement the pool-wide
  `currentActiveStreamsCount` on the stream pool. That counter was only ever `Add(1)`'d and never decremented anywhere in the codebase.

  Meanwhile, every successful reconnect (`attemptReconnect` → `topicSubscribe` → `getNextManager`) increments both counters. Net effect per disconnect/reconnect cycle: `NumActiveSubscriptions` stays
  balanced, but `currentActiveStreamsCount` grows by +1.

  Once `currentActiveStreamsCount >= maxConcurrentStreams`, `checkNumConcurrentStreams` starts returning `ClientResourceExhaustedError`, and `attemptReconnect` loops forever without ever succeeding.

  The same leak also occurred on a normal `Close()` if no `Event()` call was in flight to observe the cancelled context.

### Testing

I needed a way to repro this, so the easiest was to add some log lines and run a program that would run a basic topic-subscribe workflow. This the code of the repro code:

```go
❯ cat cmd/leak-repro/main.go
// Repro for the topic-subscription pool counter leak on reconnect.
//
// Reads MOMENTO_API_KEY and MOMENTO_CACHE_NAME from env. Subscribes to a single
// topic on a 1-channel client (so the per-pool max is
// MAX_CONCURRENT_STREAMS_PER_CHANNEL = 100). Force disconnects (e.g. toggle
// wifi) and watch whether the subscription survives many reconnect cycles.
package main

import (
	"context"
	"errors"
	"fmt"
	"log"
	"os"
	"os/signal"
	"syscall"
	"time"

	"github.com/momentohq/client-sdk-go/auth"
	"github.com/momentohq/client-sdk-go/config"
	"github.com/momentohq/client-sdk-go/config/logger/momento_default_logger"
	"github.com/momentohq/client-sdk-go/momento"
)

func main() {
	apiKey := os.Getenv("MOMENTO_API_KEY")
	if apiKey == "" {
		log.Fatal("MOMENTO_API_KEY is not set")
	}
	cacheName := os.Getenv("MOMENTO_CACHE_NAME")
	if cacheName == "" {
		log.Fatal("MOMENTO_CACHE_NAME is not set")
	}
	topicName := "leak-repro-topic"

	credProvider, err := auth.NewStringMomentoTokenProvider(apiKey)
	if err != nil {
		log.Fatalf("credential provider: %v", err)
	}

	loggerFactory := momento_default_logger.NewDefaultMomentoLoggerFactory(momento_default_logger.INFO)
	topicsCfg := config.TopicsDefaultWithLogger(loggerFactory).WithNumStreamGrpcChannels(1)

	topicClient, err := momento.NewTopicClient(topicsCfg, credProvider)
	if err != nil {
		log.Fatalf("new topic client: %v", err)
	}
	defer topicClient.Close()

	ctx, cancel := context.WithCancel(context.Background())
	defer cancel()

	fmt.Printf("[repro] subscribing to cache=%q topic=%q\n", cacheName, topicName)
	sub, err := topicClient.Subscribe(ctx, &momento.TopicSubscribeRequest{
		CacheName: cacheName,
		TopicName: topicName,
	})
	if err != nil {
		log.Fatalf("subscribe: %v", err)
	}
	defer sub.Close()

	sigCh := make(chan os.Signal, 1)
	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
	go func() {
		<-sigCh
		fmt.Println("\n[repro] interrupt received, closing subscription (Ctrl-C again to force exit)")
		sub.Close()
		cancel()
		<-sigCh
		fmt.Println("\n[repro] second interrupt, forcing exit")
		os.Exit(130)
	}()

	start := time.Now()
	var events int
	for {
		ev, err := sub.Event(ctx)
		if err != nil {
			if errors.Is(err, context.Canceled) {
				fmt.Printf("[repro] context cancelled after %d events (%.0fs)\n", events, time.Since(start).Seconds())
				return
			}
			fmt.Printf("[repro] *** subscription died after %d events (%.0fs): %v\n", events, time.Since(start).Seconds(), err)
			return
		}
		events++
		switch e := ev.(type) {
		case momento.TopicHeartbeat:
			// expected ~every 15s; useful as a liveness signal
			fmt.Printf("[repro] heartbeat #%d\n", events)
		case momento.TopicDiscontinuity:
			fmt.Printf("[repro] discontinuity: %+v\n", e)
		case momento.TopicItem:
			fmt.Printf("[repro] item: seq=%d value=%v\n", e.GetTopicSequenceNumber(), e.GetValue())
		}
	}
}
```

I added some log lines to the SDK, run the test, then shut off my WiFi, wait a little bit, then re-enable it.

I confirmed on `main` that the code _never_ reconnected.


With this branch, you can see it actually reconnecting (receiving heartbeats) when I would reconnect. Then, when I would disconnect and reconnect, you can see it come back (again):

```bash
❯ go run ./cmd/leak-repro
[repro] subscribing to cache="default-cache" topic="leak-repro-topic"
[2026-05-18T04:14:36Z] WARN (topic-client): [LEAK REPRO] stream alloc:   pool currentActiveStreamsCount=1, channel NumActiveSubscriptions=1
[2026-05-18T04:14:36Z] WARN (topic-client): [LEAK REPRO] stream alloc:   pool currentActiveStreamsCount=2, channel NumActiveSubscriptions=2
[2026-05-18T04:14:47Z] ERROR (topic-client): Stream disconnected due to error: rpc error: code = Unavailable desc = keepalive ping failed to receive ACK within timeout
[2026-05-18T04:14:47Z] WARN (topic-client): [LEAK REPRO] decrement: releasing slot via pool
[2026-05-18T04:14:47Z] WARN (topic-client): [LEAK REPRO] stream release: pool currentActiveStreamsCount=1, channel NumActiveSubscriptions=1
[2026-05-18T04:14:47Z] INFO (topic-client): Waiting 500 milliseconds before attempting to reconnect
[2026-05-18T04:14:48Z] INFO (topic-client): Attempting reconnecting to client stream
[2026-05-18T04:14:48Z] WARN (topic-client): [LEAK REPRO] stream alloc:   pool currentActiveStreamsCount=2, channel NumActiveSubscriptions=2
[2026-05-18T04:14:48Z] WARN (topic-client): [LEAK REPRO] stream release: pool currentActiveStreamsCount=1, channel NumActiveSubscriptions=1
[2026-05-18T04:14:48Z] WARN (topic-client): Failed to reconnect to stream
[2026-05-18T04:14:48Z] INFO (topic-client): Waiting 500 milliseconds before attempting to reconnect
[2026-05-18T04:14:48Z] INFO (topic-client): Attempting reconnecting to client stream
[2026-05-18T04:14:48Z] WARN (topic-client): [LEAK REPRO] stream release: pool currentActiveStreamsCount=0, channel NumActiveSubscriptions=0
[2026-05-18T04:14:48Z] WARN (topic-client): Failed to reconnect to stream
[2026-05-18T04:14:48Z] INFO (topic-client): Waiting 500 milliseconds before attempting to reconnect
[2026-05-18T04:14:48Z] WARN (topic-client): [LEAK REPRO] stream alloc:   pool currentActiveStreamsCount=1, channel NumActiveSubscriptions=1
[2026-05-18T04:14:49Z] INFO (topic-client): Attempting reconnecting to client stream
[2026-05-18T04:14:49Z] WARN (topic-client): [LEAK REPRO] stream release: pool currentActiveStreamsCount=0, channel NumActiveSubscriptions=0
[2026-05-18T04:14:49Z] WARN (topic-client): Failed to reconnect to stream
[2026-05-18T04:14:49Z] INFO (topic-client): Waiting 500 milliseconds before attempting to reconnect
[2026-05-18T04:14:49Z] WARN (topic-client): [LEAK REPRO] stream alloc:   pool currentActiveStreamsCount=1, channel NumActiveSubscriptions=1
[2026-05-18T04:14:49Z] INFO (topic-client): Attempting reconnecting to client stream
[2026-05-18T04:14:49Z] WARN (topic-client): [LEAK REPRO] stream alloc:   pool currentActiveStreamsCount=2, channel NumActiveSubscriptions=2
[2026-05-18T04:14:49Z] WARN (topic-client): [LEAK REPRO] stream release: pool currentActiveStreamsCount=1, channel NumActiveSubscriptions=1
[2026-05-18T04:14:49Z] WARN (topic-client): Failed to reconnect to stream
[2026-05-18T04:14:49Z] INFO (topic-client): Waiting 500 milliseconds before attempting to reconnect
[2026-05-18T04:14:50Z] INFO (topic-client): Attempting reconnecting to client stream
[2026-05-18T04:14:50Z] WARN (topic-client): [LEAK REPRO] stream release: pool currentActiveStreamsCount=0, channel NumActiveSubscriptions=0
[2026-05-18T04:14:50Z] WARN (topic-client): Failed to reconnect to stream
[2026-05-18T04:14:50Z] INFO (topic-client): Waiting 500 milliseconds before attempting to reconnect
[2026-05-18T04:14:50Z] WARN (topic-client): [LEAK REPRO] stream alloc:   pool currentActiveStreamsCount=1, channel NumActiveSubscriptions=1
[2026-05-18T04:14:50Z] INFO (topic-client): Attempting reconnecting to client stream
[2026-05-18T04:14:50Z] WARN (topic-client): [LEAK REPRO] stream alloc:   pool currentActiveStreamsCount=2, channel NumActiveSubscriptions=2
[2026-05-18T04:14:50Z] WARN (topic-client): [LEAK REPRO] stream release: pool currentActiveStreamsCount=1, channel NumActiveSubscriptions=1
[2026-05-18T04:14:50Z] WARN (topic-client): Failed to reconnect to stream
[2026-05-18T04:14:50Z] INFO (topic-client): Waiting 500 milliseconds before attempting to reconnect
[2026-05-18T04:14:51Z] INFO (topic-client): Attempting reconnecting to client stream
[2026-05-18T04:14:51Z] WARN (topic-client): [LEAK REPRO] stream alloc:   pool currentActiveStreamsCount=2, channel NumActiveSubscriptions=2
[2026-05-18T04:14:51Z] WARN (topic-client): [LEAK REPRO] stream release: pool currentActiveStreamsCount=1, channel NumActiveSubscriptions=1
[2026-05-18T04:14:51Z] WARN (topic-client): Failed to reconnect to stream
[2026-05-18T04:14:51Z] INFO (topic-client): Waiting 500 milliseconds before attempting to reconnect
[2026-05-18T04:14:51Z] INFO (topic-client): Attempting reconnecting to client stream
[2026-05-18T04:14:51Z] WARN (topic-client): [LEAK REPRO] stream release: pool currentActiveStreamsCount=0, channel NumActiveSubscriptions=0
[2026-05-18T04:14:51Z] WARN (topic-client): Failed to reconnect to stream
[2026-05-18T04:14:51Z] INFO (topic-client): Waiting 500 milliseconds before attempting to reconnect
[2026-05-18T04:14:51Z] WARN (topic-client): [LEAK REPRO] stream alloc:   pool currentActiveStreamsCount=1, channel NumActiveSubscriptions=1
[2026-05-18T04:14:52Z] INFO (topic-client): Attempting reconnecting to client stream
[2026-05-18T04:14:52Z] WARN (topic-client): [LEAK REPRO] stream alloc:   pool currentActiveStreamsCount=2, channel NumActiveSubscriptions=2
[2026-05-18T04:14:52Z] WARN (topic-client): [LEAK REPRO] stream release: pool currentActiveStreamsCount=1, channel NumActiveSubscriptions=1
[2026-05-18T04:14:52Z] WARN (topic-client): Failed to reconnect to stream
[2026-05-18T04:14:52Z] INFO (topic-client): Waiting 500 milliseconds before attempting to reconnect
[2026-05-18T04:14:52Z] INFO (topic-client): Attempting reconnecting to client stream
[2026-05-18T04:14:52Z] WARN (topic-client): [LEAK REPRO] stream alloc:   pool currentActiveStreamsCount=2, channel NumActiveSubscriptions=2
[2026-05-18T04:14:52Z] WARN (topic-client): [LEAK REPRO] stream release: pool currentActiveStreamsCount=1, channel NumActiveSubscriptions=1
[2026-05-18T04:14:52Z] WARN (topic-client): Failed to reconnect to stream
[2026-05-18T04:14:52Z] INFO (topic-client): Waiting 500 milliseconds before attempting to reconnect
[2026-05-18T04:14:53Z] INFO (topic-client): Attempting reconnecting to client stream
[2026-05-18T04:14:53Z] WARN (topic-client): [LEAK REPRO] stream alloc:   pool currentActiveStreamsCount=2, channel NumActiveSubscriptions=2
[2026-05-18T04:14:53Z] WARN (topic-client): [LEAK REPRO] stream release: pool currentActiveStreamsCount=1, channel NumActiveSubscriptions=1
[2026-05-18T04:14:53Z] WARN (topic-client): Failed to reconnect to stream
[2026-05-18T04:14:53Z] INFO (topic-client): Waiting 500 milliseconds before attempting to reconnect
[2026-05-18T04:14:53Z] INFO (topic-client): Attempting reconnecting to client stream
[2026-05-18T04:14:53Z] WARN (topic-client): [LEAK REPRO] stream alloc:   pool currentActiveStreamsCount=2, channel NumActiveSubscriptions=2
[2026-05-18T04:14:53Z] WARN (topic-client): [LEAK REPRO] stream release: pool currentActiveStreamsCount=1, channel NumActiveSubscriptions=1
[2026-05-18T04:14:53Z] WARN (topic-client): Failed to reconnect to stream
[2026-05-18T04:14:53Z] INFO (topic-client): Waiting 500 milliseconds before attempting to reconnect
[2026-05-18T04:14:54Z] INFO (topic-client): Attempting reconnecting to client stream
[2026-05-18T04:14:54Z] WARN (topic-client): [LEAK REPRO] stream release: pool currentActiveStreamsCount=1, channel NumActiveSubscriptions=1
[2026-05-18T04:14:54Z] WARN (topic-client): [LEAK REPRO] stream alloc:   pool currentActiveStreamsCount=2, channel NumActiveSubscriptions=2
[2026-05-18T04:14:54Z] WARN (topic-client): Failed to reconnect to stream
[2026-05-18T04:14:54Z] INFO (topic-client): Waiting 500 milliseconds before attempting to reconnect
[2026-05-18T04:14:54Z] INFO (topic-client): Attempting reconnecting to client stream
[2026-05-18T04:14:54Z] WARN (topic-client): [LEAK REPRO] stream alloc:   pool currentActiveStreamsCount=2, channel NumActiveSubscriptions=2
[2026-05-18T04:14:54Z] WARN (topic-client): [LEAK REPRO] stream release: pool currentActiveStreamsCount=1, channel NumActiveSubscriptions=1
[2026-05-18T04:14:54Z] WARN (topic-client): Failed to reconnect to stream
[2026-05-18T04:14:54Z] INFO (topic-client): Waiting 500 milliseconds before attempting to reconnect
[2026-05-18T04:14:55Z] INFO (topic-client): Attempting reconnecting to client stream
[2026-05-18T04:14:55Z] WARN (topic-client): [LEAK REPRO] stream release: pool currentActiveStreamsCount=0, channel NumActiveSubscriptions=0
[2026-05-18T04:14:55Z] WARN (topic-client): Failed to reconnect to stream
[2026-05-18T04:14:55Z] INFO (topic-client): Waiting 500 milliseconds before attempting to reconnect
[2026-05-18T04:14:55Z] WARN (topic-client): [LEAK REPRO] stream alloc:   pool currentActiveStreamsCount=1, channel NumActiveSubscriptions=1
[2026-05-18T04:14:55Z] INFO (topic-client): Attempting reconnecting to client stream
[2026-05-18T04:14:55Z] WARN (topic-client): [LEAK REPRO] stream alloc:   pool currentActiveStreamsCount=2, channel NumActiveSubscriptions=2
[2026-05-18T04:14:55Z] WARN (topic-client): [LEAK REPRO] stream release: pool currentActiveStreamsCount=1, channel NumActiveSubscriptions=1
[2026-05-18T04:14:55Z] WARN (topic-client): Failed to reconnect to stream
[2026-05-18T04:14:55Z] INFO (topic-client): Waiting 500 milliseconds before attempting to reconnect
[2026-05-18T04:14:56Z] INFO (topic-client): Attempting reconnecting to client stream
[2026-05-18T04:14:56Z] WARN (topic-client): [LEAK REPRO] stream alloc:   pool currentActiveStreamsCount=2, channel NumActiveSubscriptions=2
[2026-05-18T04:14:56Z] WARN (topic-client): [LEAK REPRO] stream release: pool currentActiveStreamsCount=1, channel NumActiveSubscriptions=1
[2026-05-18T04:14:56Z] WARN (topic-client): Failed to reconnect to stream
[2026-05-18T04:14:56Z] INFO (topic-client): Waiting 500 milliseconds before attempting to reconnect
[2026-05-18T04:14:56Z] INFO (topic-client): Attempting reconnecting to client stream
[2026-05-18T04:14:56Z] WARN (topic-client): [LEAK REPRO] stream alloc:   pool currentActiveStreamsCount=2, channel NumActiveSubscriptions=2
[2026-05-18T04:14:56Z] WARN (topic-client): [LEAK REPRO] stream release: pool currentActiveStreamsCount=1, channel NumActiveSubscriptions=1
[2026-05-18T04:14:56Z] WARN (topic-client): Failed to reconnect to stream
[2026-05-18T04:14:56Z] INFO (topic-client): Waiting 500 milliseconds before attempting to reconnect
[2026-05-18T04:14:57Z] INFO (topic-client): Attempting reconnecting to client stream
[2026-05-18T04:14:57Z] WARN (topic-client): [LEAK REPRO] stream release: pool currentActiveStreamsCount=0, channel NumActiveSubscriptions=0
[2026-05-18T04:14:57Z] WARN (topic-client): Failed to reconnect to stream
[2026-05-18T04:14:57Z] INFO (topic-client): Waiting 500 milliseconds before attempting to reconnect
[2026-05-18T04:14:57Z] WARN (topic-client): [LEAK REPRO] stream alloc:   pool currentActiveStreamsCount=1, channel NumActiveSubscriptions=1
[2026-05-18T04:14:57Z] INFO (topic-client): Attempting reconnecting to client stream
[2026-05-18T04:14:57Z] WARN (topic-client): [LEAK REPRO] stream release: pool currentActiveStreamsCount=0, channel NumActiveSubscriptions=0
[2026-05-18T04:14:57Z] WARN (topic-client): Failed to reconnect to stream
[2026-05-18T04:14:57Z] INFO (topic-client): Waiting 500 milliseconds before attempting to reconnect
[2026-05-18T04:14:57Z] WARN (topic-client): [LEAK REPRO] stream alloc:   pool currentActiveStreamsCount=1, channel NumActiveSubscriptions=1
[2026-05-18T04:14:58Z] INFO (topic-client): Attempting reconnecting to client stream
[2026-05-18T04:14:58Z] WARN (topic-client): [LEAK REPRO] stream release: pool currentActiveStreamsCount=1, channel NumActiveSubscriptions=1
[2026-05-18T04:14:58Z] WARN (topic-client): [LEAK REPRO] stream alloc:   pool currentActiveStreamsCount=2, channel NumActiveSubscriptions=2
[2026-05-18T04:14:58Z] WARN (topic-client): Failed to reconnect to stream
[2026-05-18T04:14:58Z] INFO (topic-client): Waiting 500 milliseconds before attempting to reconnect
[2026-05-18T04:14:58Z] INFO (topic-client): Attempting reconnecting to client stream
[2026-05-18T04:14:58Z] WARN (topic-client): [LEAK REPRO] stream alloc:   pool currentActiveStreamsCount=2, channel NumActiveSubscriptions=2
[2026-05-18T04:14:58Z] WARN (topic-client): [LEAK REPRO] stream release: pool currentActiveStreamsCount=1, channel NumActiveSubscriptions=1
[2026-05-18T04:14:58Z] WARN (topic-client): Failed to reconnect to stream
[2026-05-18T04:14:58Z] INFO (topic-client): Waiting 500 milliseconds before attempting to reconnect
[2026-05-18T04:14:59Z] INFO (topic-client): Attempting reconnecting to client stream
[2026-05-18T04:14:59Z] WARN (topic-client): [LEAK REPRO] stream release: pool currentActiveStreamsCount=0, channel NumActiveSubscriptions=0
[2026-05-18T04:14:59Z] WARN (topic-client): Failed to reconnect to stream
[2026-05-18T04:14:59Z] INFO (topic-client): Waiting 500 milliseconds before attempting to reconnect
[2026-05-18T04:14:59Z] WARN (topic-client): [LEAK REPRO] stream alloc:   pool currentActiveStreamsCount=1, channel NumActiveSubscriptions=1
[2026-05-18T04:14:59Z] INFO (topic-client): Attempting reconnecting to client stream
[2026-05-18T04:14:59Z] WARN (topic-client): [LEAK REPRO] stream release: pool currentActiveStreamsCount=0, channel NumActiveSubscriptions=0
[2026-05-18T04:14:59Z] WARN (topic-client): Failed to reconnect to stream
[2026-05-18T04:14:59Z] INFO (topic-client): Waiting 500 milliseconds before attempting to reconnect
[2026-05-18T04:14:59Z] WARN (topic-client): [LEAK REPRO] stream alloc:   pool currentActiveStreamsCount=1, channel NumActiveSubscriptions=1
[2026-05-18T04:15:00Z] INFO (topic-client): Attempting reconnecting to client stream
[2026-05-18T04:15:00Z] WARN (topic-client): [LEAK REPRO] stream release: pool currentActiveStreamsCount=0, channel NumActiveSubscriptions=0
[2026-05-18T04:15:00Z] WARN (topic-client): Failed to reconnect to stream
[2026-05-18T04:15:00Z] INFO (topic-client): Waiting 500 milliseconds before attempting to reconnect
[2026-05-18T04:15:00Z] WARN (topic-client): [LEAK REPRO] stream alloc:   pool currentActiveStreamsCount=1, channel NumActiveSubscriptions=1
[2026-05-18T04:15:00Z] INFO (topic-client): Attempting reconnecting to client stream
[2026-05-18T04:15:00Z] WARN (topic-client): [LEAK REPRO] stream alloc:   pool currentActiveStreamsCount=2, channel NumActiveSubscriptions=2
[2026-05-18T04:15:00Z] WARN (topic-client): [LEAK REPRO] stream release: pool currentActiveStreamsCount=1, channel NumActiveSubscriptions=1
[2026-05-18T04:15:00Z] WARN (topic-client): Failed to reconnect to stream
[2026-05-18T04:15:00Z] INFO (topic-client): Waiting 500 milliseconds before attempting to reconnect
[2026-05-18T04:15:01Z] INFO (topic-client): Attempting reconnecting to client stream
[2026-05-18T04:15:01Z] WARN (topic-client): [LEAK REPRO] stream alloc:   pool currentActiveStreamsCount=2, channel NumActiveSubscriptions=2
[2026-05-18T04:15:01Z] WARN (topic-client): [LEAK REPRO] stream release: pool currentActiveStreamsCount=1, channel NumActiveSubscriptions=1
[2026-05-18T04:15:01Z] WARN (topic-client): Failed to reconnect to stream
[2026-05-18T04:15:01Z] INFO (topic-client): Waiting 500 milliseconds before attempting to reconnect
[2026-05-18T04:15:01Z] INFO (topic-client): Attempting reconnecting to client stream
[2026-05-18T04:15:01Z] WARN (topic-client): [LEAK REPRO] stream alloc:   pool currentActiveStreamsCount=2, channel NumActiveSubscriptions=2
[2026-05-18T04:15:01Z] WARN (topic-client): [LEAK REPRO] stream release: pool currentActiveStreamsCount=1, channel NumActiveSubscriptions=1
[2026-05-18T04:15:01Z] WARN (topic-client): Failed to reconnect to stream
[2026-05-18T04:15:01Z] INFO (topic-client): Waiting 500 milliseconds before attempting to reconnect
[2026-05-18T04:15:02Z] INFO (topic-client): Attempting reconnecting to client stream
[2026-05-18T04:15:02Z] WARN (topic-client): [LEAK REPRO] stream alloc:   pool currentActiveStreamsCount=2, channel NumActiveSubscriptions=2
[2026-05-18T04:15:02Z] WARN (topic-client): [LEAK REPRO] stream release: pool currentActiveStreamsCount=1, channel NumActiveSubscriptions=1
[2026-05-18T04:15:02Z] WARN (topic-client): Failed to reconnect to stream
[2026-05-18T04:15:02Z] INFO (topic-client): Waiting 500 milliseconds before attempting to reconnect
[2026-05-18T04:15:02Z] INFO (topic-client): Attempting reconnecting to client stream
[2026-05-18T04:15:02Z] WARN (topic-client): [LEAK REPRO] stream release: pool currentActiveStreamsCount=0, channel NumActiveSubscriptions=0
[2026-05-18T04:15:02Z] WARN (topic-client): Failed to reconnect to stream
[2026-05-18T04:15:02Z] INFO (topic-client): Waiting 500 milliseconds before attempting to reconnect
[2026-05-18T04:15:02Z] WARN (topic-client): [LEAK REPRO] stream alloc:   pool currentActiveStreamsCount=1, channel NumActiveSubscriptions=1
[2026-05-18T04:15:03Z] INFO (topic-client): Attempting reconnecting to client stream
[2026-05-18T04:15:03Z] WARN (topic-client): [LEAK REPRO] stream release: pool currentActiveStreamsCount=0, channel NumActiveSubscriptions=0
[2026-05-18T04:15:03Z] WARN (topic-client): Failed to reconnect to stream
[2026-05-18T04:15:03Z] INFO (topic-client): Waiting 500 milliseconds before attempting to reconnect
[2026-05-18T04:15:03Z] WARN (topic-client): [LEAK REPRO] stream alloc:   pool currentActiveStreamsCount=1, channel NumActiveSubscriptions=1
[2026-05-18T04:15:03Z] INFO (topic-client): Attempting reconnecting to client stream
[2026-05-18T04:15:03Z] INFO (topic-client): Successfully reconnected to subscription stream
[2026-05-18T04:15:03Z] WARN (topic-client): [LEAK REPRO] stream alloc:   pool currentActiveStreamsCount=2, channel NumActiveSubscriptions=2
[repro] heartbeat #1
[repro] heartbeat #2
[repro] heartbeat #3
[repro] heartbeat #4
[2026-05-18T04:15:37Z] ERROR (topic-client): Stream disconnected due to error: rpc error: code = Unavailable desc = keepalive ping failed to receive ACK within timeout
[2026-05-18T04:15:37Z] WARN (topic-client): [LEAK REPRO] decrement: releasing slot via pool
[2026-05-18T04:15:37Z] WARN (topic-client): [LEAK REPRO] stream release: pool currentActiveStreamsCount=1, channel NumActiveSubscriptions=1
[2026-05-18T04:15:37Z] INFO (topic-client): Waiting 500 milliseconds before attempting to reconnect
[2026-05-18T04:15:37Z] INFO (topic-client): Attempting reconnecting to client stream
[2026-05-18T04:15:37Z] WARN (topic-client): [LEAK REPRO] stream alloc:   pool currentActiveStreamsCount=2, channel NumActiveSubscriptions=2
[2026-05-18T04:15:37Z] WARN (topic-client): [LEAK REPRO] stream release: pool currentActiveStreamsCount=1, channel NumActiveSubscriptions=1
[2026-05-18T04:15:37Z] WARN (topic-client): Failed to reconnect to stream
[2026-05-18T04:15:37Z] INFO (topic-client): Waiting 500 milliseconds before attempting to reconnect
[2026-05-18T04:15:38Z] INFO (topic-client): Attempting reconnecting to client stream
[2026-05-18T04:15:38Z] WARN (topic-client): [LEAK REPRO] stream alloc:   pool currentActiveStreamsCount=2, channel NumActiveSubscriptions=2
[2026-05-18T04:15:38Z] WARN (topic-client): [LEAK REPRO] stream release: pool currentActiveStreamsCount=1, channel NumActiveSubscriptions=1
[2026-05-18T04:15:38Z] WARN (topic-client): Failed to reconnect to stream
[2026-05-18T04:15:38Z] INFO (topic-client): Waiting 500 milliseconds before attempting to reconnect
[2026-05-18T04:15:38Z] INFO (topic-client): Attempting reconnecting to client stream
[2026-05-18T04:15:38Z] WARN (topic-client): [LEAK REPRO] stream alloc:   pool currentActiveStreamsCount=2, channel NumActiveSubscriptions=2
[2026-05-18T04:15:38Z] WARN (topic-client): [LEAK REPRO] stream release: pool currentActiveStreamsCount=1, channel NumActiveSubscriptions=1
[2026-05-18T04:15:38Z] WARN (topic-client): Failed to reconnect to stream
[2026-05-18T04:15:38Z] INFO (topic-client): Waiting 500 milliseconds before attempting to reconnect
[2026-05-18T04:15:39Z] INFO (topic-client): Attempting reconnecting to client stream
[2026-05-18T04:15:39Z] WARN (topic-client): [LEAK REPRO] stream alloc:   pool currentActiveStreamsCount=2, channel NumActiveSubscriptions=2
[2026-05-18T04:15:39Z] WARN (topic-client): [LEAK REPRO] stream release: pool currentActiveStreamsCount=1, channel NumActiveSubscriptions=1
[2026-05-18T04:15:39Z] WARN (topic-client): Failed to reconnect to stream
[2026-05-18T04:15:39Z] INFO (topic-client): Waiting 500 milliseconds before attempting to reconnect
[2026-05-18T04:15:39Z] INFO (topic-client): Attempting reconnecting to client stream
[2026-05-18T04:15:39Z] WARN (topic-client): [LEAK REPRO] stream alloc:   pool currentActiveStreamsCount=2, channel NumActiveSubscriptions=2
[2026-05-18T04:15:39Z] WARN (topic-client): [LEAK REPRO] stream release: pool currentActiveStreamsCount=1, channel NumActiveSubscriptions=1
[2026-05-18T04:15:39Z] WARN (topic-client): Failed to reconnect to stream
[2026-05-18T04:15:39Z] INFO (topic-client): Waiting 500 milliseconds before attempting to reconnect
[2026-05-18T04:15:40Z] INFO (topic-client): Attempting reconnecting to client stream
[2026-05-18T04:15:40Z] WARN (topic-client): [LEAK REPRO] stream alloc:   pool currentActiveStreamsCount=2, channel NumActiveSubscriptions=2
[2026-05-18T04:15:40Z] WARN (topic-client): [LEAK REPRO] stream release: pool currentActiveStreamsCount=1, channel NumActiveSubscriptions=1
[2026-05-18T04:15:40Z] WARN (topic-client): Failed to reconnect to stream
[2026-05-18T04:15:40Z] INFO (topic-client): Waiting 500 milliseconds before attempting to reconnect
[2026-05-18T04:15:41Z] INFO (topic-client): Attempting reconnecting to client stream
[2026-05-18T04:15:41Z] WARN (topic-client): [LEAK REPRO] stream release: pool currentActiveStreamsCount=0, channel NumActiveSubscriptions=0
[2026-05-18T04:15:41Z] WARN (topic-client): Failed to reconnect to stream
[2026-05-18T04:15:41Z] WARN (topic-client): [LEAK REPRO] stream alloc:   pool currentActiveStreamsCount=1, channel NumActiveSubscriptions=1
[2026-05-18T04:15:41Z] INFO (topic-client): Waiting 500 milliseconds before attempting to reconnect
[2026-05-18T04:15:41Z] INFO (topic-client): Attempting reconnecting to client stream
[2026-05-18T04:15:41Z] WARN (topic-client): [LEAK REPRO] stream alloc:   pool currentActiveStreamsCount=2, channel NumActiveSubscriptions=2
[2026-05-18T04:15:41Z] WARN (topic-client): [LEAK REPRO] stream release: pool currentActiveStreamsCount=1, channel NumActiveSubscriptions=1
[2026-05-18T04:15:41Z] WARN (topic-client): Failed to reconnect to stream
[2026-05-18T04:15:41Z] INFO (topic-client): Waiting 500 milliseconds before attempting to reconnect
[2026-05-18T04:15:42Z] INFO (topic-client): Attempting reconnecting to client stream
[2026-05-18T04:15:42Z] WARN (topic-client): [LEAK REPRO] stream alloc:   pool currentActiveStreamsCount=2, channel NumActiveSubscriptions=2
[2026-05-18T04:15:42Z] WARN (topic-client): [LEAK REPRO] stream release: pool currentActiveStreamsCount=1, channel NumActiveSubscriptions=1
[2026-05-18T04:15:42Z] WARN (topic-client): Failed to reconnect to stream
[2026-05-18T04:15:42Z] INFO (topic-client): Waiting 500 milliseconds before attempting to reconnect
[2026-05-18T04:15:42Z] INFO (topic-client): Attempting reconnecting to client stream
[2026-05-18T04:15:42Z] WARN (topic-client): [LEAK REPRO] stream alloc:   pool currentActiveStreamsCount=2, channel NumActiveSubscriptions=2
[2026-05-18T04:15:42Z] WARN (topic-client): [LEAK REPRO] stream release: pool currentActiveStreamsCount=1, channel NumActiveSubscriptions=1
[2026-05-18T04:15:42Z] WARN (topic-client): Failed to reconnect to stream
[2026-05-18T04:15:42Z] INFO (topic-client): Waiting 500 milliseconds before attempting to reconnect
[2026-05-18T04:15:43Z] INFO (topic-client): Attempting reconnecting to client stream
[2026-05-18T04:15:43Z] WARN (topic-client): [LEAK REPRO] stream alloc:   pool currentActiveStreamsCount=2, channel NumActiveSubscriptions=2
[2026-05-18T04:15:43Z] WARN (topic-client): [LEAK REPRO] stream release: pool currentActiveStreamsCount=1, channel NumActiveSubscriptions=1
[2026-05-18T04:15:43Z] WARN (topic-client): Failed to reconnect to stream
[2026-05-18T04:15:43Z] INFO (topic-client): Waiting 500 milliseconds before attempting to reconnect
[2026-05-18T04:15:43Z] INFO (topic-client): Attempting reconnecting to client stream
[2026-05-18T04:15:43Z] WARN (topic-client): [LEAK REPRO] stream alloc:   pool currentActiveStreamsCount=2, channel NumActiveSubscriptions=2
[2026-05-18T04:15:43Z] WARN (topic-client): [LEAK REPRO] stream release: pool currentActiveStreamsCount=1, channel NumActiveSubscriptions=1
[2026-05-18T04:15:43Z] WARN (topic-client): Failed to reconnect to stream
[2026-05-18T04:15:43Z] INFO (topic-client): Waiting 500 milliseconds before attempting to reconnect
[2026-05-18T04:15:44Z] INFO (topic-client): Attempting reconnecting to client stream
[2026-05-18T04:15:44Z] WARN (topic-client): [LEAK REPRO] stream alloc:   pool currentActiveStreamsCount=2, channel NumActiveSubscriptions=2
[2026-05-18T04:15:44Z] WARN (topic-client): [LEAK REPRO] stream release: pool currentActiveStreamsCount=1, channel NumActiveSubscriptions=1
[2026-05-18T04:15:44Z] WARN (topic-client): Failed to reconnect to stream
[2026-05-18T04:15:44Z] INFO (topic-client): Waiting 500 milliseconds before attempting to reconnect
[2026-05-18T04:15:44Z] INFO (topic-client): Attempting reconnecting to client stream
[2026-05-18T04:15:44Z] WARN (topic-client): [LEAK REPRO] stream alloc:   pool currentActiveStreamsCount=2, channel NumActiveSubscriptions=2
[2026-05-18T04:15:44Z] WARN (topic-client): [LEAK REPRO] stream release: pool currentActiveStreamsCount=1, channel NumActiveSubscriptions=1
[2026-05-18T04:15:44Z] WARN (topic-client): Failed to reconnect to stream
[2026-05-18T04:15:44Z] INFO (topic-client): Waiting 500 milliseconds before attempting to reconnect
[2026-05-18T04:15:45Z] INFO (topic-client): Attempting reconnecting to client stream
[2026-05-18T04:15:45Z] WARN (topic-client): [LEAK REPRO] stream alloc:   pool currentActiveStreamsCount=2, channel NumActiveSubscriptions=2
[2026-05-18T04:15:45Z] WARN (topic-client): [LEAK REPRO] stream release: pool currentActiveStreamsCount=1, channel NumActiveSubscriptions=1
[2026-05-18T04:15:45Z] WARN (topic-client): Failed to reconnect to stream
[2026-05-18T04:15:45Z] INFO (topic-client): Waiting 500 milliseconds before attempting to reconnect
[2026-05-18T04:15:45Z] INFO (topic-client): Attempting reconnecting to client stream
[2026-05-18T04:15:45Z] WARN (topic-client): [LEAK REPRO] stream alloc:   pool currentActiveStreamsCount=2, channel NumActiveSubscriptions=2
[2026-05-18T04:15:45Z] WARN (topic-client): [LEAK REPRO] stream release: pool currentActiveStreamsCount=1, channel NumActiveSubscriptions=1
[2026-05-18T04:15:45Z] WARN (topic-client): Failed to reconnect to stream
[2026-05-18T04:15:45Z] INFO (topic-client): Waiting 500 milliseconds before attempting to reconnect
[2026-05-18T04:15:46Z] INFO (topic-client): Attempting reconnecting to client stream
[2026-05-18T04:15:46Z] WARN (topic-client): [LEAK REPRO] stream release: pool currentActiveStreamsCount=0, channel NumActiveSubscriptions=0
[2026-05-18T04:15:46Z] WARN (topic-client): Failed to reconnect to stream
[2026-05-18T04:15:46Z] INFO (topic-client): Waiting 500 milliseconds before attempting to reconnect
[2026-05-18T04:15:46Z] WARN (topic-client): [LEAK REPRO] stream alloc:   pool currentActiveStreamsCount=1, channel NumActiveSubscriptions=1
[2026-05-18T04:15:46Z] INFO (topic-client): Attempting reconnecting to client stream
[2026-05-18T04:15:46Z] WARN (topic-client): [LEAK REPRO] stream release: pool currentActiveStreamsCount=0, channel NumActiveSubscriptions=0
[2026-05-18T04:15:46Z] WARN (topic-client): Failed to reconnect to stream
[2026-05-18T04:15:46Z] INFO (topic-client): Waiting 500 milliseconds before attempting to reconnect
[2026-05-18T04:15:46Z] WARN (topic-client): [LEAK REPRO] stream alloc:   pool currentActiveStreamsCount=1, channel NumActiveSubscriptions=1
[2026-05-18T04:15:47Z] INFO (topic-client): Attempting reconnecting to client stream
[2026-05-18T04:15:47Z] WARN (topic-client): [LEAK REPRO] stream alloc:   pool currentActiveStreamsCount=2, channel NumActiveSubscriptions=2
[2026-05-18T04:15:47Z] WARN (topic-client): [LEAK REPRO] stream release: pool currentActiveStreamsCount=1, channel NumActiveSubscriptions=1
[2026-05-18T04:15:47Z] WARN (topic-client): Failed to reconnect to stream
[2026-05-18T04:15:47Z] INFO (topic-client): Waiting 500 milliseconds before attempting to reconnect
[2026-05-18T04:15:47Z] INFO (topic-client): Attempting reconnecting to client stream
[2026-05-18T04:15:47Z] INFO (topic-client): Successfully reconnected to subscription stream
[2026-05-18T04:15:47Z] WARN (topic-client): [LEAK REPRO] stream alloc:   pool currentActiveStreamsCount=2, channel NumActiveSubscriptions=2
[repro] heartbeat #5
[repro] heartbeat #6
^C
[repro] interrupt received, closing subscription (Ctrl-C again to force exit)
[2026-05-18T04:16:03Z] WARN (topic-client): [LEAK REPRO] decrement: releasing slot via pool
[2026-05-18T04:16:03Z] WARN (topic-client): [LEAK REPRO] stream release: pool currentActiveStreamsCount=1, channel NumActiveSubscriptions=1
[2026-05-18T04:16:03Z] WARN (topic-client): [LEAK REPRO] decrement: no-op (already released)
[repro] context cancelled after 6 events (87s)
[2026-05-18T04:16:03Z] WARN (topic-client): [LEAK REPRO] decrement: no-op (already released)
❯
``` 