### PR TITLE
feat(topics): safer connection management with exact pool slot accounting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ vendor
 .env
 .vscode
 client-sdk-go.iml
+*.test

--- a/Makefile
+++ b/Makefile
@@ -121,11 +121,15 @@ precommit: lint test
 
 
 test: install-ginkgo
+	@echo "Running internal unit tests..."
+	@go test -count=1 ./internal/...
 	@echo "Running tests..."
 	@ginkgo ${GINKGO_OPTS} --label-filter "!momento-local" ${TEST_DIRS}
 
 
 prod-test: install-ginkgo
+	@echo "Running internal unit tests..."
+	@go test -count=1 ./internal/...
 	@echo "Running tests with consistent reads..."
 	@CONSISTENT_READS=1 ginkgo ${GINKGO_OPTS} --label-filter "!momento-local" ${TEST_DIRS}
 

--- a/internal/grpcmanagers/topic_manager.go
+++ b/internal/grpcmanagers/topic_manager.go
@@ -45,6 +45,8 @@ func NewStreamTopicGrpcManager(request *models.TopicStreamGrpcManagerRequest) (*
 }
 
 func (topicManager *TopicGrpcManager) Close() momentoerrors.MomentoSvcErr {
-	topicManager.NumActiveSubscriptions.Store(0)
+	// Don't reset NumActiveSubscriptions: outstanding Reservation.Release
+	// calls may still decrement it after Close, and a reset would race with
+	// them and push the counter negative.
 	return momentoerrors.ConvertSvcErr(topicManager.Conn.Close())
 }

--- a/internal/grpcmanagers/topic_manager_lists/dynamic_stream_grpc_manager_pool.go
+++ b/internal/grpcmanagers/topic_manager_lists/dynamic_stream_grpc_manager_pool.go
@@ -21,9 +21,10 @@ import (
 // external readers.
 type dynamicStreamGrpcManagerPool struct {
 	streamPoolCore
-	grpcManagers                []*grpcmanagers.TopicGrpcManager
-	numGrpcManagers             atomic.Int32
-	managerIndex                atomic.Uint64
+	grpcManagers    []*grpcmanagers.TopicGrpcManager
+	numGrpcManagers atomic.Int32
+	// managerIndex is only touched by getNextManager under the core's mutex.
+	managerIndex                uint64
 	maxManagerCount             int    // max grpc channels
 	currentMaxConcurrentStreams uint32 // grpc channels * MAX_CONCURRENT_STREAMS_PER_CHANNEL
 	logger                      logger.MomentoLogger
@@ -73,11 +74,12 @@ func (d *dynamicStreamGrpcManagerPool) getNextManager() (*grpcmanagers.TopicGrpc
 		return nil, err
 	}
 
-	// Max number of attempts is set to the max number of concurrent streams in order to preserve
-	// the round-robin system (incrementing nextManagerIndex) but to not cut short the number
-	//  of attempts in case there are many subscriptions starting up at the same time.
+	// Round-robin over the channels until one has a free slot. Allocation is
+	// serialized by the core mutex, so one pass over every channel would
+	// suffice; the generous bound is defensive.
 	for i := 0; uint32(i) < d.currentMaxConcurrentStreams; i++ {
-		nextManagerIndex := d.managerIndex.Add(1)
+		d.managerIndex++
+		nextManagerIndex := d.managerIndex
 		topicManager := d.grpcManagers[nextManagerIndex%uint64(len(d.grpcManagers))]
 		newCount := topicManager.NumActiveSubscriptions.Add(1)
 		if newCount <= int64(config.MAX_CONCURRENT_STREAMS_PER_CHANNEL) {

--- a/internal/grpcmanagers/topic_manager_lists/dynamic_stream_grpc_manager_pool.go
+++ b/internal/grpcmanagers/topic_manager_lists/dynamic_stream_grpc_manager_pool.go
@@ -168,6 +168,11 @@ func (d *dynamicStreamGrpcManagerPool) makeNextManagerAvailable() {
 			topicManager, err := d.getNextManager()
 			select {
 			case <-d.ctx.Done():
+				// Close interrupted a prepared envelope: return the prefetched
+				// slot so the counters stay exact. Error envelopes hold no slot.
+				if topicManager != nil {
+					d.releaseManager(topicManager)
+				}
 				return
 			case d.nextAvailableGrpcManagerChannel <- &StreamGrpcManagerRequest{
 				TopicManager: topicManager,

--- a/internal/grpcmanagers/topic_manager_lists/dynamic_stream_grpc_manager_pool.go
+++ b/internal/grpcmanagers/topic_manager_lists/dynamic_stream_grpc_manager_pool.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"sync"
 	"sync/atomic"
 
 	"github.com/momentohq/client-sdk-go/config"
@@ -13,18 +14,28 @@ import (
 	"github.com/momentohq/client-sdk-go/internal/momentoerrors"
 )
 
-// dynamicStreamGrpcManagerPool manages a dynamic pool of gRPC channels for stream pubsub requests.
+// dynamicStreamGrpcManagerPool manages a dynamic pool of gRPC channels for
+// stream pubsub requests.
+//
+// makeNextManagerAvailable is the sole writer to grpcManagers; numGrpcManagers
+// mirrors the length atomically for external readers. Close waits on
+// dispatcherDone before iterating grpcManagers, so neither racing append nor
+// racing send is possible.
 type dynamicStreamGrpcManagerPool struct {
 	grpcManagers                    []*grpcmanagers.TopicGrpcManager
+	numGrpcManagers                 atomic.Int32
 	managerIndex                    atomic.Uint64
-	maxManagerCount                 int    // maximum number of grpc channels that can be created
-	currentMaxConcurrentStreams     uint32 // current number of grpc channels * MAX_CONCURRENT_STREAMS_PER_CHANNEL
+	maxManagerCount                 int    // max grpc channels
+	currentMaxConcurrentStreams     uint32 // grpc channels * MAX_CONCURRENT_STREAMS_PER_CHANNEL
 	currentActiveStreamsCount       atomic.Uint64
 	logger                          logger.MomentoLogger
 	newTopicManagerProps            *models.TopicStreamGrpcManagerRequest
 	nextAvailableGrpcManagerChannel chan *StreamGrpcManagerRequest
 	ctx                             context.Context
 	cancel                          context.CancelFunc
+	// dispatcherDone is closed when makeNextManagerAvailable returns.
+	dispatcherDone chan struct{}
+	closeOnce      sync.Once
 }
 
 // GetNextTopicGrpcManager returns the next available TopicGrpcManager from the pool
@@ -33,7 +44,7 @@ type dynamicStreamGrpcManagerPool struct {
 // Only the makeNextManagerAvailable goroutine started in NewDynamicStreamGrpcManagerPool
 // places the next available stream manager on the channel (or an error if no stream manager
 // is available).
-func (d *dynamicStreamGrpcManagerPool) GetNextTopicGrpcManager() (*grpcmanagers.TopicGrpcManager, momentoerrors.MomentoSvcErr) {
+func (d *dynamicStreamGrpcManagerPool) GetNextTopicGrpcManager() (*Reservation, momentoerrors.MomentoSvcErr) {
 	select {
 	// If the context was cancelled, we should no longer return any topic managers
 	case <-d.ctx.Done():
@@ -50,20 +61,25 @@ func (d *dynamicStreamGrpcManagerPool) GetNextTopicGrpcManager() (*grpcmanagers.
 		if topicManagerRequest.Err != nil {
 			return nil, topicManagerRequest.Err
 		}
-		return topicManagerRequest.TopicManager, nil
+		return NewReservation(topicManagerRequest.TopicManager, d.releaseManager), nil
 	}
 }
 
-// Close shuts down all the grpc connections in the pool.
+// Close shuts down all gRPC connections. Safe to call multiple times.
+// Cancels the dispatcher context, waits for the dispatcher to exit, closes
+// the manager channel, then tears down each connection.
 func (d *dynamicStreamGrpcManagerPool) Close() {
-	d.cancel() // Cancel context first to stop goroutines
-	close(d.nextAvailableGrpcManagerChannel)
-	for _, topicManager := range d.grpcManagers {
-		err := topicManager.Close()
-		if err != nil {
-			d.logger.Error("Error closing topic manager: %s", err.Error())
+	d.closeOnce.Do(func() {
+		d.cancel()
+		<-d.dispatcherDone
+		close(d.nextAvailableGrpcManagerChannel)
+		for _, topicManager := range d.grpcManagers {
+			err := topicManager.Close()
+			if err != nil {
+				d.logger.Error("Error closing topic manager: %s", err.Error())
+			}
 		}
-	}
+	})
 }
 
 // GetCurrentActiveStreamsCount returns the current number of active streams in the pool.
@@ -71,10 +87,10 @@ func (d *dynamicStreamGrpcManagerPool) GetCurrentActiveStreamsCount() uint64 {
 	return d.currentActiveStreamsCount.Load()
 }
 
-// ReleaseTopicGrpcManager decrements both the per-channel NumActiveSubscriptions counter
-// on the given manager and the pool-wide currentActiveStreamsCount, freeing up the slot
-// so future GetNextTopicGrpcManager calls see capacity. Returns the new per-channel count.
-func (d *dynamicStreamGrpcManagerPool) ReleaseTopicGrpcManager(manager *grpcmanagers.TopicGrpcManager) int64 {
+// releaseManager backs Reservation.Release for this pool. Decrements the
+// per-channel and pool-wide counters; the pool-wide CAS bottoms at zero so
+// it can't go negative.
+func (d *dynamicStreamGrpcManagerPool) releaseManager(manager *grpcmanagers.TopicGrpcManager) int64 {
 	newCount := manager.NumActiveSubscriptions.Add(-1)
 	for {
 		current := d.currentActiveStreamsCount.Load()
@@ -90,7 +106,7 @@ func (d *dynamicStreamGrpcManagerPool) ReleaseTopicGrpcManager(manager *grpcmana
 
 // GetCurrentNumberOfGrpcManagers returns the current number of grpc managers in the pool.
 func (d *dynamicStreamGrpcManagerPool) GetCurrentNumberOfGrpcManagers() int {
-	return len(d.grpcManagers)
+	return int(d.numGrpcManagers.Load())
 }
 
 // NewDynamicStreamGrpcManagerPool creates a new pool with a dynamic number of grpc managers for stream pubsub requests.
@@ -121,10 +137,13 @@ func NewDynamicStreamGrpcManagerPool(request *models.TopicStreamGrpcManagerReque
 		nextAvailableGrpcManagerChannel: nextAvailableGrpcManagerChannel,
 		ctx:                             ctx,
 		cancel:                          cancel,
+		dispatcherDone:                  make(chan struct{}),
 	}
 
-	// Start goroutine to continually make the next available stream manager
-	// available on the streamManagerRequestQueue
+	pool.numGrpcManagers.Store(int32(len(streamTopicManagers)))
+
+	// Start the dispatcher goroutine that keeps the unbuffered channel fed
+	// with the next available manager.
 	go pool.makeNextManagerAvailable()
 
 	return pool, nil
@@ -140,6 +159,7 @@ func NewDynamicStreamGrpcManagerPool(request *models.TopicStreamGrpcManagerReque
 // only be able to pull one topic grpc manager from the channel at a time to allocate
 // to each subscribe request.
 func (d *dynamicStreamGrpcManagerPool) makeNextManagerAvailable() {
+	defer close(d.dispatcherDone)
 	for {
 		select {
 		case <-d.ctx.Done():
@@ -232,6 +252,7 @@ func (d *dynamicStreamGrpcManagerPool) addManager() momentoerrors.MomentoSvcErr 
 		return err
 	}
 	d.grpcManagers = append(d.grpcManagers, streamTopicManager)
+	d.numGrpcManagers.Store(int32(len(d.grpcManagers)))
 	d.currentMaxConcurrentStreams = uint32(len(d.grpcManagers)) * uint32(config.MAX_CONCURRENT_STREAMS_PER_CHANNEL)
 	return nil
 }

--- a/internal/grpcmanagers/topic_manager_lists/dynamic_stream_grpc_manager_pool.go
+++ b/internal/grpcmanagers/topic_manager_lists/dynamic_stream_grpc_manager_pool.go
@@ -3,7 +3,6 @@ package topic_manager_lists
 import (
 	"fmt"
 	"math"
-	"sync/atomic"
 
 	"github.com/momentohq/client-sdk-go/config"
 	"github.com/momentohq/client-sdk-go/config/logger"
@@ -17,12 +16,10 @@ import (
 // streamPoolCore; this type supplies the grow-on-demand capacity policy.
 //
 // grpcManagers and currentMaxConcurrentStreams are only mutated by addManager
-// under the core's mutex; numGrpcManagers mirrors the length atomically for
-// external readers.
+// under the core's mutex.
 type dynamicStreamGrpcManagerPool struct {
 	streamPoolCore
-	grpcManagers    []*grpcmanagers.TopicGrpcManager
-	numGrpcManagers atomic.Int32
+	grpcManagers []*grpcmanagers.TopicGrpcManager
 	// managerIndex is only touched by getNextManager under the core's mutex.
 	managerIndex                uint64
 	maxManagerCount             int    // max grpc channels
@@ -52,7 +49,6 @@ func NewDynamicStreamGrpcManagerPool(request *models.TopicStreamGrpcManagerReque
 		logger:                      logger,
 		newTopicManagerProps:        request,
 	}
-	pool.numGrpcManagers.Store(int32(len(streamTopicManagers)))
 	pool.initStreamPoolCore(pool.getNextManager, func() {
 		closeAllManagers(pool.grpcManagers, logger)
 	})
@@ -61,7 +57,9 @@ func NewDynamicStreamGrpcManagerPool(request *models.TopicStreamGrpcManagerReque
 
 // GetCurrentNumberOfGrpcManagers returns the current number of grpc managers in the pool.
 func (d *dynamicStreamGrpcManagerPool) GetCurrentNumberOfGrpcManagers() int {
-	return int(d.numGrpcManagers.Load())
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return len(d.grpcManagers)
 }
 
 // getNextManager returns the next available stream manager from the pool,
@@ -74,20 +72,10 @@ func (d *dynamicStreamGrpcManagerPool) getNextManager() (*grpcmanagers.TopicGrpc
 		return nil, err
 	}
 
-	// Round-robin over the channels until one has a free slot. Allocation is
-	// serialized by the core mutex, so one pass over every channel would
-	// suffice; the generous bound is defensive.
-	for i := 0; uint32(i) < d.currentMaxConcurrentStreams; i++ {
-		d.managerIndex++
-		nextManagerIndex := d.managerIndex
-		topicManager := d.grpcManagers[nextManagerIndex%uint64(len(d.grpcManagers))]
-		newCount := topicManager.NumActiveSubscriptions.Add(1)
-		if newCount <= int64(config.MAX_CONCURRENT_STREAMS_PER_CHANNEL) {
-			d.logger.Debug("Starting new subscription on grpc channel %d which now has %d streams", nextManagerIndex%uint64(len(d.grpcManagers)), newCount)
-			d.currentActiveStreamsCount.Add(1)
-			return topicManager, nil
-		}
-		topicManager.NumActiveSubscriptions.Add(-1)
+	// The attempt bound is generous: allocation is serialized by the core
+	// mutex, so one pass over every channel would suffice.
+	if topicManager := d.reserveSlot(d.grpcManagers, &d.managerIndex, d.currentMaxConcurrentStreams, d.logger); topicManager != nil {
+		return topicManager, nil
 	}
 
 	// If there are no more streams available, return an error
@@ -141,7 +129,6 @@ func (d *dynamicStreamGrpcManagerPool) addManager() momentoerrors.MomentoSvcErr 
 		return err
 	}
 	d.grpcManagers = append(d.grpcManagers, streamTopicManager)
-	d.numGrpcManagers.Store(int32(len(d.grpcManagers)))
 	d.currentMaxConcurrentStreams = uint32(len(d.grpcManagers)) * uint32(config.MAX_CONCURRENT_STREAMS_PER_CHANNEL)
 	return nil
 }

--- a/internal/grpcmanagers/topic_manager_lists/dynamic_stream_grpc_manager_pool.go
+++ b/internal/grpcmanagers/topic_manager_lists/dynamic_stream_grpc_manager_pool.go
@@ -1,10 +1,8 @@
 package topic_manager_lists
 
 import (
-	"context"
 	"fmt"
 	"math"
-	"sync"
 	"sync/atomic"
 
 	"github.com/momentohq/client-sdk-go/config"
@@ -15,98 +13,21 @@ import (
 )
 
 // dynamicStreamGrpcManagerPool manages a dynamic pool of gRPC channels for
-// stream pubsub requests.
+// stream pubsub requests. Allocation, release, and Close live in the embedded
+// streamPoolCore; this type supplies the grow-on-demand capacity policy.
 //
-// makeNextManagerAvailable is the sole writer to grpcManagers; numGrpcManagers
-// mirrors the length atomically for external readers. Close waits on
-// dispatcherDone before iterating grpcManagers, so neither racing append nor
-// racing send is possible.
+// grpcManagers and currentMaxConcurrentStreams are only mutated by addManager
+// under the core's mutex; numGrpcManagers mirrors the length atomically for
+// external readers.
 type dynamicStreamGrpcManagerPool struct {
-	grpcManagers                    []*grpcmanagers.TopicGrpcManager
-	numGrpcManagers                 atomic.Int32
-	managerIndex                    atomic.Uint64
-	maxManagerCount                 int    // max grpc channels
-	currentMaxConcurrentStreams     uint32 // grpc channels * MAX_CONCURRENT_STREAMS_PER_CHANNEL
-	currentActiveStreamsCount       atomic.Uint64
-	logger                          logger.MomentoLogger
-	newTopicManagerProps            *models.TopicStreamGrpcManagerRequest
-	nextAvailableGrpcManagerChannel chan *StreamGrpcManagerRequest
-	ctx                             context.Context
-	cancel                          context.CancelFunc
-	// dispatcherDone is closed when makeNextManagerAvailable returns.
-	dispatcherDone chan struct{}
-	closeOnce      sync.Once
-}
-
-// GetNextTopicGrpcManager returns the next available TopicGrpcManager from the pool
-// by pulling from the nextAvailableGrpcManagerChannel.
-//
-// Only the makeNextManagerAvailable goroutine started in NewDynamicStreamGrpcManagerPool
-// places the next available stream manager on the channel (or an error if no stream manager
-// is available).
-func (d *dynamicStreamGrpcManagerPool) GetNextTopicGrpcManager() (*Reservation, momentoerrors.MomentoSvcErr) {
-	select {
-	// If the context was cancelled, we should no longer return any topic managers
-	case <-d.ctx.Done():
-		return nil, momentoerrors.NewMomentoSvcErr(momentoerrors.CanceledError, "Context cancelled", nil)
-	default:
-		topicManagerRequest := <-d.nextAvailableGrpcManagerChannel
-
-		// If the channel is closed, we'll receive a zero value (nil in this case since it's a pointer type).
-		// This means that the pool is shutting down and we should no longer return any topic managers.
-		if topicManagerRequest == nil {
-			return nil, momentoerrors.NewMomentoSvcErr(momentoerrors.ClientSdkError, "Received nil from nextAvailableGrpcManagerChannel", nil)
-		}
-
-		if topicManagerRequest.Err != nil {
-			return nil, topicManagerRequest.Err
-		}
-		return NewReservation(topicManagerRequest.TopicManager, d.releaseManager), nil
-	}
-}
-
-// Close shuts down all gRPC connections. Safe to call multiple times.
-// Cancels the dispatcher context, waits for the dispatcher to exit, closes
-// the manager channel, then tears down each connection.
-func (d *dynamicStreamGrpcManagerPool) Close() {
-	d.closeOnce.Do(func() {
-		d.cancel()
-		<-d.dispatcherDone
-		close(d.nextAvailableGrpcManagerChannel)
-		for _, topicManager := range d.grpcManagers {
-			err := topicManager.Close()
-			if err != nil {
-				d.logger.Error("Error closing topic manager: %s", err.Error())
-			}
-		}
-	})
-}
-
-// GetCurrentActiveStreamsCount returns the current number of active streams in the pool.
-func (d *dynamicStreamGrpcManagerPool) GetCurrentActiveStreamsCount() uint64 {
-	return d.currentActiveStreamsCount.Load()
-}
-
-// releaseManager backs Reservation.Release for this pool. Decrements the
-// per-channel and pool-wide counters; the pool-wide CAS bottoms at zero so
-// it can't go negative.
-func (d *dynamicStreamGrpcManagerPool) releaseManager(manager *grpcmanagers.TopicGrpcManager) int64 {
-	newCount := manager.NumActiveSubscriptions.Add(-1)
-	for {
-		current := d.currentActiveStreamsCount.Load()
-		if current == 0 {
-			break
-		}
-		if d.currentActiveStreamsCount.CompareAndSwap(current, current-1) {
-			break
-		}
-	}
-	return newCount
-}
-
-// GetCurrentNumberOfGrpcManagers returns the current number of grpc managers in the pool.
-func (d *dynamicStreamGrpcManagerPool) GetCurrentNumberOfGrpcManagers() int {
-	return int(d.numGrpcManagers.Load())
+	streamPoolCore
+	grpcManagers                []*grpcmanagers.TopicGrpcManager
+	numGrpcManagers             atomic.Int32
+	managerIndex                atomic.Uint64
+	maxManagerCount             int    // max grpc channels
+	currentMaxConcurrentStreams uint32 // grpc channels * MAX_CONCURRENT_STREAMS_PER_CHANNEL
+	logger                      logger.MomentoLogger
+	newTopicManagerProps        *models.TopicStreamGrpcManagerRequest
 }
 
 // NewDynamicStreamGrpcManagerPool creates a new pool with a dynamic number of grpc managers for stream pubsub requests.
@@ -123,67 +44,28 @@ func NewDynamicStreamGrpcManagerPool(request *models.TopicStreamGrpcManagerReque
 	streamTopicManagers = append(streamTopicManagers, streamTopicManager)
 	logger.Debug("Max subscriptions: %d, max manager count: %d", maxSubscriptions, int(math.Ceil(float64(maxSubscriptions)/float64(config.MAX_CONCURRENT_STREAMS_PER_CHANNEL))))
 
-	// Unbuffered channel so the stream manager list will block on sending the next
-	// available stream manager until the most recent request is processed.
-	nextAvailableGrpcManagerChannel := make(chan *StreamGrpcManagerRequest)
-	ctx, cancel := context.WithCancel(context.Background())
-
 	pool := &dynamicStreamGrpcManagerPool{
-		grpcManagers:                    streamTopicManagers,
-		maxManagerCount:                 int(math.Ceil(float64(maxSubscriptions) / float64(config.MAX_CONCURRENT_STREAMS_PER_CHANNEL))),
-		currentMaxConcurrentStreams:     uint32(config.MAX_CONCURRENT_STREAMS_PER_CHANNEL), // for one channel
-		logger:                          logger,
-		newTopicManagerProps:            request,
-		nextAvailableGrpcManagerChannel: nextAvailableGrpcManagerChannel,
-		ctx:                             ctx,
-		cancel:                          cancel,
-		dispatcherDone:                  make(chan struct{}),
+		grpcManagers:                streamTopicManagers,
+		maxManagerCount:             int(math.Ceil(float64(maxSubscriptions) / float64(config.MAX_CONCURRENT_STREAMS_PER_CHANNEL))),
+		currentMaxConcurrentStreams: uint32(config.MAX_CONCURRENT_STREAMS_PER_CHANNEL), // for one channel
+		logger:                      logger,
+		newTopicManagerProps:        request,
 	}
-
 	pool.numGrpcManagers.Store(int32(len(streamTopicManagers)))
-
-	// Start the dispatcher goroutine that keeps the unbuffered channel fed
-	// with the next available manager.
-	go pool.makeNextManagerAvailable()
-
+	pool.initStreamPoolCore(pool.getNextManager, func() {
+		closeAllManagers(pool.grpcManagers, logger)
+	})
 	return pool, nil
 }
 
-// makeNextManagerAvailable continually places the next available stream manager
-// on the nextAvailableGrpcManagerChannel.
-//
-// The nextAvailableGrpcManagerChannel is unbuffered, so the dynamicStreamGrpcManagerPool
-// will block on sending the next available stream manager until the most recent request
-// is processed.
-// So even if there is a burst of concurrent subscribe requests, the pubsub client should
-// only be able to pull one topic grpc manager from the channel at a time to allocate
-// to each subscribe request.
-func (d *dynamicStreamGrpcManagerPool) makeNextManagerAvailable() {
-	defer close(d.dispatcherDone)
-	for {
-		select {
-		case <-d.ctx.Done():
-			return
-		default:
-			topicManager, err := d.getNextManager()
-			select {
-			case <-d.ctx.Done():
-				// Close interrupted a prepared envelope: return the prefetched
-				// slot so the counters stay exact. Error envelopes hold no slot.
-				if topicManager != nil {
-					d.releaseManager(topicManager)
-				}
-				return
-			case d.nextAvailableGrpcManagerChannel <- &StreamGrpcManagerRequest{
-				TopicManager: topicManager,
-				Err:          err,
-			}:
-			}
-		}
-	}
+// GetCurrentNumberOfGrpcManagers returns the current number of grpc managers in the pool.
+func (d *dynamicStreamGrpcManagerPool) GetCurrentNumberOfGrpcManagers() int {
+	return int(d.numGrpcManagers.Load())
 }
 
-// getNextManager is used by makeNextManagerAvailable to return the next available stream manager from the pool.
+// getNextManager returns the next available stream manager from the pool,
+// reserving a slot on it and growing the pool if needed. Called by
+// streamPoolCore under its mutex.
 func (d *dynamicStreamGrpcManagerPool) getNextManager() (*grpcmanagers.TopicGrpcManager, momentoerrors.MomentoSvcErr) {
 	// First check if there is enough grpc stream capacity to make a new subscription
 	err := d.checkNumConcurrentStreams()
@@ -217,7 +99,7 @@ func (d *dynamicStreamGrpcManagerPool) getNextManager() (*grpcmanagers.TopicGrpc
 // If both maximums have been reached, it will return a ClientResourceExhaustedError.
 func (d *dynamicStreamGrpcManagerPool) checkNumConcurrentStreams() momentoerrors.MomentoSvcErr {
 	numActiveStreams := d.currentActiveStreamsCount.Load()
-	d.logger.Debug("Current number of active subscriptions: %d", d.currentActiveStreamsCount.Load())
+	d.logger.Debug("Current number of active subscriptions: %d", numActiveStreams)
 
 	numStreamManagers := len(d.grpcManagers)
 

--- a/internal/grpcmanagers/topic_manager_lists/pool_close_test.go
+++ b/internal/grpcmanagers/topic_manager_lists/pool_close_test.go
@@ -1,13 +1,15 @@
 package topic_manager_lists
 
 import (
+	"strings"
+	"sync"
 	"testing"
-	"time"
 
 	"github.com/momentohq/client-sdk-go/auth"
 	"github.com/momentohq/client-sdk-go/config"
 	"github.com/momentohq/client-sdk-go/config/logger"
 	"github.com/momentohq/client-sdk-go/internal/models"
+	"github.com/momentohq/client-sdk-go/internal/momentoerrors"
 )
 
 // newTestManagerRequest builds a manager request against momento-local
@@ -25,88 +27,92 @@ func newTestManagerRequest(t *testing.T) *models.TopicStreamGrpcManagerRequest {
 	}
 }
 
-func waitForActiveStreamsCount(t *testing.T, got func() uint64, want uint64) {
+func newStaticTestPool(t *testing.T, numChannels uint32) *staticStreamGrpcManagerPool {
 	t.Helper()
-	deadline := time.Now().Add(5 * time.Second)
-	for time.Now().Before(deadline) {
-		if got() == want {
-			return
-		}
-		time.Sleep(time.Millisecond)
-	}
-	t.Fatalf("active streams count = %d, want %d after waiting", got(), want)
-}
-
-// TestTopicStreamPoolCloseReleasesPrefetchedSlotStatic pins the dispatcher's
-// shutdown accounting: makeNextManagerAvailable eagerly reserves a slot for
-// the envelope it parks on the unbuffered channel, and Close interrupting that
-// parked send must return the slot so the counters end exact.
-func TestTopicStreamPoolCloseReleasesPrefetchedSlotStatic(t *testing.T) {
-	t.Parallel()
-
 	pool, err := NewStaticStreamGrpcManagerPool(
 		newTestManagerRequest(t),
-		1,
-		logger.NewNoopMomentoLoggerFactory().GetLogger("pool-close-test"),
+		numChannels,
+		logger.NewNoopMomentoLoggerFactory().GetLogger("pool-test"),
 	)
 	if err != nil {
 		t.Fatalf("NewStaticStreamGrpcManagerPool returned error: %v", err)
 	}
+	return pool
+}
 
-	// The dispatcher prefetches one manager and parks holding its slot.
-	waitForActiveStreamsCount(t, pool.GetCurrentActiveStreamsCount, 1)
+// TestTopicStreamPoolHoldsNoSlotsWhileIdle pins the exact-counting contract:
+// an idle pool reports zero active streams, each reservation counts exactly
+// one, and a release is immediately visible.
+func TestTopicStreamPoolHoldsNoSlotsWhileIdle(t *testing.T) {
+	t.Parallel()
 
-	// Close waits on dispatcherDone, so the release is visible once it returns.
-	pool.Close()
+	pool := newStaticTestPool(t, 1)
+	defer pool.Close()
+
 	if got := pool.GetCurrentActiveStreamsCount(); got != 0 {
-		t.Fatalf("active streams count after Close = %d, want 0", got)
+		t.Fatalf("idle active streams count = %d, want 0", got)
 	}
-	if got := pool.grpcManagers[0].NumActiveSubscriptions.Load(); got != 0 {
-		t.Fatalf("manager subscription count after Close = %d, want 0", got)
+
+	reservation, err := pool.GetNextTopicGrpcManager()
+	if err != nil {
+		t.Fatalf("GetNextTopicGrpcManager returned error: %v", err)
+	}
+	if got := pool.GetCurrentActiveStreamsCount(); got != 1 {
+		t.Fatalf("active streams count with one reservation = %d, want 1", got)
+	}
+
+	reservation.Release()
+	if got := pool.GetCurrentActiveStreamsCount(); got != 0 {
+		t.Fatalf("active streams count after release = %d, want 0", got)
 	}
 }
 
-// TestTopicStreamPoolCloseReleasesPrefetchedSlotDynamic is the dynamic-pool
-// twin of the static prefetch-release test.
-func TestTopicStreamPoolCloseReleasesPrefetchedSlotDynamic(t *testing.T) {
+// TestTopicStreamPoolExhaustionErrorIsNeverStale verifies capacity is
+// evaluated per call: a pool that just returned ResourceExhausted hands out a
+// manager on the very next call once a slot frees.
+func TestTopicStreamPoolExhaustionErrorIsNeverStale(t *testing.T) {
 	t.Parallel()
 
-	pool, err := NewDynamicStreamGrpcManagerPool(
-		newTestManagerRequest(t),
-		100,
-		logger.NewNoopMomentoLoggerFactory().GetLogger("pool-close-test"),
-	)
-	if err != nil {
-		t.Fatalf("NewDynamicStreamGrpcManagerPool returned error: %v", err)
-	}
+	pool := newStaticTestPool(t, 1)
+	defer pool.Close()
 
-	waitForActiveStreamsCount(t, pool.GetCurrentActiveStreamsCount, 1)
-
-	pool.Close()
-	if got := pool.GetCurrentActiveStreamsCount(); got != 0 {
-		t.Fatalf("active streams count after Close = %d, want 0", got)
-	}
-	for i, manager := range pool.grpcManagers {
-		if got := manager.NumActiveSubscriptions.Load(); got != 0 {
-			t.Fatalf("manager %d subscription count after Close = %d, want 0", i, got)
+	reservations := make([]*Reservation, 0, config.MAX_CONCURRENT_STREAMS_PER_CHANNEL)
+	for i := 0; i < config.MAX_CONCURRENT_STREAMS_PER_CHANNEL; i++ {
+		reservation, err := pool.GetNextTopicGrpcManager()
+		if err != nil {
+			t.Fatalf("GetNextTopicGrpcManager %d returned error: %v", i, err)
 		}
+		reservations = append(reservations, reservation)
+	}
+
+	if _, err := pool.GetNextTopicGrpcManager(); err == nil {
+		t.Fatal("expected ResourceExhausted error from a full pool")
+	} else if err.Code() != momentoerrors.ClientResourceExhaustedError {
+		t.Fatalf("error code = %s, want %s", err.Code(), momentoerrors.ClientResourceExhaustedError)
+	}
+
+	// Free one slot; the next call must succeed immediately.
+	reservations[0].Release()
+	reservation, err := pool.GetNextTopicGrpcManager()
+	if err != nil {
+		t.Fatalf("GetNextTopicGrpcManager after release returned error: %v", err)
+	}
+	reservation.Release()
+	for _, r := range reservations[1:] {
+		r.Release()
+	}
+	if got := pool.GetCurrentActiveStreamsCount(); got != 0 {
+		t.Fatalf("active streams count after releasing all = %d, want 0", got)
 	}
 }
 
-// TestTopicStreamPoolCloseIsIdempotent guards the closeOnce hardening: double
-// and concurrent Close must not panic (send on closed channel, double close)
-// or hang.
-func TestTopicStreamPoolCloseIsIdempotent(t *testing.T) {
+// TestTopicStreamPoolGetAfterCloseReturnsCanceled verifies shutdown behavior:
+// Close is idempotent (including concurrently) and subsequent reservations
+// are refused with CanceledError.
+func TestTopicStreamPoolGetAfterCloseReturnsCanceled(t *testing.T) {
 	t.Parallel()
 
-	pool, err := NewStaticStreamGrpcManagerPool(
-		newTestManagerRequest(t),
-		1,
-		logger.NewNoopMomentoLoggerFactory().GetLogger("pool-close-test"),
-	)
-	if err != nil {
-		t.Fatalf("NewStaticStreamGrpcManagerPool returned error: %v", err)
-	}
+	pool := newStaticTestPool(t, 1)
 
 	done := make(chan struct{})
 	go func() {
@@ -116,4 +122,149 @@ func TestTopicStreamPoolCloseIsIdempotent(t *testing.T) {
 	pool.Close()
 	<-done
 	pool.Close()
+
+	reservation, err := pool.GetNextTopicGrpcManager()
+	if err == nil {
+		t.Fatal("expected GetNextTopicGrpcManager to fail after Close")
+	}
+	if err.Code() != momentoerrors.CanceledError {
+		t.Fatalf("error code = %s, want %s", err.Code(), momentoerrors.CanceledError)
+	}
+	if reservation != nil {
+		t.Fatal("expected nil reservation after Close")
+	}
+	if got := pool.GetCurrentActiveStreamsCount(); got != 0 {
+		t.Fatalf("active streams count after Close = %d, want 0", got)
+	}
+}
+
+// TestTopicStreamPoolGetRacingCloseIsSafe hammers GetNextTopicGrpcManager
+// while Close runs: every call must return either a usable Reservation or a
+// shutdown/capacity error — never panic or hang — and releasing everything
+// drains the counters to zero.
+func TestTopicStreamPoolGetRacingCloseIsSafe(t *testing.T) {
+	t.Parallel()
+
+	const goroutines = 32
+	const perGoroutine = 25
+
+	pool := newStaticTestPool(t, 2)
+
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	wg.Add(goroutines + 1)
+	for g := 0; g < goroutines; g++ {
+		go func() {
+			defer wg.Done()
+			<-start
+			for i := 0; i < perGoroutine; i++ {
+				reservation, err := pool.GetNextTopicGrpcManager()
+				if err != nil {
+					if code := err.Code(); code != momentoerrors.CanceledError && code != momentoerrors.ClientResourceExhaustedError {
+						t.Errorf("unexpected error code %s: %v", code, err)
+					}
+					continue
+				}
+				reservation.Release()
+			}
+		}()
+	}
+	go func() {
+		defer wg.Done()
+		<-start
+		pool.Close()
+	}()
+	close(start)
+	wg.Wait()
+
+	if got := pool.GetCurrentActiveStreamsCount(); got != 0 {
+		t.Fatalf("active streams count after race = %d, want 0", got)
+	}
+}
+
+// TestTopicDynamicStreamPoolGrowsOnDemand verifies the dynamic pool adds a
+// channel when the current capacity is consumed, with exact counters and no
+// RPCs (slots are reserved without opening streams).
+func TestTopicDynamicStreamPoolGrowsOnDemand(t *testing.T) {
+	t.Parallel()
+
+	perChannel := config.MAX_CONCURRENT_STREAMS_PER_CHANNEL
+	pool, err := NewDynamicStreamGrpcManagerPool(
+		newTestManagerRequest(t),
+		uint32(perChannel+50), // maxManagerCount = 2
+		logger.NewNoopMomentoLoggerFactory().GetLogger("pool-test"),
+	)
+	if err != nil {
+		t.Fatalf("NewDynamicStreamGrpcManagerPool returned error: %v", err)
+	}
+	defer pool.Close()
+
+	if got := pool.GetCurrentNumberOfGrpcManagers(); got != 1 {
+		t.Fatalf("initial manager count = %d, want 1", got)
+	}
+
+	reservations := make([]*Reservation, 0, perChannel+1)
+	for i := 0; i < perChannel; i++ {
+		reservation, getErr := pool.GetNextTopicGrpcManager()
+		if getErr != nil {
+			t.Fatalf("GetNextTopicGrpcManager %d returned error: %v", i, getErr)
+		}
+		reservations = append(reservations, reservation)
+	}
+	if got := pool.GetCurrentNumberOfGrpcManagers(); got != 1 {
+		t.Fatalf("manager count at exactly one channel's capacity = %d, want 1", got)
+	}
+
+	// One past the first channel's capacity forces growth.
+	reservation, getErr := pool.GetNextTopicGrpcManager()
+	if getErr != nil {
+		t.Fatalf("GetNextTopicGrpcManager past capacity returned error: %v", getErr)
+	}
+	reservations = append(reservations, reservation)
+	if got := pool.GetCurrentNumberOfGrpcManagers(); got != 2 {
+		t.Fatalf("manager count after growth = %d, want 2", got)
+	}
+
+	for _, r := range reservations {
+		r.Release()
+	}
+	if got := pool.GetCurrentActiveStreamsCount(); got != 0 {
+		t.Fatalf("active streams count after releasing all = %d, want 0", got)
+	}
+}
+
+// TestTopicDynamicStreamPoolStopsAtMaxSubscriptions verifies the dynamic pool
+// refuses reservations past maxSubscriptions with a fresh error message.
+func TestTopicDynamicStreamPoolStopsAtMaxSubscriptions(t *testing.T) {
+	t.Parallel()
+
+	perChannel := config.MAX_CONCURRENT_STREAMS_PER_CHANNEL
+	pool, err := NewDynamicStreamGrpcManagerPool(
+		newTestManagerRequest(t),
+		uint32(perChannel), // a single channel, no growth allowed
+		logger.NewNoopMomentoLoggerFactory().GetLogger("pool-test"),
+	)
+	if err != nil {
+		t.Fatalf("NewDynamicStreamGrpcManagerPool returned error: %v", err)
+	}
+	defer pool.Close()
+
+	for i := 0; i < perChannel; i++ {
+		if _, getErr := pool.GetNextTopicGrpcManager(); getErr != nil {
+			t.Fatalf("GetNextTopicGrpcManager %d returned error: %v", i, getErr)
+		}
+	}
+	_, getErr := pool.GetNextTopicGrpcManager()
+	if getErr == nil {
+		t.Fatal("expected error past maxSubscriptions")
+	}
+	if getErr.Code() != momentoerrors.ClientResourceExhaustedError {
+		t.Fatalf("error code = %s, want %s", getErr.Code(), momentoerrors.ClientResourceExhaustedError)
+	}
+	if !strings.Contains(getErr.Error(), "maximum number of concurrent grpc streams") {
+		t.Fatalf("unexpected error message: %v", getErr)
+	}
+	if got := pool.GetCurrentNumberOfGrpcManagers(); got != 1 {
+		t.Fatalf("manager count = %d, want 1 (growth not allowed)", got)
+	}
 }

--- a/internal/grpcmanagers/topic_manager_lists/pool_close_test.go
+++ b/internal/grpcmanagers/topic_manager_lists/pool_close_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/momentohq/client-sdk-go/auth"
 	"github.com/momentohq/client-sdk-go/config"
 	"github.com/momentohq/client-sdk-go/config/logger"
+	"github.com/momentohq/client-sdk-go/internal/grpcmanagers"
 	"github.com/momentohq/client-sdk-go/internal/models"
 	"github.com/momentohq/client-sdk-go/internal/momentoerrors"
 )
@@ -180,6 +181,47 @@ func TestTopicStreamPoolGetRacingCloseIsSafe(t *testing.T) {
 	if got := pool.GetCurrentActiveStreamsCount(); got != 0 {
 		t.Fatalf("active streams count after race = %d, want 0", got)
 	}
+}
+
+// TestTopicUnaryPoolReservationLifecycle covers the real unary pool, which
+// the subscription tests only exercise through fakes: reservations hand out
+// managers round-robin, Release is a no-op returning zero, and Close is
+// idempotent.
+func TestTopicUnaryPoolReservationLifecycle(t *testing.T) {
+	t.Parallel()
+
+	pool, err := NewStaticUnaryGrpcManagerPool(
+		newTestManagerRequest(t),
+		2,
+		logger.NewNoopMomentoLoggerFactory().GetLogger("unary-pool-test"),
+	)
+	if err != nil {
+		t.Fatalf("NewStaticUnaryGrpcManagerPool returned error: %v", err)
+	}
+
+	seen := make(map[*grpcmanagers.TopicGrpcManager]bool)
+	for i := 0; i < 4; i++ {
+		reservation, getErr := pool.GetNextTopicGrpcManager()
+		if getErr != nil {
+			t.Fatalf("GetNextTopicGrpcManager %d returned error: %v", i, getErr)
+		}
+		if reservation.Manager() == nil {
+			t.Fatal("reservation manager is nil")
+		}
+		seen[reservation.Manager()] = true
+		if got := reservation.Release(); got != 0 {
+			t.Fatalf("unary Release returned %d, want 0 (no-op)", got)
+		}
+		if got := reservation.Manager().NumActiveSubscriptions.Load(); got != 0 {
+			t.Fatalf("unary reservations must not touch subscription counts, got %d", got)
+		}
+	}
+	if len(seen) != 2 {
+		t.Fatalf("round-robin visited %d managers, want 2", len(seen))
+	}
+
+	pool.Close()
+	pool.Close() // idempotent
 }
 
 // TestTopicStreamPoolRespectsPerChannelCap fills a multi-channel pool to

--- a/internal/grpcmanagers/topic_manager_lists/pool_close_test.go
+++ b/internal/grpcmanagers/topic_manager_lists/pool_close_test.go
@@ -1,0 +1,119 @@
+package topic_manager_lists
+
+import (
+	"testing"
+	"time"
+
+	"github.com/momentohq/client-sdk-go/auth"
+	"github.com/momentohq/client-sdk-go/config"
+	"github.com/momentohq/client-sdk-go/config/logger"
+	"github.com/momentohq/client-sdk-go/internal/models"
+)
+
+// newTestManagerRequest builds a manager request against momento-local
+// defaults. grpc.NewClient dials lazily, so these tests never need a running
+// server: no RPC is ever issued.
+func newTestManagerRequest(t *testing.T) *models.TopicStreamGrpcManagerRequest {
+	t.Helper()
+	credProvider, err := auth.NewMomentoLocalProvider(&auth.MomentoLocalConfig{})
+	if err != nil {
+		t.Fatalf("NewMomentoLocalProvider returned error: %v", err)
+	}
+	return &models.TopicStreamGrpcManagerRequest{
+		GrpcConfiguration:  config.NewTopicsStaticGrpcConfiguration(&config.TopicsGrpcConfigurationProps{}),
+		CredentialProvider: credProvider,
+	}
+}
+
+func waitForActiveStreamsCount(t *testing.T, got func() uint64, want uint64) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if got() == want {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatalf("active streams count = %d, want %d after waiting", got(), want)
+}
+
+// TestTopicStreamPoolCloseReleasesPrefetchedSlotStatic pins the dispatcher's
+// shutdown accounting: makeNextManagerAvailable eagerly reserves a slot for
+// the envelope it parks on the unbuffered channel, and Close interrupting that
+// parked send must return the slot so the counters end exact.
+func TestTopicStreamPoolCloseReleasesPrefetchedSlotStatic(t *testing.T) {
+	t.Parallel()
+
+	pool, err := NewStaticStreamGrpcManagerPool(
+		newTestManagerRequest(t),
+		1,
+		logger.NewNoopMomentoLoggerFactory().GetLogger("pool-close-test"),
+	)
+	if err != nil {
+		t.Fatalf("NewStaticStreamGrpcManagerPool returned error: %v", err)
+	}
+
+	// The dispatcher prefetches one manager and parks holding its slot.
+	waitForActiveStreamsCount(t, pool.GetCurrentActiveStreamsCount, 1)
+
+	// Close waits on dispatcherDone, so the release is visible once it returns.
+	pool.Close()
+	if got := pool.GetCurrentActiveStreamsCount(); got != 0 {
+		t.Fatalf("active streams count after Close = %d, want 0", got)
+	}
+	if got := pool.grpcManagers[0].NumActiveSubscriptions.Load(); got != 0 {
+		t.Fatalf("manager subscription count after Close = %d, want 0", got)
+	}
+}
+
+// TestTopicStreamPoolCloseReleasesPrefetchedSlotDynamic is the dynamic-pool
+// twin of the static prefetch-release test.
+func TestTopicStreamPoolCloseReleasesPrefetchedSlotDynamic(t *testing.T) {
+	t.Parallel()
+
+	pool, err := NewDynamicStreamGrpcManagerPool(
+		newTestManagerRequest(t),
+		100,
+		logger.NewNoopMomentoLoggerFactory().GetLogger("pool-close-test"),
+	)
+	if err != nil {
+		t.Fatalf("NewDynamicStreamGrpcManagerPool returned error: %v", err)
+	}
+
+	waitForActiveStreamsCount(t, pool.GetCurrentActiveStreamsCount, 1)
+
+	pool.Close()
+	if got := pool.GetCurrentActiveStreamsCount(); got != 0 {
+		t.Fatalf("active streams count after Close = %d, want 0", got)
+	}
+	for i, manager := range pool.grpcManagers {
+		if got := manager.NumActiveSubscriptions.Load(); got != 0 {
+			t.Fatalf("manager %d subscription count after Close = %d, want 0", i, got)
+		}
+	}
+}
+
+// TestTopicStreamPoolCloseIsIdempotent guards the closeOnce hardening: double
+// and concurrent Close must not panic (send on closed channel, double close)
+// or hang.
+func TestTopicStreamPoolCloseIsIdempotent(t *testing.T) {
+	t.Parallel()
+
+	pool, err := NewStaticStreamGrpcManagerPool(
+		newTestManagerRequest(t),
+		1,
+		logger.NewNoopMomentoLoggerFactory().GetLogger("pool-close-test"),
+	)
+	if err != nil {
+		t.Fatalf("NewStaticStreamGrpcManagerPool returned error: %v", err)
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		pool.Close()
+	}()
+	pool.Close()
+	<-done
+	pool.Close()
+}

--- a/internal/grpcmanagers/topic_manager_lists/pool_close_test.go
+++ b/internal/grpcmanagers/topic_manager_lists/pool_close_test.go
@@ -224,6 +224,9 @@ func TestTopicDynamicStreamPoolGrowsOnDemand(t *testing.T) {
 	if got := pool.GetCurrentNumberOfGrpcManagers(); got != 2 {
 		t.Fatalf("manager count after growth = %d, want 2", got)
 	}
+	if got := pool.GetCurrentActiveStreamsCount(); got != uint64(perChannel+1) {
+		t.Fatalf("active streams count after growth = %d, want %d", got, perChannel+1)
+	}
 
 	for _, r := range reservations {
 		r.Release()

--- a/internal/grpcmanagers/topic_manager_lists/pool_close_test.go
+++ b/internal/grpcmanagers/topic_manager_lists/pool_close_test.go
@@ -182,6 +182,46 @@ func TestTopicStreamPoolGetRacingCloseIsSafe(t *testing.T) {
 	}
 }
 
+// TestTopicStreamPoolRespectsPerChannelCap fills a multi-channel pool to
+// capacity and checks the invariant the round-robin reservation must hold:
+// no channel ever exceeds MAX_CONCURRENT_STREAMS_PER_CHANNEL, and a full pool
+// lands exactly at the cap on every channel.
+func TestTopicStreamPoolRespectsPerChannelCap(t *testing.T) {
+	t.Parallel()
+
+	const numChannels = 3
+	pool := newStaticTestPool(t, numChannels)
+	defer pool.Close()
+
+	perChannel := int64(config.MAX_CONCURRENT_STREAMS_PER_CHANNEL)
+	total := numChannels * config.MAX_CONCURRENT_STREAMS_PER_CHANNEL
+	reservations := make([]*Reservation, 0, total)
+	for i := 0; i < total; i++ {
+		reservation, err := pool.GetNextTopicGrpcManager()
+		if err != nil {
+			t.Fatalf("GetNextTopicGrpcManager %d returned error: %v", i, err)
+		}
+		reservations = append(reservations, reservation)
+		for channel, manager := range pool.grpcManagers {
+			if got := manager.NumActiveSubscriptions.Load(); got > perChannel {
+				t.Fatalf("channel %d exceeded the per-channel cap after %d reservations: %d > %d", channel, i+1, got, perChannel)
+			}
+		}
+	}
+	for channel, manager := range pool.grpcManagers {
+		if got := manager.NumActiveSubscriptions.Load(); got != perChannel {
+			t.Fatalf("channel %d subscription count at full pool = %d, want exactly %d", channel, got, perChannel)
+		}
+	}
+
+	for _, reservation := range reservations {
+		reservation.Release()
+	}
+	if got := pool.GetCurrentActiveStreamsCount(); got != 0 {
+		t.Fatalf("active streams count after releasing all = %d, want 0", got)
+	}
+}
+
 // TestTopicDynamicStreamPoolGrowsOnDemand verifies the dynamic pool adds a
 // channel when the current capacity is consumed, with exact counters and no
 // RPCs (slots are reserved without opening streams).

--- a/internal/grpcmanagers/topic_manager_lists/reservation.go
+++ b/internal/grpcmanagers/topic_manager_lists/reservation.go
@@ -1,0 +1,40 @@
+package topic_manager_lists
+
+import (
+	"sync/atomic"
+
+	"github.com/momentohq/client-sdk-go/internal/grpcmanagers"
+)
+
+// Reservation is an acquired stream slot from a TopicGrpcConnectionPool.
+// Call Release when done; redundant calls are safe. Dropping a Reservation
+// without calling Release leaks the slot.
+type Reservation struct {
+	manager  *grpcmanagers.TopicGrpcManager
+	release  func(*grpcmanagers.TopicGrpcManager) int64
+	released atomic.Bool
+}
+
+// NewReservation builds a Reservation backed by release. Both args must be non-nil.
+func NewReservation(
+	manager *grpcmanagers.TopicGrpcManager,
+	release func(*grpcmanagers.TopicGrpcManager) int64,
+) *Reservation {
+	return &Reservation{
+		manager: manager,
+		release: release,
+	}
+}
+
+func (r *Reservation) Manager() *grpcmanagers.TopicGrpcManager {
+	return r.manager
+}
+
+// Release returns the slot to the pool. Only the first call decrements;
+// subsequent calls return the current per-channel count without effect.
+func (r *Reservation) Release() int64 {
+	if !r.released.CompareAndSwap(false, true) {
+		return r.manager.NumActiveSubscriptions.Load()
+	}
+	return r.release(r.manager)
+}

--- a/internal/grpcmanagers/topic_manager_lists/reservation.go
+++ b/internal/grpcmanagers/topic_manager_lists/reservation.go
@@ -7,8 +7,10 @@ import (
 )
 
 // Reservation is an acquired stream slot from a TopicGrpcConnectionPool.
-// Call Release when done; redundant calls are safe. Dropping a Reservation
-// without calling Release leaks the slot.
+// Call Release when done; redundant calls are safe. Decrement and leak
+// semantics come from the pool's release function (the unary pool's is a
+// no-op). Dropping a stream-pool Reservation without calling Release leaks
+// the slot for the lifetime of the pool.
 type Reservation struct {
 	manager  *grpcmanagers.TopicGrpcManager
 	release  func(*grpcmanagers.TopicGrpcManager) int64
@@ -30,8 +32,10 @@ func (r *Reservation) Manager() *grpcmanagers.TopicGrpcManager {
 	return r.manager
 }
 
-// Release returns the slot to the pool. Only the first call decrements;
-// subsequent calls return the current per-channel count without effect.
+// Release returns the slot to the pool. Only the first call invokes the
+// pool's release; subsequent calls return the live per-channel count without
+// effect. That value is advisory — a concurrent winning Release may not have
+// performed its decrement yet.
 func (r *Reservation) Release() int64 {
 	if !r.released.CompareAndSwap(false, true) {
 		return r.manager.NumActiveSubscriptions.Load()

--- a/internal/grpcmanagers/topic_manager_lists/reservation_test.go
+++ b/internal/grpcmanagers/topic_manager_lists/reservation_test.go
@@ -1,0 +1,125 @@
+package topic_manager_lists
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/momentohq/client-sdk-go/internal/grpcmanagers"
+)
+
+// newCountingReleaser returns a release function that increments a counter
+// each time it is invoked, plus the counter so tests can observe invocations.
+func newCountingReleaser() (func(*grpcmanagers.TopicGrpcManager) int64, *atomic.Int64) {
+	var calls atomic.Int64
+	release := func(mgr *grpcmanagers.TopicGrpcManager) int64 {
+		calls.Add(1)
+		return mgr.NumActiveSubscriptions.Add(-1)
+	}
+	return release, &calls
+}
+
+func TestReservation_ReleaseIsIdempotent(t *testing.T) {
+	t.Parallel()
+
+	mgr := &grpcmanagers.TopicGrpcManager{}
+	mgr.NumActiveSubscriptions.Store(1)
+
+	release, calls := newCountingReleaser()
+	r := NewReservation(mgr, release)
+
+	first := r.Release()
+	if first != 0 {
+		t.Fatalf("first Release returned %d, want 0 (manager counter after decrement)", first)
+	}
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("release function called %d times after first Release, want 1", got)
+	}
+
+	// Redundant calls must not double-decrement.
+	for i := 0; i < 5; i++ {
+		r.Release()
+	}
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("release function called %d times after repeated Release, want 1", got)
+	}
+	if got := mgr.NumActiveSubscriptions.Load(); got != 0 {
+		t.Fatalf("NumActiveSubscriptions = %d, want 0 (only one decrement should have occurred)", got)
+	}
+}
+
+func TestReservation_ReleaseReportsCurrentCountOnSubsequentCalls(t *testing.T) {
+	t.Parallel()
+
+	mgr := &grpcmanagers.TopicGrpcManager{}
+	mgr.NumActiveSubscriptions.Store(3)
+
+	release, _ := newCountingReleaser()
+	r := NewReservation(mgr, release)
+
+	first := r.Release()
+	if first != 2 {
+		t.Fatalf("first Release returned %d, want 2 (started at 3, decremented once)", first)
+	}
+
+	// External actor adjusts the counter to simulate other subscriptions. The
+	// second Release should report whatever the live value is, without
+	// performing another decrement.
+	mgr.NumActiveSubscriptions.Add(5)
+	second := r.Release()
+	if second != 7 {
+		t.Fatalf("second Release returned %d, want 7 (live counter value, no decrement)", second)
+	}
+}
+
+func TestReservation_ManagerReturnsUnderlying(t *testing.T) {
+	t.Parallel()
+
+	mgr := &grpcmanagers.TopicGrpcManager{}
+	release, _ := newCountingReleaser()
+	r := NewReservation(mgr, release)
+
+	if r.Manager() != mgr {
+		t.Fatal("Manager() should return the manager passed to NewReservation")
+	}
+
+	r.Release()
+	if r.Manager() != mgr {
+		t.Fatal("Manager() should remain accessible after Release for in-flight callers")
+	}
+}
+
+func TestReservation_ConcurrentReleaseDecrementsOnce(t *testing.T) {
+	t.Parallel()
+
+	// Run many concurrent Release calls on the same Reservation; only the
+	// first should perform the decrement. Validates the CAS guarantee under
+	// contention and exercises the race detector when -race is enabled.
+	const goroutines = 256
+
+	mgr := &grpcmanagers.TopicGrpcManager{}
+	mgr.NumActiveSubscriptions.Store(int64(goroutines + 10))
+
+	release, calls := newCountingReleaser()
+	r := NewReservation(mgr, release)
+
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			<-start
+			r.Release()
+		}()
+	}
+	close(start)
+	wg.Wait()
+
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("release function called %d times, want 1 under concurrent Release", got)
+	}
+	if got := mgr.NumActiveSubscriptions.Load(); got != int64(goroutines+9) {
+		t.Fatalf("NumActiveSubscriptions = %d, want %d (started at goroutines+10, exactly one decrement)", got, goroutines+9)
+	}
+}

--- a/internal/grpcmanagers/topic_manager_lists/static_stream_grpc_manager_pool.go
+++ b/internal/grpcmanagers/topic_manager_lists/static_stream_grpc_manager_pool.go
@@ -147,6 +147,11 @@ func (s *staticStreamGrpcManagerPool) makeNextManagerAvailable() {
 			topicManager, err := s.getNextManager()
 			select {
 			case <-s.ctx.Done():
+				// Close interrupted a prepared envelope: return the prefetched
+				// slot so the counters stay exact. Error envelopes hold no slot.
+				if topicManager != nil {
+					s.releaseManager(topicManager)
+				}
 				return
 			case s.nextAvailableGrpcManagerChannel <- &StreamGrpcManagerRequest{
 				TopicManager: topicManager,

--- a/internal/grpcmanagers/topic_manager_lists/static_stream_grpc_manager_pool.go
+++ b/internal/grpcmanagers/topic_manager_lists/static_stream_grpc_manager_pool.go
@@ -3,6 +3,7 @@ package topic_manager_lists
 import (
 	"context"
 	"fmt"
+	"sync"
 	"sync/atomic"
 
 	"github.com/momentohq/client-sdk-go/config"
@@ -22,6 +23,9 @@ type staticStreamGrpcManagerPool struct {
 	nextAvailableGrpcManagerChannel chan *StreamGrpcManagerRequest
 	ctx                             context.Context
 	cancel                          context.CancelFunc
+	// dispatcherDone is closed when makeNextManagerAvailable returns.
+	dispatcherDone chan struct{}
+	closeOnce      sync.Once
 }
 
 // GetNextTopicGrpcManager returns the next available TopicGrpcManager from the pool
@@ -30,7 +34,7 @@ type staticStreamGrpcManagerPool struct {
 // Only the makeNextManagerAvailable goroutine started in NewStaticStreamGrpcManagerPool
 // places the next available stream manager on the channel (or an error if no stream manager
 // is available).
-func (s *staticStreamGrpcManagerPool) GetNextTopicGrpcManager() (*grpcmanagers.TopicGrpcManager, momentoerrors.MomentoSvcErr) {
+func (s *staticStreamGrpcManagerPool) GetNextTopicGrpcManager() (*Reservation, momentoerrors.MomentoSvcErr) {
 	select {
 	// If the context was cancelled, we should no longer return any topic managers
 	case <-s.ctx.Done():
@@ -47,20 +51,25 @@ func (s *staticStreamGrpcManagerPool) GetNextTopicGrpcManager() (*grpcmanagers.T
 		if topicManagerRequest.Err != nil {
 			return nil, topicManagerRequest.Err
 		}
-		return topicManagerRequest.TopicManager, nil
+		return NewReservation(topicManagerRequest.TopicManager, s.releaseManager), nil
 	}
 }
 
-// Close shuts down all the grpc connections in the pool.
+// Close shuts down all gRPC connections. Safe to call multiple times.
+// Cancels the dispatcher context, waits for the dispatcher to exit, closes
+// the manager channel, then tears down each connection.
 func (s *staticStreamGrpcManagerPool) Close() {
-	s.cancel() // Cancel context first to stop goroutine
-	close(s.nextAvailableGrpcManagerChannel)
-	for _, topicManager := range s.grpcManagers {
-		err := topicManager.Close()
-		if err != nil {
-			s.logger.Error("Error closing topic manager: %v", err)
+	s.closeOnce.Do(func() {
+		s.cancel()
+		<-s.dispatcherDone
+		close(s.nextAvailableGrpcManagerChannel)
+		for _, topicManager := range s.grpcManagers {
+			err := topicManager.Close()
+			if err != nil {
+				s.logger.Error("Error closing topic manager: %v", err)
+			}
 		}
-	}
+	})
 }
 
 // GetCurrentActiveStreamsCount returns the current number of active streams in the pool.
@@ -68,10 +77,10 @@ func (s *staticStreamGrpcManagerPool) GetCurrentActiveStreamsCount() uint64 {
 	return s.currentActiveStreamsCount.Load()
 }
 
-// ReleaseTopicGrpcManager decrements both the per-channel NumActiveSubscriptions counter
-// on the given manager and the pool-wide currentActiveStreamsCount, freeing up the slot
-// so future GetNextTopicGrpcManager calls see capacity. Returns the new per-channel count.
-func (s *staticStreamGrpcManagerPool) ReleaseTopicGrpcManager(manager *grpcmanagers.TopicGrpcManager) int64 {
+// releaseManager backs Reservation.Release for this pool. Decrements the
+// per-channel and pool-wide counters; the pool-wide CAS bottoms at zero so
+// it can't go negative.
+func (s *staticStreamGrpcManagerPool) releaseManager(manager *grpcmanagers.TopicGrpcManager) int64 {
 	newCount := manager.NumActiveSubscriptions.Add(-1)
 	for {
 		current := s.currentActiveStreamsCount.Load()
@@ -112,6 +121,7 @@ func NewStaticStreamGrpcManagerPool(
 		nextAvailableGrpcManagerChannel: nextAvailableGrpcManagerChannel,
 		ctx:                             ctx,
 		cancel:                          cancel,
+		dispatcherDone:                  make(chan struct{}),
 	}
 
 	go pool.makeNextManagerAvailable()
@@ -128,6 +138,7 @@ func NewStaticStreamGrpcManagerPool(
 // only be able to pull one topic grpc manager from the channel at a time to allocate
 // to each subscribe request.
 func (s *staticStreamGrpcManagerPool) makeNextManagerAvailable() {
+	defer close(s.dispatcherDone)
 	for {
 		select {
 		case <-s.ctx.Done():

--- a/internal/grpcmanagers/topic_manager_lists/static_stream_grpc_manager_pool.go
+++ b/internal/grpcmanagers/topic_manager_lists/static_stream_grpc_manager_pool.go
@@ -77,20 +77,10 @@ func (s *staticStreamGrpcManagerPool) getNextManager() (*grpcmanagers.TopicGrpcM
 		return nil, err
 	}
 
-	// Round-robin over the channels until one has a free slot. Allocation is
-	// serialized by the core mutex, so one pass over every channel would
-	// suffice; the generous bound is defensive.
-	for i := 0; uint32(i) < s.maxConcurrentStreams; i++ {
-		s.managerIndex++
-		nextManagerIndex := s.managerIndex
-		topicManager := s.grpcManagers[nextManagerIndex%uint64(len(s.grpcManagers))]
-		newCount := topicManager.NumActiveSubscriptions.Add(1)
-		if newCount <= int64(config.MAX_CONCURRENT_STREAMS_PER_CHANNEL) {
-			s.logger.Debug("Starting new subscription on grpc channel %d which now has %d streams", nextManagerIndex%uint64(len(s.grpcManagers)), newCount)
-			s.currentActiveStreamsCount.Add(1)
-			return topicManager, nil
-		}
-		topicManager.NumActiveSubscriptions.Add(-1)
+	// The attempt bound is generous: allocation is serialized by the core
+	// mutex, so one pass over every channel would suffice.
+	if topicManager := s.reserveSlot(s.grpcManagers, &s.managerIndex, s.maxConcurrentStreams, s.logger); topicManager != nil {
+		return topicManager, nil
 	}
 
 	// If there are no more streams available, return an error

--- a/internal/grpcmanagers/topic_manager_lists/static_stream_grpc_manager_pool.go
+++ b/internal/grpcmanagers/topic_manager_lists/static_stream_grpc_manager_pool.go
@@ -2,7 +2,6 @@ package topic_manager_lists
 
 import (
 	"fmt"
-	"sync/atomic"
 
 	"github.com/momentohq/client-sdk-go/config"
 	"github.com/momentohq/client-sdk-go/config/logger"
@@ -16,8 +15,9 @@ import (
 // streamPoolCore; this type supplies the fixed-size capacity policy.
 type staticStreamGrpcManagerPool struct {
 	streamPoolCore
-	grpcManagers         []*grpcmanagers.TopicGrpcManager
-	managerIndex         atomic.Uint64
+	grpcManagers []*grpcmanagers.TopicGrpcManager
+	// managerIndex is only touched by getNextManager under the core's mutex.
+	managerIndex         uint64
 	maxConcurrentStreams uint32
 	logger               logger.MomentoLogger
 }
@@ -77,11 +77,12 @@ func (s *staticStreamGrpcManagerPool) getNextManager() (*grpcmanagers.TopicGrpcM
 		return nil, err
 	}
 
-	// Max number of attempts is set to the max number of concurrent streams in order to preserve
-	// the round-robin system (incrementing nextManagerIndex) but to not cut short the number
-	//  of attempts in case there are many subscriptions starting up at the same time.
+	// Round-robin over the channels until one has a free slot. Allocation is
+	// serialized by the core mutex, so one pass over every channel would
+	// suffice; the generous bound is defensive.
 	for i := 0; uint32(i) < s.maxConcurrentStreams; i++ {
-		nextManagerIndex := s.managerIndex.Add(1)
+		s.managerIndex++
+		nextManagerIndex := s.managerIndex
 		topicManager := s.grpcManagers[nextManagerIndex%uint64(len(s.grpcManagers))]
 		newCount := topicManager.NumActiveSubscriptions.Add(1)
 		if newCount <= int64(config.MAX_CONCURRENT_STREAMS_PER_CHANNEL) {

--- a/internal/grpcmanagers/topic_manager_lists/static_stream_grpc_manager_pool.go
+++ b/internal/grpcmanagers/topic_manager_lists/static_stream_grpc_manager_pool.go
@@ -1,9 +1,7 @@
 package topic_manager_lists
 
 import (
-	"context"
 	"fmt"
-	"sync"
 	"sync/atomic"
 
 	"github.com/momentohq/client-sdk-go/config"
@@ -13,85 +11,15 @@ import (
 	"github.com/momentohq/client-sdk-go/internal/momentoerrors"
 )
 
-// staticStreamGrpcManagerPool manages a static pool of gRPC channels for stream pubsub requests.
+// staticStreamGrpcManagerPool manages a static pool of gRPC channels for
+// stream pubsub requests. Allocation, release, and Close live in the embedded
+// streamPoolCore; this type supplies the fixed-size capacity policy.
 type staticStreamGrpcManagerPool struct {
-	grpcManagers                    []*grpcmanagers.TopicGrpcManager
-	managerIndex                    atomic.Uint64
-	currentActiveStreamsCount       atomic.Uint64
-	maxConcurrentStreams            uint32
-	logger                          logger.MomentoLogger
-	nextAvailableGrpcManagerChannel chan *StreamGrpcManagerRequest
-	ctx                             context.Context
-	cancel                          context.CancelFunc
-	// dispatcherDone is closed when makeNextManagerAvailable returns.
-	dispatcherDone chan struct{}
-	closeOnce      sync.Once
-}
-
-// GetNextTopicGrpcManager returns the next available TopicGrpcManager from the pool
-// by pulling from the nextAvailableGrpcManagerChannel.
-//
-// Only the makeNextManagerAvailable goroutine started in NewStaticStreamGrpcManagerPool
-// places the next available stream manager on the channel (or an error if no stream manager
-// is available).
-func (s *staticStreamGrpcManagerPool) GetNextTopicGrpcManager() (*Reservation, momentoerrors.MomentoSvcErr) {
-	select {
-	// If the context was cancelled, we should no longer return any topic managers
-	case <-s.ctx.Done():
-		return nil, momentoerrors.NewMomentoSvcErr(momentoerrors.CanceledError, "Context cancelled", nil)
-	default:
-		topicManagerRequest := <-s.nextAvailableGrpcManagerChannel
-
-		// If the channel is closed, we'll receive a zero value (nil in this case since it's a pointer type).
-		// This means that the pool is shutting down and we should no longer return any topic managers.
-		if topicManagerRequest == nil {
-			return nil, momentoerrors.NewMomentoSvcErr(momentoerrors.ClientSdkError, "Received nil from nextAvailableGrpcManagerChannel", nil)
-		}
-
-		if topicManagerRequest.Err != nil {
-			return nil, topicManagerRequest.Err
-		}
-		return NewReservation(topicManagerRequest.TopicManager, s.releaseManager), nil
-	}
-}
-
-// Close shuts down all gRPC connections. Safe to call multiple times.
-// Cancels the dispatcher context, waits for the dispatcher to exit, closes
-// the manager channel, then tears down each connection.
-func (s *staticStreamGrpcManagerPool) Close() {
-	s.closeOnce.Do(func() {
-		s.cancel()
-		<-s.dispatcherDone
-		close(s.nextAvailableGrpcManagerChannel)
-		for _, topicManager := range s.grpcManagers {
-			err := topicManager.Close()
-			if err != nil {
-				s.logger.Error("Error closing topic manager: %v", err)
-			}
-		}
-	})
-}
-
-// GetCurrentActiveStreamsCount returns the current number of active streams in the pool.
-func (s *staticStreamGrpcManagerPool) GetCurrentActiveStreamsCount() uint64 {
-	return s.currentActiveStreamsCount.Load()
-}
-
-// releaseManager backs Reservation.Release for this pool. Decrements the
-// per-channel and pool-wide counters; the pool-wide CAS bottoms at zero so
-// it can't go negative.
-func (s *staticStreamGrpcManagerPool) releaseManager(manager *grpcmanagers.TopicGrpcManager) int64 {
-	newCount := manager.NumActiveSubscriptions.Add(-1)
-	for {
-		current := s.currentActiveStreamsCount.Load()
-		if current == 0 {
-			break
-		}
-		if s.currentActiveStreamsCount.CompareAndSwap(current, current-1) {
-			break
-		}
-	}
-	return newCount
+	streamPoolCore
+	grpcManagers         []*grpcmanagers.TopicGrpcManager
+	managerIndex         atomic.Uint64
+	maxConcurrentStreams uint32
+	logger               logger.MomentoLogger
 }
 
 // NewStaticStreamGrpcManagerPool creates a new pool with a fixed number of grpc managers for stream pubsub requests.
@@ -109,57 +37,15 @@ func NewStaticStreamGrpcManagerPool(
 		streamTopicManagers = append(streamTopicManagers, streamTopicManager)
 	}
 
-	// Use an unbuffered channel here so the staticStreamGrpcManagerPool will block on sending
-	// the next available stream manager until the most recent request is processed.
-	nextAvailableGrpcManagerChannel := make(chan *StreamGrpcManagerRequest)
-	ctx, cancel := context.WithCancel(context.Background())
-
 	pool := &staticStreamGrpcManagerPool{
-		grpcManagers:                    streamTopicManagers,
-		maxConcurrentStreams:            numStreamChannels * uint32(config.MAX_CONCURRENT_STREAMS_PER_CHANNEL),
-		logger:                          logger,
-		nextAvailableGrpcManagerChannel: nextAvailableGrpcManagerChannel,
-		ctx:                             ctx,
-		cancel:                          cancel,
-		dispatcherDone:                  make(chan struct{}),
+		grpcManagers:         streamTopicManagers,
+		maxConcurrentStreams: numStreamChannels * uint32(config.MAX_CONCURRENT_STREAMS_PER_CHANNEL),
+		logger:               logger,
 	}
-
-	go pool.makeNextManagerAvailable()
+	pool.initStreamPoolCore(pool.getNextManager, func() {
+		closeAllManagers(pool.grpcManagers, logger)
+	})
 	return pool, nil
-}
-
-// makeNextManagerAvailable continually places the next available stream manager
-// on the nextAvailableGrpcManagerChannel.
-//
-// The nextAvailableGrpcManagerChannel is unbuffered, so the staticStreamGrpcManagerPool
-// will block on sending the next available stream manager until the most recent request
-// is processed.
-// So even if there is a burst of concurrent subscribe requests, the pubsub client should
-// only be able to pull one topic grpc manager from the channel at a time to allocate
-// to each subscribe request.
-func (s *staticStreamGrpcManagerPool) makeNextManagerAvailable() {
-	defer close(s.dispatcherDone)
-	for {
-		select {
-		case <-s.ctx.Done():
-			return
-		default:
-			topicManager, err := s.getNextManager()
-			select {
-			case <-s.ctx.Done():
-				// Close interrupted a prepared envelope: return the prefetched
-				// slot so the counters stay exact. Error envelopes hold no slot.
-				if topicManager != nil {
-					s.releaseManager(topicManager)
-				}
-				return
-			case s.nextAvailableGrpcManagerChannel <- &StreamGrpcManagerRequest{
-				TopicManager: topicManager,
-				Err:          err,
-			}:
-			}
-		}
-	}
 }
 
 // checkNumConcurrentStreams checks the number of concurrent streams before starting a new subscription
@@ -182,7 +68,8 @@ func (s *staticStreamGrpcManagerPool) checkNumConcurrentStreams() momentoerrors.
 	return nil
 }
 
-// getNextManager is used by makeNextManagerAvailable to return the next available stream manager from the pool.
+// getNextManager returns the next available stream manager from the pool,
+// reserving a slot on it. Called by streamPoolCore under its mutex.
 func (s *staticStreamGrpcManagerPool) getNextManager() (*grpcmanagers.TopicGrpcManager, momentoerrors.MomentoSvcErr) {
 	// First check if there is enough grpc stream capacity to make a new subscription
 	err := s.checkNumConcurrentStreams()

--- a/internal/grpcmanagers/topic_manager_lists/static_unary_grpc_manager_pool.go
+++ b/internal/grpcmanagers/topic_manager_lists/static_unary_grpc_manager_pool.go
@@ -32,12 +32,7 @@ func (list *staticUnaryGrpcManagerPool) releaseManager(_ *grpcmanagers.TopicGrpc
 // Close shuts down all gRPC connections. Safe to call multiple times.
 func (list *staticUnaryGrpcManagerPool) Close() {
 	list.closeOnce.Do(func() {
-		for _, topicManager := range list.grpcManagers {
-			err := topicManager.Close()
-			if err != nil {
-				list.logger.Error("Error closing topic manager: %v", err)
-			}
-		}
+		closeAllManagers(list.grpcManagers, list.logger)
 	})
 }
 

--- a/internal/grpcmanagers/topic_manager_lists/static_unary_grpc_manager_pool.go
+++ b/internal/grpcmanagers/topic_manager_lists/static_unary_grpc_manager_pool.go
@@ -1,6 +1,7 @@
 package topic_manager_lists
 
 import (
+	"sync"
 	"sync/atomic"
 
 	"github.com/momentohq/client-sdk-go/config/logger"
@@ -14,34 +15,30 @@ type staticUnaryGrpcManagerPool struct {
 	grpcManagers []*grpcmanagers.TopicGrpcManager
 	managerIndex atomic.Uint64
 	logger       logger.MomentoLogger
+	closeOnce    sync.Once
 }
 
-// GetNextTopicGrpcManager returns the next available TopicGrpcManager from the pool
-// using a round-robin approach.
-//
-// Publish requests can queue up if there are >100 concurrent requests on a grpc connection,
-// but unary requests will eventually complete so no need for the same level of bookkeeping
-// as for the stream grpc manager pools.
-func (list *staticUnaryGrpcManagerPool) GetNextTopicGrpcManager() (*grpcmanagers.TopicGrpcManager, momentoerrors.MomentoSvcErr) {
+// GetNextTopicGrpcManager returns the next manager via round-robin.
+// Reservation.Release is a no-op since unary requests don't hold slots.
+func (list *staticUnaryGrpcManagerPool) GetNextTopicGrpcManager() (*Reservation, momentoerrors.MomentoSvcErr) {
 	nextManagerIndex := list.managerIndex.Add(1)
-	return list.grpcManagers[nextManagerIndex%uint64(len(list.grpcManagers))], nil
+	return NewReservation(list.grpcManagers[nextManagerIndex%uint64(len(list.grpcManagers))], list.releaseManager), nil
 }
 
-// ReleaseTopicGrpcManager is a no-op for the unary pool because unary requests
-// don't hold long-lived stream slots and the pool doesn't track per-channel
-// subscription counts.
-func (list *staticUnaryGrpcManagerPool) ReleaseTopicGrpcManager(_ *grpcmanagers.TopicGrpcManager) int64 {
+func (list *staticUnaryGrpcManagerPool) releaseManager(_ *grpcmanagers.TopicGrpcManager) int64 {
 	return 0
 }
 
-// Close shuts down all the grpc connections in the pool.
+// Close shuts down all gRPC connections. Safe to call multiple times.
 func (list *staticUnaryGrpcManagerPool) Close() {
-	for _, topicManager := range list.grpcManagers {
-		err := topicManager.Close()
-		if err != nil {
-			list.logger.Error("Error closing topic manager: %v", err)
+	list.closeOnce.Do(func() {
+		for _, topicManager := range list.grpcManagers {
+			err := topicManager.Close()
+			if err != nil {
+				list.logger.Error("Error closing topic manager: %v", err)
+			}
 		}
-	}
+	})
 }
 
 // NewStaticUnaryGrpcManagerPool creates a new pool with a fixed number of grpc managers for unary pubsub requests.

--- a/internal/grpcmanagers/topic_manager_lists/stream_pool_core.go
+++ b/internal/grpcmanagers/topic_manager_lists/stream_pool_core.go
@@ -1,6 +1,7 @@
 package topic_manager_lists
 
 import (
+	"context"
 	"sync"
 	"sync/atomic"
 
@@ -42,7 +43,7 @@ func (c *streamPoolCore) GetNextTopicGrpcManager() (*Reservation, momentoerrors.
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	if c.closed {
-		return nil, momentoerrors.NewMomentoSvcErr(momentoerrors.CanceledError, "connection pool is shutting down", nil)
+		return nil, momentoerrors.NewMomentoSvcErr(momentoerrors.CanceledError, "connection pool is shutting down", context.Canceled)
 	}
 	topicManager, err := c.getNextManager()
 	if err != nil {

--- a/internal/grpcmanagers/topic_manager_lists/stream_pool_core.go
+++ b/internal/grpcmanagers/topic_manager_lists/stream_pool_core.go
@@ -1,0 +1,97 @@
+package topic_manager_lists
+
+import (
+	"sync"
+	"sync/atomic"
+
+	"github.com/momentohq/client-sdk-go/config/logger"
+	"github.com/momentohq/client-sdk-go/internal/grpcmanagers"
+	"github.com/momentohq/client-sdk-go/internal/momentoerrors"
+)
+
+// streamPoolCore implements the reserve/release/Close machinery shared by the
+// static and dynamic stream pools. The mutex serializes allocation, so every
+// capacity decision sees live counters: no slot is held while the pool is
+// idle, and a capacity error can never be stale — a Release that frees a slot
+// is visible to the very next GetNextTopicGrpcManager call.
+//
+// Pools supply their capacity policy via getNextManager and their connection
+// teardown via closeManagers; both run under the mutex.
+type streamPoolCore struct {
+	mu     sync.Mutex
+	closed bool
+	// closeOnce makes Close idempotent and blocks concurrent callers until
+	// the first Close has finished tearing down connections.
+	closeOnce                 sync.Once
+	currentActiveStreamsCount atomic.Uint64
+	// getNextManager reserves a slot on success. Called only under mu.
+	getNextManager func() (*grpcmanagers.TopicGrpcManager, momentoerrors.MomentoSvcErr)
+	// closeManagers tears down the pool's connections. Called only under mu.
+	closeManagers func()
+}
+
+func (c *streamPoolCore) initStreamPoolCore(
+	getNextManager func() (*grpcmanagers.TopicGrpcManager, momentoerrors.MomentoSvcErr),
+	closeManagers func(),
+) {
+	c.getNextManager = getNextManager
+	c.closeManagers = closeManagers
+}
+
+// GetNextTopicGrpcManager reserves a manager from the pool. After Close it
+// returns CanceledError.
+func (c *streamPoolCore) GetNextTopicGrpcManager() (*Reservation, momentoerrors.MomentoSvcErr) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.closed {
+		return nil, momentoerrors.NewMomentoSvcErr(momentoerrors.CanceledError, "connection pool is shutting down", nil)
+	}
+	topicManager, err := c.getNextManager()
+	if err != nil {
+		return nil, err
+	}
+	return NewReservation(topicManager, c.releaseManager), nil
+}
+
+// Close shuts down all gRPC connections. Safe to call multiple times;
+// concurrent calls block until the first completes.
+func (c *streamPoolCore) Close() {
+	c.closeOnce.Do(func() {
+		c.mu.Lock()
+		defer c.mu.Unlock()
+		c.closed = true
+		c.closeManagers()
+	})
+}
+
+// GetCurrentActiveStreamsCount returns the current number of active streams in the pool.
+func (c *streamPoolCore) GetCurrentActiveStreamsCount() uint64 {
+	return c.currentActiveStreamsCount.Load()
+}
+
+// releaseManager backs Reservation.Release for the stream pools. Decrements
+// the per-channel and pool-wide counters; the pool-wide CAS bottoms at zero
+// so it can't go negative. Deliberately not guarded by mu so releases can't
+// contend with Close.
+func (c *streamPoolCore) releaseManager(manager *grpcmanagers.TopicGrpcManager) int64 {
+	newCount := manager.NumActiveSubscriptions.Add(-1)
+	for {
+		current := c.currentActiveStreamsCount.Load()
+		if current == 0 {
+			break
+		}
+		if c.currentActiveStreamsCount.CompareAndSwap(current, current-1) {
+			break
+		}
+	}
+	return newCount
+}
+
+// closeAllManagers closes every connection in managers, logging failures.
+func closeAllManagers(managers []*grpcmanagers.TopicGrpcManager, log logger.MomentoLogger) {
+	for _, topicManager := range managers {
+		if err := topicManager.Close(); err != nil {
+			log.Error("Error closing topic manager: %s", err.Error())
+		}
+	}
+}

--- a/internal/grpcmanagers/topic_manager_lists/stream_pool_core.go
+++ b/internal/grpcmanagers/topic_manager_lists/stream_pool_core.go
@@ -97,7 +97,7 @@ func (c *streamPoolCore) reserveSlot(
 	log logger.MomentoLogger,
 ) *grpcmanagers.TopicGrpcManager {
 	for i := uint32(0); i < attempts; i++ {
-		*index++
+		(*index)++
 		topicManager := managers[*index%uint64(len(managers))]
 		newCount := topicManager.NumActiveSubscriptions.Add(1)
 		if newCount <= int64(config.MAX_CONCURRENT_STREAMS_PER_CHANNEL) {

--- a/internal/grpcmanagers/topic_manager_lists/stream_pool_core.go
+++ b/internal/grpcmanagers/topic_manager_lists/stream_pool_core.go
@@ -4,6 +4,7 @@ import (
 	"sync"
 	"sync/atomic"
 
+	"github.com/momentohq/client-sdk-go/config"
 	"github.com/momentohq/client-sdk-go/config/logger"
 	"github.com/momentohq/client-sdk-go/internal/grpcmanagers"
 	"github.com/momentohq/client-sdk-go/internal/momentoerrors"
@@ -83,6 +84,30 @@ func (c *streamPoolCore) releaseManager(manager *grpcmanagers.TopicGrpcManager) 
 		}
 	}
 	return newCount
+}
+
+// reserveSlot round-robins over managers until one has spare per-channel
+// capacity, reserving a slot on it and bumping the pool-wide counter. index
+// is owned by the calling pool and only advances under the core mutex.
+// Returns nil when no channel has capacity within attempts probes.
+func (c *streamPoolCore) reserveSlot(
+	managers []*grpcmanagers.TopicGrpcManager,
+	index *uint64,
+	attempts uint32,
+	log logger.MomentoLogger,
+) *grpcmanagers.TopicGrpcManager {
+	for i := uint32(0); i < attempts; i++ {
+		*index++
+		topicManager := managers[*index%uint64(len(managers))]
+		newCount := topicManager.NumActiveSubscriptions.Add(1)
+		if newCount <= int64(config.MAX_CONCURRENT_STREAMS_PER_CHANNEL) {
+			log.Debug("Starting new subscription on grpc channel %d which now has %d streams", *index%uint64(len(managers)), newCount)
+			c.currentActiveStreamsCount.Add(1)
+			return topicManager
+		}
+		topicManager.NumActiveSubscriptions.Add(-1)
+	}
+	return nil
 }
 
 // closeAllManagers closes every connection in managers, logging failures.

--- a/internal/grpcmanagers/topic_manager_lists/stream_pool_core.go
+++ b/internal/grpcmanagers/topic_manager_lists/stream_pool_core.go
@@ -18,11 +18,8 @@ import (
 // Pools supply their capacity policy via getNextManager and their connection
 // teardown via closeManagers; both run under the mutex.
 type streamPoolCore struct {
-	mu     sync.Mutex
-	closed bool
-	// closeOnce makes Close idempotent and blocks concurrent callers until
-	// the first Close has finished tearing down connections.
-	closeOnce                 sync.Once
+	mu                        sync.Mutex
+	closed                    bool
 	currentActiveStreamsCount atomic.Uint64
 	// getNextManager reserves a slot on success. Called only under mu.
 	getNextManager func() (*grpcmanagers.TopicGrpcManager, momentoerrors.MomentoSvcErr)
@@ -54,14 +51,15 @@ func (c *streamPoolCore) GetNextTopicGrpcManager() (*Reservation, momentoerrors.
 }
 
 // Close shuts down all gRPC connections. Safe to call multiple times;
-// concurrent calls block until the first completes.
+// concurrent calls block on the mutex until the first completes.
 func (c *streamPoolCore) Close() {
-	c.closeOnce.Do(func() {
-		c.mu.Lock()
-		defer c.mu.Unlock()
-		c.closed = true
-		c.closeManagers()
-	})
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.closed {
+		return
+	}
+	c.closed = true
+	c.closeManagers()
 }
 
 // GetCurrentActiveStreamsCount returns the current number of active streams in the pool.

--- a/internal/grpcmanagers/topic_manager_lists/topic_grpc_connection_pool.go
+++ b/internal/grpcmanagers/topic_manager_lists/topic_grpc_connection_pool.go
@@ -1,7 +1,6 @@
 package topic_manager_lists
 
 import (
-	"github.com/momentohq/client-sdk-go/internal/grpcmanagers"
 	"github.com/momentohq/client-sdk-go/internal/momentoerrors"
 )
 
@@ -14,17 +13,12 @@ type TopicGrpcConnectionPool interface {
 	// leaks the slot for the lifetime of the pool; Close shuts the pool down
 	// but does not reclaim leaked slots.
 	//
+	// After Close, the stream pools return CanceledError.
+	//
 	// The unary pool's Release is a no-op since unary requests don't hold
 	// long-lived slots; callers invoke it uniformly anyway.
 	GetNextTopicGrpcManager() (*Reservation, momentoerrors.MomentoSvcErr)
 
 	// Close shuts down all gRPC connections in the pool.
 	Close()
-}
-
-// StreamGrpcManagerRequest is the dispatcher-to-caller envelope: either the
-// next manager or the allocation error.
-type StreamGrpcManagerRequest struct {
-	TopicManager *grpcmanagers.TopicGrpcManager
-	Err          momentoerrors.MomentoSvcErr
 }

--- a/internal/grpcmanagers/topic_manager_lists/topic_grpc_connection_pool.go
+++ b/internal/grpcmanagers/topic_manager_lists/topic_grpc_connection_pool.go
@@ -11,7 +11,8 @@ type TopicGrpcConnectionPool interface {
 	// GetNextTopicGrpcManager reserves a manager from the pool. Callers must
 	// call Reservation.Release when done; Release is idempotent so overlapping
 	// cleanup paths can each call it. Dropping a Reservation without releasing
-	// leaks the slot until Close.
+	// leaks the slot for the lifetime of the pool; Close shuts the pool down
+	// but does not reclaim leaked slots.
 	//
 	// The unary pool's Release is a no-op since unary requests don't hold
 	// long-lived slots; callers invoke it uniformly anyway.

--- a/internal/grpcmanagers/topic_manager_lists/topic_grpc_connection_pool.go
+++ b/internal/grpcmanagers/topic_manager_lists/topic_grpc_connection_pool.go
@@ -5,25 +5,24 @@ import (
 	"github.com/momentohq/client-sdk-go/internal/momentoerrors"
 )
 
-// TopicGrpcConnectionPool is the base interface for all topic grpc connection pool structs,
-// which manage a pool of grpc connections and continually provide the next available grpc stub
-// for the pubsub client to use.
+// TopicGrpcConnectionPool hands out the next available manager to the pubsub
+// client on request.
 type TopicGrpcConnectionPool interface {
-	// GetNextTopicGrpcManager returns the next available TopicGrpcManager from the pool.
-	GetNextTopicGrpcManager() (*grpcmanagers.TopicGrpcManager, momentoerrors.MomentoSvcErr)
+	// GetNextTopicGrpcManager reserves a manager from the pool. Callers must
+	// call Reservation.Release when done; Release is idempotent so overlapping
+	// cleanup paths can each call it. Dropping a Reservation without releasing
+	// leaks the slot until Close.
+	//
+	// The unary pool's Release is a no-op since unary requests don't hold
+	// long-lived slots; callers invoke it uniformly anyway.
+	GetNextTopicGrpcManager() (*Reservation, momentoerrors.MomentoSvcErr)
 
-	// ReleaseTopicGrpcManager decrements the per-channel and pool-wide subscription
-	// counters for a manager that is no longer in use, returning the new per-channel
-	// subscription count for logging. For unary pools that do not track these counters,
-	// this is a no-op that returns 0.
-	ReleaseTopicGrpcManager(manager *grpcmanagers.TopicGrpcManager) int64
-
-	// Close shuts down all the grpc connections in the pool.
+	// Close shuts down all gRPC connections in the pool.
 	Close()
 }
 
-// StreamGrpcManagerRequest is used for putting the next available stream manager on a channel for the
-// pubSubClient to pull from, or an error that specifies why no stream manager is available.
+// StreamGrpcManagerRequest is the dispatcher-to-caller envelope: either the
+// next manager or the allocation error.
 type StreamGrpcManagerRequest struct {
 	TopicManager *grpcmanagers.TopicGrpcManager
 	Err          momentoerrors.MomentoSvcErr

--- a/internal/momentoerrors/types.go
+++ b/internal/momentoerrors/types.go
@@ -42,3 +42,9 @@ func (err momentoSvcError) Error() string {
 	}
 	return fmt.Sprintf("%s: %s", err.code, err.message)
 }
+
+// Unwrap exposes the underlying cause to errors.Is/errors.As, e.g. so a
+// caller can match context.Canceled behind a CanceledError.
+func (err momentoSvcError) Unwrap() error {
+	return err.originalErr
+}

--- a/internal/momentoerrors/types_test.go
+++ b/internal/momentoerrors/types_test.go
@@ -1,0 +1,53 @@
+package momentoerrors
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func TestMomentoSvcErrorUnwrapExposesCause(t *testing.T) {
+	t.Parallel()
+
+	cause := context.Canceled
+	err := NewMomentoSvcErr(CanceledError, "subscribe context canceled", cause)
+
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("errors.Is(err, context.Canceled) = false, want true (err: %v)", err)
+	}
+
+	var svcErr MomentoSvcErr
+	if !errors.As(err, &svcErr) || svcErr.Code() != CanceledError {
+		t.Fatalf("errors.As did not recover the MomentoSvcErr (err: %v)", err)
+	}
+}
+
+func TestMomentoSvcErrorUnwrapNilCause(t *testing.T) {
+	t.Parallel()
+
+	err := NewMomentoSvcErr(TimeoutError, "no cause", nil)
+	if errors.Unwrap(err) != nil {
+		t.Fatalf("Unwrap() = %v, want nil", errors.Unwrap(err))
+	}
+}
+
+// TestConvertSvcErrUnwrapsToGrpcStatus pins the behavior change Unwrap
+// introduces in ConvertSvcErr: a MomentoSvcErr wrapping a gRPC status error
+// now re-converts by the inner status code instead of falling back to
+// ClientSdkError.
+func TestConvertSvcErrUnwrapsToGrpcStatus(t *testing.T) {
+	t.Parallel()
+
+	wrapped := NewMomentoSvcErr(ServerUnavailableError, "stream disconnected", status.Error(codes.Unavailable, "unavailable"))
+	if got := ConvertSvcErr(wrapped).Code(); got != ServerUnavailableError {
+		t.Fatalf("ConvertSvcErr(wrapped grpc status).Code() = %s, want %s", got, ServerUnavailableError)
+	}
+
+	plain := NewMomentoSvcErr(CanceledError, "subscription closed", nil)
+	if got := ConvertSvcErr(plain).Code(); got != ClientSdkError {
+		t.Fatalf("ConvertSvcErr(no-status MomentoSvcErr).Code() = %s, want %s (documented fallback)", got, ClientSdkError)
+	}
+}

--- a/momento/pubsub_client.go
+++ b/momento/pubsub_client.go
@@ -95,7 +95,7 @@ func newPubSubClient(request *models.PubSubClientRequest) (*pubSubClient, moment
 }
 
 // topicSubscribe reserves a stream slot and opens a gRPC subscribe stream
-// against it. Failures release the slot and cancel the request context
+// against it. Failures cancel the request context and release the slot
 // before returning.
 func (client *pubSubClient) topicSubscribe(ctx context.Context, request *TopicSubscribeRequest) (*streamState, error) {
 	reservation, reservationErr := client.streamGrpcConnectionPool.GetNextTopicGrpcManager()
@@ -124,8 +124,10 @@ func (client *pubSubClient) topicSubscribe(ctx context.Context, request *TopicSu
 	var header, trailer metadata.MD
 	subscribeClient, err := reservation.Manager().StreamClient.Subscribe(requestContext, subscriptionRequest)
 	if err != nil {
-		reservation.Release()
+		// Cancel before releasing, like every other cleanup path, so the
+		// stream's resources tear down before the slot is reusable.
 		cancelFunction()
+		reservation.Release()
 		if subscribeClient != nil {
 			header, _ = subscribeClient.Header()
 			trailer = subscribeClient.Trailer()

--- a/momento/pubsub_client.go
+++ b/momento/pubsub_client.go
@@ -7,7 +7,6 @@ import (
 	"github.com/momentohq/client-sdk-go/config/logger"
 	"github.com/momentohq/client-sdk-go/config/middleware"
 	"github.com/momentohq/client-sdk-go/internal"
-	"github.com/momentohq/client-sdk-go/internal/grpcmanagers"
 	"github.com/momentohq/client-sdk-go/internal/grpcmanagers/topic_manager_lists"
 	"github.com/momentohq/client-sdk-go/internal/models"
 	"github.com/momentohq/client-sdk-go/internal/momentoerrors"
@@ -95,11 +94,13 @@ func newPubSubClient(request *models.PubSubClientRequest) (*pubSubClient, moment
 	}, nil
 }
 
-func (client *pubSubClient) topicSubscribe(ctx context.Context, request *TopicSubscribeRequest) (*grpcmanagers.TopicGrpcManager, pb.Pubsub_SubscribeClient, context.Context, context.CancelFunc, error) {
-	// Get the next available grpc manager
-	topicManager, topicManagerErr := client.streamGrpcConnectionPool.GetNextTopicGrpcManager()
-	if topicManagerErr != nil {
-		return nil, nil, nil, nil, topicManagerErr
+// topicSubscribe reserves a stream slot and opens a gRPC subscribe stream
+// against it. Failures release the slot and cancel the request context
+// before returning.
+func (client *pubSubClient) topicSubscribe(ctx context.Context, request *TopicSubscribeRequest) (*streamState, error) {
+	reservation, reservationErr := client.streamGrpcConnectionPool.GetNextTopicGrpcManager()
+	if reservationErr != nil {
+		return nil, reservationErr
 	}
 
 	subscriptionRequest := &pb.XSubscriptionRequest{
@@ -117,24 +118,27 @@ func (client *pubSubClient) topicSubscribe(ctx context.Context, request *TopicSu
 		}
 	}
 
-	// add withCancel to context
 	cancelContext, cancelFunction := context.WithCancel(ctx)
 	requestContext := internal.CreateTopicRequestContextFromMetadataMap(cancelContext, request.CacheName, requestMetadata)
 
 	var header, trailer metadata.MD
-	subscribeClient, err := topicManager.StreamClient.Subscribe(requestContext, subscriptionRequest)
-
+	subscribeClient, err := reservation.Manager().StreamClient.Subscribe(requestContext, subscriptionRequest)
 	if err != nil {
-		client.streamGrpcConnectionPool.ReleaseTopicGrpcManager(topicManager)
+		reservation.Release()
 		cancelFunction()
 		if subscribeClient != nil {
 			header, _ = subscribeClient.Header()
 			trailer = subscribeClient.Trailer()
 		}
-		return nil, nil, nil, nil, momentoerrors.ConvertSvcErr(err, header, trailer)
+		return nil, momentoerrors.ConvertSvcErr(err, header, trailer)
 	}
 
-	return topicManager, subscribeClient, cancelContext, cancelFunction, err
+	return &streamState{
+		reservation:     reservation,
+		subscribeClient: subscribeClient,
+		cancelContext:   cancelContext,
+		cancelFunction:  cancelFunction,
+	}, nil
 }
 
 func (client *pubSubClient) topicPublish(ctx context.Context, request *TopicPublishRequest) error {
@@ -150,10 +154,13 @@ func (client *pubSubClient) topicPublish(ctx context.Context, request *TopicPubl
 	}
 
 	requestContext := internal.CreateTopicRequestContextFromMetadataMap(ctx, request.CacheName, requestMetadata)
-	topicManager, err := client.unaryGrpcConnectionPool.GetNextTopicGrpcManager()
+	reservation, err := client.unaryGrpcConnectionPool.GetNextTopicGrpcManager()
 	if err != nil {
 		return err
 	}
+	// Release is a no-op for the unary pool; called for contract uniformity.
+	defer reservation.Release()
+	topicManager := reservation.Manager()
 	var header, trailer metadata.MD
 	switch value := request.Value.(type) {
 	case String:

--- a/momento/topic_client.go
+++ b/momento/topic_client.go
@@ -26,8 +26,11 @@ type TopicClient interface {
 	//
 	// The ctx bounds the subscription's lifetime, not just the Subscribe call:
 	// the underlying stream — including any stream re-established by the
-	// automatic reconnect logic — is a child of this ctx, so cancelling it
-	// ends the subscription and releases its connection-pool slot.
+	// automatic reconnect logic — is a child of this ctx. Cancelling it ends
+	// the subscription: a blocked or subsequent Item/Event call returns an
+	// error and releases the subscription's connection-pool slot. If no
+	// Item/Event call runs after cancellation, call Close (idempotent) to
+	// release the slot.
 	Subscribe(ctx context.Context, request *TopicSubscribeRequest) (TopicSubscription, error)
 	Publish(ctx context.Context, request *TopicPublishRequest) (responses.TopicPublishResponse, error)
 

--- a/momento/topic_client.go
+++ b/momento/topic_client.go
@@ -22,6 +22,12 @@ import (
 )
 
 type TopicClient interface {
+	// Subscribe starts a subscription on the given topic.
+	//
+	// The ctx bounds the subscription's lifetime, not just the Subscribe call:
+	// the underlying stream — including any stream re-established by the
+	// automatic reconnect logic — is a child of this ctx, so cancelling it
+	// ends the subscription and releases its connection-pool slot.
 	Subscribe(ctx context.Context, request *TopicSubscribeRequest) (TopicSubscription, error)
 	Publish(ctx context.Context, request *TopicPublishRequest) (responses.TopicPublishResponse, error)
 
@@ -89,7 +95,7 @@ func (c defaultTopicClient) Subscribe(ctx context.Context, request *TopicSubscri
 		return nil, momentoerrors.NewMomentoSvcErr(
 			momentoerrors.CanceledError,
 			"subscribe request context was canceled",
-			nil,
+			ctx.Err(),
 		)
 	case <-firstMessageCtx.Done():
 		return nil, momentoerrors.NewMomentoSvcErr(

--- a/momento/topic_client.go
+++ b/momento/topic_client.go
@@ -83,8 +83,6 @@ func (c defaultTopicClient) Subscribe(ctx context.Context, request *TopicSubscri
 	subChan := make(chan *topicSubscription, 1)
 	errChan := make(chan error, 1)
 
-	// Send the subscribe request in a separate goroutine to avoid blocking the main thread.
-	// Here, we'll block until one of the select cases is triggered.
 	go c.sendSubscribe(ctx, request, subChan, errChan)
 	select {
 	case <-ctx.Done():
@@ -107,8 +105,7 @@ func (c defaultTopicClient) Subscribe(ctx context.Context, request *TopicSubscri
 }
 
 func (c defaultTopicClient) sendSubscribe(requestCtx context.Context, request *TopicSubscribeRequest, subChan chan *topicSubscription, errChan chan error) {
-	var firstMsg *pb.XSubscriptionItem
-	topicManager, subscribeClient, cancelContext, cancelFunction, err := c.pubSubClient.topicSubscribe(requestCtx, &TopicSubscribeRequest{
+	state, err := c.pubSubClient.topicSubscribe(requestCtx, &TopicSubscribeRequest{
 		CacheName:                   request.CacheName,
 		TopicName:                   request.TopicName,
 		ResumeAtTopicSequenceNumber: request.ResumeAtTopicSequenceNumber,
@@ -125,23 +122,27 @@ func (c defaultTopicClient) sendSubscribe(requestCtx context.Context, request *T
 		c.log.Debug("Resuming subscription from sequence number %d and sequence page %d.", request.ResumeAtTopicSequenceNumber, request.SequencePage)
 	}
 
-	// Ping the stream to provide a nice error message if the cache does not exist.
-	firstMsg, err = subscribeClient.Recv()
+	// Single cleanup path: cancel, release, report.
+	fail := func(err error) {
+		state.cancelFunction()
+		state.reservation.Release()
+		errChan <- err
+	}
+
+	// Ping the stream to surface a nice error if the cache does not exist.
+	firstMsg, err := state.subscribeClient.Recv()
 	if err != nil {
 		c.log.Debug("failed to receive first message from subscription: %s", err.Error())
 
-		// We now count number of active subscriptions per grpc channel, so if we did not return
-		// an error earlier when calling c.pubSubClient.topicSubscribe, we know that the error
-		// here is due to a service-side subscription limit.
+		// topicSubscribe would have errored already if the local pool was
+		// exhausted, so a ResourceExhausted here is a service-side limit.
 		rpcError, _ := status.FromError(err)
 		if rpcError != nil {
 			if rpcError.Code() == codes.ResourceExhausted {
 				c.log.Warn("Topic subscription limit reached for this account; please contact us at support@momentohq.com")
 			}
 		}
-		cancelFunction()
-		c.pubSubClient.streamGrpcConnectionPool.ReleaseTopicGrpcManager(topicManager)
-		errChan <- momentoerrors.ConvertSvcErr(err)
+		fail(momentoerrors.ConvertSvcErr(err))
 		return
 	}
 
@@ -149,13 +150,11 @@ func (c defaultTopicClient) sendSubscribe(requestCtx context.Context, request *T
 	case *pb.XSubscriptionItem_Heartbeat:
 		// The first message to a new subscription will always be a heartbeat.
 	default:
-		cancelFunction()
-		c.pubSubClient.streamGrpcConnectionPool.ReleaseTopicGrpcManager(topicManager)
-		errChan <- momentoerrors.NewMomentoSvcErr(
+		fail(momentoerrors.NewMomentoSvcErr(
 			momentoerrors.InternalServerError,
 			fmt.Sprintf("expected a heartbeat message, got: %T", firstMsg.Kind),
 			err,
-		)
+		))
 		return
 	}
 
@@ -168,18 +167,16 @@ func (c defaultTopicClient) sendSubscribe(requestCtx context.Context, request *T
 			break
 		}
 	}
-	subChan <- &topicSubscription{
-		topicManager:       topicManager,
+	sub := &topicSubscription{
 		topicEventCallback: topicEventCallback,
-		subscribeClient:    subscribeClient,
 		momentoTopicClient: c.pubSubClient,
 		cacheName:          request.CacheName,
 		topicName:          request.TopicName,
 		log:                c.log,
-		cancelContext:      cancelContext,
-		cancelFunction:     cancelFunction,
 		retryStrategy:      c.retryStrategy,
 	}
+	sub.state.Store(state)
+	subChan <- sub
 }
 
 func (c defaultTopicClient) Publish(ctx context.Context, request *TopicPublishRequest) (responses.TopicPublishResponse, error) {

--- a/momento/topic_client.go
+++ b/momento/topic_client.go
@@ -174,6 +174,8 @@ func (c defaultTopicClient) sendSubscribe(requestCtx context.Context, request *T
 		topicName:          request.TopicName,
 		log:                c.log,
 		retryStrategy:      c.retryStrategy,
+		streamParentCtx:    requestCtx,
+		closedSignal:       make(chan struct{}),
 	}
 	sub.state.Store(state)
 	subChan <- sub

--- a/momento/topic_client_test.go
+++ b/momento/topic_client_test.go
@@ -2,6 +2,7 @@ package momento_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -343,10 +344,12 @@ var _ = Describe("topic-client", Label(TOPICS_SERVICE_LABEL), func() {
 			panic(err)
 		}
 
-		// expect one Item() success and one failure
+		// expect one Item() success and one failure: the closed subscription
+		// returns a typed CanceledError that unwraps to context.Canceled
 		item, err = sub1.Item(sharedContext.Ctx)
 		Expect(item).To(BeNil())
-		Expect(err.Error()).To(Equal("context canceled"))
+		Expect(err).To(HaveMomentoErrorCode(CanceledError))
+		Expect(errors.Is(err, context.Canceled)).To(BeTrue())
 
 		item, err = sub2.Item(sharedContext.Ctx)
 		if err != nil {

--- a/momento/topic_client_test.go
+++ b/momento/topic_client_test.go
@@ -58,6 +58,7 @@ var _ = Describe("topic-client", Label(TOPICS_SERVICE_LABEL), func() {
 		if err != nil {
 			panic(err)
 		}
+		defer sub.Close()
 
 		cancelContext, cancelFunction := context.WithCancel(sharedContext.Ctx)
 		var receivedValues []TopicValue
@@ -135,6 +136,7 @@ var _ = Describe("topic-client", Label(TOPICS_SERVICE_LABEL), func() {
 		if err != nil {
 			panic(err)
 		}
+		defer sub.Close()
 
 		cancelContext, cancelFunction := context.WithCancel(sharedContext.Ctx)
 		var receivedItems []TopicEvent
@@ -211,6 +213,7 @@ var _ = Describe("topic-client", Label(TOPICS_SERVICE_LABEL), func() {
 			CacheName: sharedContext.CacheName,
 			TopicName: topicName,
 		})
+		defer sub.Close()
 
 		// immediately cancel the context
 		ctx, cancel := context.WithCancel(context.Background())
@@ -250,12 +253,12 @@ var _ = Describe("topic-client", Label(TOPICS_SERVICE_LABEL), func() {
 
 	Describe(`Subscribe`, func() {
 		It(`Does not error on a non-existent topic`, func() {
-			Expect(
-				sharedContext.TopicClient.Subscribe(sharedContext.Ctx, &TopicSubscribeRequest{
-					CacheName: sharedContext.CacheName,
-					TopicName: topicName,
-				}),
-			).Error().NotTo(HaveOccurred())
+			sub, err := sharedContext.TopicClient.Subscribe(sharedContext.Ctx, &TopicSubscribeRequest{
+				CacheName: sharedContext.CacheName,
+				TopicName: topicName,
+			})
+			Expect(err).NotTo(HaveOccurred())
+			sub.Close()
 		})
 	})
 
@@ -280,6 +283,7 @@ var _ = Describe("topic-client", Label(TOPICS_SERVICE_LABEL), func() {
 		if err != nil {
 			panic(err)
 		}
+		defer sub2.Close()
 
 		// publish messages to both
 		_, err = sharedContext.TopicClient.Publish(sharedContext.Ctx, &TopicPublishRequest{

--- a/momento/topic_manager_test.go
+++ b/momento/topic_manager_test.go
@@ -56,6 +56,8 @@ var _ = Describe("retry topic-grpc-managers", Label(RETRY_LABEL, MOMENTO_LOCAL_L
 		}
 	})
 
+	// These specs leak reservations on purpose: they fill the pool to assert
+	// its accounting. The pool is torn down via Close() at the end of each spec.
 	Describe("StaticStreamManagerList", func() {
 		It("Get one new stream at a time until max concurrent streams reached", func() {
 			numGrpcChannels := uint32(2)
@@ -72,7 +74,7 @@ var _ = Describe("retry topic-grpc-managers", Label(RETRY_LABEL, MOMENTO_LOCAL_L
 				Expect(err).ToNot(HaveOccurred())
 				Expect(streamManager).NotTo(BeNil())
 
-				subscribeClient, subscribeErr := streamManager.StreamClient.Subscribe(ctx, subscriptionRequest)
+				subscribeClient, subscribeErr := streamManager.Manager().StreamClient.Subscribe(ctx, subscriptionRequest)
 				Expect(subscribeErr).ToNot(HaveOccurred())
 				Expect(subscribeClient).NotTo(BeNil())
 
@@ -137,7 +139,7 @@ var _ = Describe("retry topic-grpc-managers", Label(RETRY_LABEL, MOMENTO_LOCAL_L
 					Expect(err).ToNot(HaveOccurred())
 					Expect(streamManager).NotTo(BeNil())
 
-					subscribeClient, subscribeErr := streamManager.StreamClient.Subscribe(ctx, subscriptionRequest)
+					subscribeClient, subscribeErr := streamManager.Manager().StreamClient.Subscribe(ctx, subscriptionRequest)
 					Expect(subscribeErr).ToNot(HaveOccurred())
 					Expect(subscribeClient).NotTo(BeNil())
 
@@ -197,7 +199,7 @@ var _ = Describe("retry topic-grpc-managers", Label(RETRY_LABEL, MOMENTO_LOCAL_L
 					Expect(err).ToNot(HaveOccurred())
 					Expect(streamManager).NotTo(BeNil())
 
-					subscribeClient, subscribeErr := streamManager.StreamClient.Subscribe(ctx, subscriptionRequest)
+					subscribeClient, subscribeErr := streamManager.Manager().StreamClient.Subscribe(ctx, subscriptionRequest)
 					Expect(subscribeErr).ToNot(HaveOccurred())
 					Expect(subscribeClient).NotTo(BeNil())
 
@@ -260,7 +262,7 @@ var _ = Describe("retry topic-grpc-managers", Label(RETRY_LABEL, MOMENTO_LOCAL_L
 					} else {
 						Expect(streamManager).NotTo(BeNil())
 
-						subscribeClient, subscribeErr := streamManager.StreamClient.Subscribe(ctx, subscriptionRequest)
+						subscribeClient, subscribeErr := streamManager.Manager().StreamClient.Subscribe(ctx, subscriptionRequest)
 						Expect(subscribeErr).ToNot(HaveOccurred())
 						Expect(subscribeClient).NotTo(BeNil())
 
@@ -324,7 +326,7 @@ var _ = Describe("retry topic-grpc-managers", Label(RETRY_LABEL, MOMENTO_LOCAL_L
 				Expect(err).ToNot(HaveOccurred())
 				Expect(streamManager).NotTo(BeNil())
 
-				subscribeClient, subscribeErr := streamManager.StreamClient.Subscribe(ctx, subscriptionRequest)
+				subscribeClient, subscribeErr := streamManager.Manager().StreamClient.Subscribe(ctx, subscriptionRequest)
 				Expect(subscribeErr).ToNot(HaveOccurred())
 				Expect(subscribeClient).NotTo(BeNil())
 
@@ -395,7 +397,7 @@ var _ = Describe("retry topic-grpc-managers", Label(RETRY_LABEL, MOMENTO_LOCAL_L
 					Expect(err).ToNot(HaveOccurred())
 					Expect(streamManager).NotTo(BeNil())
 
-					subscribeClient, subscribeErr := streamManager.StreamClient.Subscribe(ctx, subscriptionRequest)
+					subscribeClient, subscribeErr := streamManager.Manager().StreamClient.Subscribe(ctx, subscriptionRequest)
 					Expect(subscribeErr).ToNot(HaveOccurred())
 					Expect(subscribeClient).NotTo(BeNil())
 
@@ -461,7 +463,7 @@ var _ = Describe("retry topic-grpc-managers", Label(RETRY_LABEL, MOMENTO_LOCAL_L
 						Expect(err).ToNot(HaveOccurred())
 						Expect(streamManager).NotTo(BeNil())
 
-						subscribeClient, subscribeErr := streamManager.StreamClient.Subscribe(ctx, subscriptionRequest)
+						subscribeClient, subscribeErr := streamManager.Manager().StreamClient.Subscribe(ctx, subscriptionRequest)
 						Expect(subscribeErr).ToNot(HaveOccurred())
 						Expect(subscribeClient).NotTo(BeNil())
 
@@ -535,7 +537,7 @@ var _ = Describe("retry topic-grpc-managers", Label(RETRY_LABEL, MOMENTO_LOCAL_L
 						} else {
 							Expect(streamManager).NotTo(BeNil())
 
-							subscribeClient, subscribeErr := streamManager.StreamClient.Subscribe(ctx, subscriptionRequest)
+							subscribeClient, subscribeErr := streamManager.Manager().StreamClient.Subscribe(ctx, subscriptionRequest)
 							Expect(subscribeErr).ToNot(HaveOccurred())
 							Expect(subscribeClient).NotTo(BeNil())
 

--- a/momento/topic_manager_test.go
+++ b/momento/topic_manager_test.go
@@ -139,119 +139,36 @@ var _ = Describe("retry topic-grpc-managers", Label(RETRY_LABEL, MOMENTO_LOCAL_L
 			waitGroup.Wait()
 		})
 
-		It("Starts a burst of streams < max concurrent streams", func() {
-			numGrpcChannels := uint32(2)
-			maxConcurrentStreams := numGrpcChannels * uint32(config.MAX_CONCURRENT_STREAMS_PER_CHANNEL)
-			staticPool, err := topic_manager_lists.NewStaticStreamGrpcManagerPool(grpcManagerRequest, numGrpcChannels, log)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(staticPool).NotTo(BeNil())
+		// The three burst variants share one body; each Entry supplies the
+		// burst size and whether the pool may refuse reservations. The expected
+		// final count is the burst size capped at pool capacity — exactly one
+		// slot per successful reservation.
+		DescribeTable("Starts a burst of streams",
+			func(burstSize int, allowExhausted bool) {
+				numGrpcChannels := uint32(2)
+				maxConcurrentStreams := numGrpcChannels * uint32(config.MAX_CONCURRENT_STREAMS_PER_CHANNEL)
+				staticPool, err := topic_manager_lists.NewStaticStreamGrpcManagerPool(grpcManagerRequest, numGrpcChannels, log)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(staticPool).NotTo(BeNil())
 
-			// Start a burst of streams to occupy just under half the max concurrent stream capacity.
-			// Shadow the shared ctx so this spec owns its streams' lifetime and
-			// can wait out its keep-alive goroutines before the next spec runs.
-			ctx, cancel := context.WithCancel(ctx)
-			streamsWaitGroup := sync.WaitGroup{}
-			waitGroup := sync.WaitGroup{}
-			for i := 0; i < int(maxConcurrentStreams/2-1); i++ {
-				waitGroup.Add(1)
-				go func() {
-					defer GinkgoRecover()
-					defer waitGroup.Done()
-					reservation, err := staticPool.GetNextTopicGrpcManager()
-					Expect(err).ToNot(HaveOccurred())
-					Expect(reservation).NotTo(BeNil())
-
-					subscribeClient, subscribeErr := reservation.Manager().StreamClient.Subscribe(ctx, subscriptionRequest)
-					Expect(subscribeErr).ToNot(HaveOccurred())
-					Expect(subscribeClient).NotTo(BeNil())
-
-					// keep the stream alive until the spec tears down
-					keepStreamAlive(ctx, subscribeClient, &streamsWaitGroup)
-				}()
-			}
-
-			// Wait for the burst to complete.
-			waitGroup.Wait()
-
-			// Allow time for all streams to be established
-			time.Sleep(500 * time.Millisecond)
-
-			// Verify correct number of streams are active.
-			Expect(staticPool.GetCurrentActiveStreamsCount()).To(Equal(uint64(maxConcurrentStreams/2 - 1)))
-
-			staticPool.Close()
-			cancel()
-			streamsWaitGroup.Wait()
-		})
-
-		It("Starts a burst of streams == max concurrent streams", func() {
-			numGrpcChannels := uint32(2)
-			maxConcurrentStreams := numGrpcChannels * uint32(config.MAX_CONCURRENT_STREAMS_PER_CHANNEL)
-			staticPool, err := topic_manager_lists.NewStaticStreamGrpcManagerPool(grpcManagerRequest, numGrpcChannels, log)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(staticPool).NotTo(BeNil())
-
-			// Start a burst of streams to occupy the max concurrent stream capacity.
-			// Shadow the shared ctx so this spec owns its streams' lifetime and
-			// can wait out its keep-alive goroutines before the next spec runs.
-			ctx, cancel := context.WithCancel(ctx)
-			streamsWaitGroup := sync.WaitGroup{}
-			waitGroup := sync.WaitGroup{}
-			for i := 0; i < int(maxConcurrentStreams); i++ {
-				waitGroup.Add(1)
-				go func() {
-					defer GinkgoRecover()
-					defer waitGroup.Done()
-					reservation, err := staticPool.GetNextTopicGrpcManager()
-					Expect(err).ToNot(HaveOccurred())
-					Expect(reservation).NotTo(BeNil())
-
-					subscribeClient, subscribeErr := reservation.Manager().StreamClient.Subscribe(ctx, subscriptionRequest)
-					Expect(subscribeErr).ToNot(HaveOccurred())
-					Expect(subscribeClient).NotTo(BeNil())
-
-					// keep the stream alive until the spec tears down
-					keepStreamAlive(ctx, subscribeClient, &streamsWaitGroup)
-				}()
-			}
-
-			// Wait for the burst to complete.
-			waitGroup.Wait()
-
-			// Allow time for all streams to be established
-			time.Sleep(500 * time.Millisecond)
-
-			// Verify correct number of streams are active.
-			Expect(staticPool.GetCurrentActiveStreamsCount()).To(Equal(uint64(maxConcurrentStreams)))
-
-			staticPool.Close()
-			cancel()
-			streamsWaitGroup.Wait()
-		})
-
-		It("Starts a burst of streams > max concurrent streams", func() {
-			numGrpcChannels := uint32(2)
-			maxConcurrentStreams := numGrpcChannels * uint32(config.MAX_CONCURRENT_STREAMS_PER_CHANNEL)
-			staticPool, err := topic_manager_lists.NewStaticStreamGrpcManagerPool(grpcManagerRequest, numGrpcChannels, log)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(staticPool).NotTo(BeNil())
-
-			// Start a burst of streams for 10 greater than the max concurrent stream capacity.
-			// Shadow the shared ctx so this spec owns its streams' lifetime and
-			// can wait out its keep-alive goroutines before the next spec runs.
-			ctx, cancel := context.WithCancel(ctx)
-			streamsWaitGroup := sync.WaitGroup{}
-			waitGroup := sync.WaitGroup{}
-			for i := 0; i < int(maxConcurrentStreams+10); i++ {
-				waitGroup.Add(1)
-				go func() {
-					defer GinkgoRecover()
-					defer waitGroup.Done()
-
-					reservation, err := staticPool.GetNextTopicGrpcManager()
-					if err != nil {
-						Expect(err.Error()).To(ContainSubstring("ClientResourceExhaustedError"))
-					} else {
+				// Shadow the shared ctx so this spec owns its streams' lifetime and
+				// can wait out its keep-alive goroutines before the next spec runs.
+				ctx, cancel := context.WithCancel(ctx)
+				streamsWaitGroup := sync.WaitGroup{}
+				waitGroup := sync.WaitGroup{}
+				for i := 0; i < burstSize; i++ {
+					waitGroup.Add(1)
+					go func() {
+						defer GinkgoRecover()
+						defer waitGroup.Done()
+						reservation, err := staticPool.GetNextTopicGrpcManager()
+						if err != nil {
+							// Only the over-capacity burst may be refused, and only
+							// with ResourceExhausted.
+							Expect(allowExhausted).To(BeTrue(), "unexpected reservation failure: %v", err)
+							Expect(err.Error()).To(ContainSubstring("ClientResourceExhaustedError"))
+							return
+						}
 						Expect(reservation).NotTo(BeNil())
 
 						subscribeClient, subscribeErr := reservation.Manager().StreamClient.Subscribe(ctx, subscriptionRequest)
@@ -260,23 +177,29 @@ var _ = Describe("retry topic-grpc-managers", Label(RETRY_LABEL, MOMENTO_LOCAL_L
 
 						// keep the stream alive until the spec tears down
 						keepStreamAlive(ctx, subscribeClient, &streamsWaitGroup)
-					}
-				}()
-			}
+					}()
+				}
 
-			// Wait for the burst to complete.
-			waitGroup.Wait()
+				// Wait for the burst to complete.
+				waitGroup.Wait()
 
-			// Allow time for all streams to be established
-			time.Sleep(500 * time.Millisecond)
+				// Allow time for all streams to be established
+				time.Sleep(500 * time.Millisecond)
 
-			// Verify correct number of streams are active.
-			Expect(staticPool.GetCurrentActiveStreamsCount()).To(Equal(uint64(maxConcurrentStreams)))
+				expected := uint64(burstSize)
+				if burstSize > int(maxConcurrentStreams) {
+					expected = uint64(maxConcurrentStreams)
+				}
+				Expect(staticPool.GetCurrentActiveStreamsCount()).To(Equal(expected))
 
-			staticPool.Close()
-			cancel()
-			streamsWaitGroup.Wait()
-		})
+				staticPool.Close()
+				cancel()
+				streamsWaitGroup.Wait()
+			},
+			Entry("to just under half capacity", config.MAX_CONCURRENT_STREAMS_PER_CHANNEL-1, false),
+			Entry("to exactly full capacity", 2*config.MAX_CONCURRENT_STREAMS_PER_CHANNEL, false),
+			Entry("to 10 past capacity", 2*config.MAX_CONCURRENT_STREAMS_PER_CHANNEL+10, true),
+		)
 	})
 
 	Describe("DynamicStreamManagerList", func() {

--- a/momento/topic_manager_test.go
+++ b/momento/topic_manager_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"os"
 	"strconv"
-	"strings"
 	"sync"
 	"time"
 
@@ -19,6 +18,8 @@ import (
 	. "github.com/momentohq/client-sdk-go/momento"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 var (
@@ -44,10 +45,11 @@ func keepStreamAlive(ctx context.Context, subscribeClient pb.Pubsub_SubscribeCli
 			default:
 				item, err := subscribeClient.Recv()
 				if err != nil {
-					// The test is ending: the pool closed the connection or the
-					// spec canceled its context.
-					if strings.Contains(err.Error(), "the client connection is closing") ||
-						strings.Contains(err.Error(), "context canceled") {
+					// The test is ending: pool Close and spec ctx cancellation
+					// both surface from Recv as a Canceled status. Match the
+					// code, not grpc-go's message strings, so a wording change
+					// upstream can't fail the spec.
+					if status.Code(err) == codes.Canceled {
 						return
 					}
 					Expect(err).ToNot(HaveOccurred())

--- a/momento/topic_manager_test.go
+++ b/momento/topic_manager_test.go
@@ -2,6 +2,8 @@ package momento_test
 
 import (
 	"context"
+	"os"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -33,7 +35,14 @@ var _ = Describe("retry topic-grpc-managers", Label(RETRY_LABEL, MOMENTO_LOCAL_L
 
 		logFactory := momento_default_logger.NewDefaultMomentoLoggerFactory(momento_default_logger.WARN)
 		log = logFactory.GetLogger("grpcmanagers-test")
-		credProvider, err := auth.NewMomentoLocalProvider(&auth.MomentoLocalConfig{Port: uint(8080)})
+		// Same env override as retry_test.go so the port is not hardcoded.
+		momentoLocalPort := os.Getenv("MOMENTO_PORT")
+		if momentoLocalPort == "" {
+			momentoLocalPort = "8080"
+		}
+		thePort, portErr := strconv.ParseUint(momentoLocalPort, 10, 32)
+		Expect(portErr).To(BeNil())
+		credProvider, err := auth.NewMomentoLocalProvider(&auth.MomentoLocalConfig{Port: uint(thePort)})
 		Expect(err).ToNot(HaveOccurred())
 
 		cacheName := uuid.New().String()
@@ -81,6 +90,7 @@ var _ = Describe("retry topic-grpc-managers", Label(RETRY_LABEL, MOMENTO_LOCAL_L
 				// keep the stream alive until end of test using a goroutine
 				waitGroup.Add(1)
 				go func() {
+					defer GinkgoRecover()
 					defer waitGroup.Done()
 					for {
 						select {
@@ -134,6 +144,7 @@ var _ = Describe("retry topic-grpc-managers", Label(RETRY_LABEL, MOMENTO_LOCAL_L
 			for i := 0; i < int(maxConcurrentStreams/2-1); i++ {
 				waitGroup.Add(1)
 				go func() {
+					defer GinkgoRecover()
 					defer waitGroup.Done()
 					streamManager, err := staticList.GetNextTopicGrpcManager()
 					Expect(err).ToNot(HaveOccurred())
@@ -145,6 +156,7 @@ var _ = Describe("retry topic-grpc-managers", Label(RETRY_LABEL, MOMENTO_LOCAL_L
 
 					// keep the stream alive using a goroutine
 					go func() {
+						defer GinkgoRecover()
 						for {
 							select {
 							case <-ctx.Done():
@@ -177,7 +189,7 @@ var _ = Describe("retry topic-grpc-managers", Label(RETRY_LABEL, MOMENTO_LOCAL_L
 			time.Sleep(500 * time.Millisecond)
 
 			// Verify correct number of streams are active.
-			Expect(staticList.GetCurrentActiveStreamsCount()).To(Equal(uint64(maxConcurrentStreams / 2)))
+			Expect(staticList.GetCurrentActiveStreamsCount()).To(Equal(uint64(maxConcurrentStreams/2 - 1)))
 
 			staticList.Close()
 		})
@@ -194,6 +206,7 @@ var _ = Describe("retry topic-grpc-managers", Label(RETRY_LABEL, MOMENTO_LOCAL_L
 			for i := 0; i < int(maxConcurrentStreams); i++ {
 				waitGroup.Add(1)
 				go func() {
+					defer GinkgoRecover()
 					defer waitGroup.Done()
 					streamManager, err := staticList.GetNextTopicGrpcManager()
 					Expect(err).ToNot(HaveOccurred())
@@ -205,6 +218,7 @@ var _ = Describe("retry topic-grpc-managers", Label(RETRY_LABEL, MOMENTO_LOCAL_L
 
 					// keep the stream alive using a goroutine
 					go func() {
+						defer GinkgoRecover()
 						for {
 							select {
 							case <-ctx.Done():
@@ -254,6 +268,7 @@ var _ = Describe("retry topic-grpc-managers", Label(RETRY_LABEL, MOMENTO_LOCAL_L
 			for i := 0; i < int(maxConcurrentStreams+10); i++ {
 				waitGroup.Add(1)
 				go func() {
+					defer GinkgoRecover()
 					defer waitGroup.Done()
 
 					streamManager, err := staticList.GetNextTopicGrpcManager()
@@ -268,6 +283,7 @@ var _ = Describe("retry topic-grpc-managers", Label(RETRY_LABEL, MOMENTO_LOCAL_L
 
 						// keep the stream alive using a goroutine
 						go func() {
+							defer GinkgoRecover()
 							for {
 								select {
 								case <-ctx.Done():
@@ -333,6 +349,7 @@ var _ = Describe("retry topic-grpc-managers", Label(RETRY_LABEL, MOMENTO_LOCAL_L
 				// keep the stream alive using a goroutine
 				waitGroup.Add(1)
 				go func() {
+					defer GinkgoRecover()
 					defer waitGroup.Done()
 					for {
 						select {
@@ -392,6 +409,7 @@ var _ = Describe("retry topic-grpc-managers", Label(RETRY_LABEL, MOMENTO_LOCAL_L
 			for i := 0; i < int(maxConcurrentStreams/2-1); i++ {
 				waitGroup.Add(1)
 				go func() {
+					defer GinkgoRecover()
 					defer waitGroup.Done()
 					streamManager, err := dynamicList.GetNextTopicGrpcManager()
 					Expect(err).ToNot(HaveOccurred())
@@ -403,6 +421,7 @@ var _ = Describe("retry topic-grpc-managers", Label(RETRY_LABEL, MOMENTO_LOCAL_L
 
 					// keep the stream alive using a goroutine
 					go func() {
+						defer GinkgoRecover()
 						for {
 							select {
 							case <-ctx.Done():
@@ -438,7 +457,7 @@ var _ = Describe("retry topic-grpc-managers", Label(RETRY_LABEL, MOMENTO_LOCAL_L
 			Expect(dynamicList.GetCurrentNumberOfGrpcManagers()).To(Equal(1))
 
 			// Verify correct number of streams are active.
-			Expect(dynamicList.GetCurrentActiveStreamsCount()).To(Equal(uint64(maxConcurrentStreams / 2)))
+			Expect(dynamicList.GetCurrentActiveStreamsCount()).To(Equal(uint64(maxConcurrentStreams/2 - 1)))
 
 			dynamicList.Close()
 		})
@@ -458,6 +477,7 @@ var _ = Describe("retry topic-grpc-managers", Label(RETRY_LABEL, MOMENTO_LOCAL_L
 				for i := 0; i < int(maxConcurrentStreams); i++ {
 					waitGroup.Add(1)
 					go func() {
+						defer GinkgoRecover()
 						defer waitGroup.Done()
 						streamManager, err := dynamicList.GetNextTopicGrpcManager()
 						Expect(err).ToNot(HaveOccurred())
@@ -469,6 +489,7 @@ var _ = Describe("retry topic-grpc-managers", Label(RETRY_LABEL, MOMENTO_LOCAL_L
 
 						// keep the stream alive using a goroutine
 						go func() {
+							defer GinkgoRecover()
 							for {
 								select {
 								case <-ctx.Done():
@@ -529,6 +550,7 @@ var _ = Describe("retry topic-grpc-managers", Label(RETRY_LABEL, MOMENTO_LOCAL_L
 				for i := 0; i < int(maxConcurrentStreams+10); i++ {
 					waitGroup.Add(1)
 					go func() {
+						defer GinkgoRecover()
 						defer waitGroup.Done()
 
 						streamManager, err := dynamicList.GetNextTopicGrpcManager()
@@ -543,6 +565,7 @@ var _ = Describe("retry topic-grpc-managers", Label(RETRY_LABEL, MOMENTO_LOCAL_L
 
 							// keep the stream alive using a goroutine
 							go func() {
+								defer GinkgoRecover()
 								for {
 									select {
 									case <-ctx.Done():

--- a/momento/topic_manager_test.go
+++ b/momento/topic_manager_test.go
@@ -101,19 +101,19 @@ var _ = Describe("retry topic-grpc-managers", Label(RETRY_LABEL, MOMENTO_LOCAL_L
 		It("Get one new stream at a time until max concurrent streams reached", func() {
 			numGrpcChannels := uint32(2)
 			maxConcurrentStreams := numGrpcChannels * uint32(config.MAX_CONCURRENT_STREAMS_PER_CHANNEL)
-			staticList, err := topic_manager_lists.NewStaticStreamGrpcManagerPool(grpcManagerRequest, numGrpcChannels, log)
+			staticPool, err := topic_manager_lists.NewStaticStreamGrpcManagerPool(grpcManagerRequest, numGrpcChannels, log)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(staticList).NotTo(BeNil())
+			Expect(staticPool).NotTo(BeNil())
 
 			// Get one new stream at a time until max concurrent streams reached.
 			ctx, cancel := context.WithCancel(ctx)
 			waitGroup := sync.WaitGroup{}
 			for i := 0; i < int(maxConcurrentStreams); i++ {
-				streamManager, err := staticList.GetNextTopicGrpcManager()
+				reservation, err := staticPool.GetNextTopicGrpcManager()
 				Expect(err).ToNot(HaveOccurred())
-				Expect(streamManager).NotTo(BeNil())
+				Expect(reservation).NotTo(BeNil())
 
-				subscribeClient, subscribeErr := streamManager.Manager().StreamClient.Subscribe(ctx, subscriptionRequest)
+				subscribeClient, subscribeErr := reservation.Manager().StreamClient.Subscribe(ctx, subscriptionRequest)
 				Expect(subscribeErr).ToNot(HaveOccurred())
 				Expect(subscribeClient).NotTo(BeNil())
 
@@ -124,15 +124,15 @@ var _ = Describe("retry topic-grpc-managers", Label(RETRY_LABEL, MOMENTO_LOCAL_L
 			time.Sleep(500 * time.Millisecond)
 
 			// Verify all managers are full of active subscriptions
-			Expect(staticList.GetCurrentActiveStreamsCount()).To(Equal(uint64(maxConcurrentStreams)))
+			Expect(staticPool.GetCurrentActiveStreamsCount()).To(Equal(uint64(maxConcurrentStreams)))
 
 			// Get one more stream and expect an error.
-			stream, err := staticList.GetNextTopicGrpcManager()
+			stream, err := staticPool.GetNextTopicGrpcManager()
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("ClientResourceExhaustedError"))
 			Expect(stream).To(BeNil())
 
-			staticList.Close()
+			staticPool.Close()
 			cancel()
 			waitGroup.Wait()
 		})
@@ -140,9 +140,9 @@ var _ = Describe("retry topic-grpc-managers", Label(RETRY_LABEL, MOMENTO_LOCAL_L
 		It("Starts a burst of streams < max concurrent streams", func() {
 			numGrpcChannels := uint32(2)
 			maxConcurrentStreams := numGrpcChannels * uint32(config.MAX_CONCURRENT_STREAMS_PER_CHANNEL)
-			staticList, err := topic_manager_lists.NewStaticStreamGrpcManagerPool(grpcManagerRequest, numGrpcChannels, log)
+			staticPool, err := topic_manager_lists.NewStaticStreamGrpcManagerPool(grpcManagerRequest, numGrpcChannels, log)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(staticList).NotTo(BeNil())
+			Expect(staticPool).NotTo(BeNil())
 
 			// Start a burst of streams to occupy just under half the max concurrent stream capacity.
 			// Shadow the shared ctx so this spec owns its streams' lifetime and
@@ -155,11 +155,11 @@ var _ = Describe("retry topic-grpc-managers", Label(RETRY_LABEL, MOMENTO_LOCAL_L
 				go func() {
 					defer GinkgoRecover()
 					defer waitGroup.Done()
-					streamManager, err := staticList.GetNextTopicGrpcManager()
+					reservation, err := staticPool.GetNextTopicGrpcManager()
 					Expect(err).ToNot(HaveOccurred())
-					Expect(streamManager).NotTo(BeNil())
+					Expect(reservation).NotTo(BeNil())
 
-					subscribeClient, subscribeErr := streamManager.Manager().StreamClient.Subscribe(ctx, subscriptionRequest)
+					subscribeClient, subscribeErr := reservation.Manager().StreamClient.Subscribe(ctx, subscriptionRequest)
 					Expect(subscribeErr).ToNot(HaveOccurred())
 					Expect(subscribeClient).NotTo(BeNil())
 
@@ -175,9 +175,9 @@ var _ = Describe("retry topic-grpc-managers", Label(RETRY_LABEL, MOMENTO_LOCAL_L
 			time.Sleep(500 * time.Millisecond)
 
 			// Verify correct number of streams are active.
-			Expect(staticList.GetCurrentActiveStreamsCount()).To(Equal(uint64(maxConcurrentStreams/2 - 1)))
+			Expect(staticPool.GetCurrentActiveStreamsCount()).To(Equal(uint64(maxConcurrentStreams/2 - 1)))
 
-			staticList.Close()
+			staticPool.Close()
 			cancel()
 			streamsWaitGroup.Wait()
 		})
@@ -185,9 +185,9 @@ var _ = Describe("retry topic-grpc-managers", Label(RETRY_LABEL, MOMENTO_LOCAL_L
 		It("Starts a burst of streams == max concurrent streams", func() {
 			numGrpcChannels := uint32(2)
 			maxConcurrentStreams := numGrpcChannels * uint32(config.MAX_CONCURRENT_STREAMS_PER_CHANNEL)
-			staticList, err := topic_manager_lists.NewStaticStreamGrpcManagerPool(grpcManagerRequest, numGrpcChannels, log)
+			staticPool, err := topic_manager_lists.NewStaticStreamGrpcManagerPool(grpcManagerRequest, numGrpcChannels, log)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(staticList).NotTo(BeNil())
+			Expect(staticPool).NotTo(BeNil())
 
 			// Start a burst of streams to occupy the max concurrent stream capacity.
 			// Shadow the shared ctx so this spec owns its streams' lifetime and
@@ -200,11 +200,11 @@ var _ = Describe("retry topic-grpc-managers", Label(RETRY_LABEL, MOMENTO_LOCAL_L
 				go func() {
 					defer GinkgoRecover()
 					defer waitGroup.Done()
-					streamManager, err := staticList.GetNextTopicGrpcManager()
+					reservation, err := staticPool.GetNextTopicGrpcManager()
 					Expect(err).ToNot(HaveOccurred())
-					Expect(streamManager).NotTo(BeNil())
+					Expect(reservation).NotTo(BeNil())
 
-					subscribeClient, subscribeErr := streamManager.Manager().StreamClient.Subscribe(ctx, subscriptionRequest)
+					subscribeClient, subscribeErr := reservation.Manager().StreamClient.Subscribe(ctx, subscriptionRequest)
 					Expect(subscribeErr).ToNot(HaveOccurred())
 					Expect(subscribeClient).NotTo(BeNil())
 
@@ -220,9 +220,9 @@ var _ = Describe("retry topic-grpc-managers", Label(RETRY_LABEL, MOMENTO_LOCAL_L
 			time.Sleep(500 * time.Millisecond)
 
 			// Verify correct number of streams are active.
-			Expect(staticList.GetCurrentActiveStreamsCount()).To(Equal(uint64(maxConcurrentStreams)))
+			Expect(staticPool.GetCurrentActiveStreamsCount()).To(Equal(uint64(maxConcurrentStreams)))
 
-			staticList.Close()
+			staticPool.Close()
 			cancel()
 			streamsWaitGroup.Wait()
 		})
@@ -230,9 +230,9 @@ var _ = Describe("retry topic-grpc-managers", Label(RETRY_LABEL, MOMENTO_LOCAL_L
 		It("Starts a burst of streams > max concurrent streams", func() {
 			numGrpcChannels := uint32(2)
 			maxConcurrentStreams := numGrpcChannels * uint32(config.MAX_CONCURRENT_STREAMS_PER_CHANNEL)
-			staticList, err := topic_manager_lists.NewStaticStreamGrpcManagerPool(grpcManagerRequest, numGrpcChannels, log)
+			staticPool, err := topic_manager_lists.NewStaticStreamGrpcManagerPool(grpcManagerRequest, numGrpcChannels, log)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(staticList).NotTo(BeNil())
+			Expect(staticPool).NotTo(BeNil())
 
 			// Start a burst of streams for 10 greater than the max concurrent stream capacity.
 			// Shadow the shared ctx so this spec owns its streams' lifetime and
@@ -246,13 +246,13 @@ var _ = Describe("retry topic-grpc-managers", Label(RETRY_LABEL, MOMENTO_LOCAL_L
 					defer GinkgoRecover()
 					defer waitGroup.Done()
 
-					streamManager, err := staticList.GetNextTopicGrpcManager()
+					reservation, err := staticPool.GetNextTopicGrpcManager()
 					if err != nil {
 						Expect(err.Error()).To(ContainSubstring("ClientResourceExhaustedError"))
 					} else {
-						Expect(streamManager).NotTo(BeNil())
+						Expect(reservation).NotTo(BeNil())
 
-						subscribeClient, subscribeErr := streamManager.Manager().StreamClient.Subscribe(ctx, subscriptionRequest)
+						subscribeClient, subscribeErr := reservation.Manager().StreamClient.Subscribe(ctx, subscriptionRequest)
 						Expect(subscribeErr).ToNot(HaveOccurred())
 						Expect(subscribeClient).NotTo(BeNil())
 
@@ -269,9 +269,9 @@ var _ = Describe("retry topic-grpc-managers", Label(RETRY_LABEL, MOMENTO_LOCAL_L
 			time.Sleep(500 * time.Millisecond)
 
 			// Verify correct number of streams are active.
-			Expect(staticList.GetCurrentActiveStreamsCount()).To(Equal(uint64(maxConcurrentStreams)))
+			Expect(staticPool.GetCurrentActiveStreamsCount()).To(Equal(uint64(maxConcurrentStreams)))
 
-			staticList.Close()
+			staticPool.Close()
 			cancel()
 			streamsWaitGroup.Wait()
 		})
@@ -281,22 +281,22 @@ var _ = Describe("retry topic-grpc-managers", Label(RETRY_LABEL, MOMENTO_LOCAL_L
 		It("Get one new stream at a time until max concurrent streams reached", func() {
 			numGrpcChannels := uint32(2)
 			maxConcurrentStreams := numGrpcChannels * uint32(config.MAX_CONCURRENT_STREAMS_PER_CHANNEL)
-			dynamicList, err := topic_manager_lists.NewDynamicStreamGrpcManagerPool(grpcManagerRequest, maxConcurrentStreams, log)
+			dynamicPool, err := topic_manager_lists.NewDynamicStreamGrpcManagerPool(grpcManagerRequest, maxConcurrentStreams, log)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(dynamicList).NotTo(BeNil())
+			Expect(dynamicPool).NotTo(BeNil())
 
 			// Dynamic list always starts with only one grpc manager.
-			Expect(dynamicList.GetCurrentNumberOfGrpcManagers()).To(Equal(1))
+			Expect(dynamicPool.GetCurrentNumberOfGrpcManagers()).To(Equal(1))
 
 			// Get one new stream at a time until max concurrent streams reached.
 			ctx, cancel := context.WithCancel(ctx)
 			waitGroup := sync.WaitGroup{}
 			for i := 0; i < int(maxConcurrentStreams); i++ {
-				streamManager, err := dynamicList.GetNextTopicGrpcManager()
+				reservation, err := dynamicPool.GetNextTopicGrpcManager()
 				Expect(err).ToNot(HaveOccurred())
-				Expect(streamManager).NotTo(BeNil())
+				Expect(reservation).NotTo(BeNil())
 
-				subscribeClient, subscribeErr := streamManager.Manager().StreamClient.Subscribe(ctx, subscriptionRequest)
+				subscribeClient, subscribeErr := reservation.Manager().StreamClient.Subscribe(ctx, subscriptionRequest)
 				Expect(subscribeErr).ToNot(HaveOccurred())
 				Expect(subscribeClient).NotTo(BeNil())
 
@@ -307,18 +307,18 @@ var _ = Describe("retry topic-grpc-managers", Label(RETRY_LABEL, MOMENTO_LOCAL_L
 			time.Sleep(500 * time.Millisecond)
 
 			// New managers should have been added as needed to support the max number of concurrent streams.
-			Expect(dynamicList.GetCurrentNumberOfGrpcManagers()).To(Equal(int(numGrpcChannels)))
+			Expect(dynamicPool.GetCurrentNumberOfGrpcManagers()).To(Equal(int(numGrpcChannels)))
 
 			// Verify all managers are full of active subscriptions
-			Expect(dynamicList.GetCurrentActiveStreamsCount()).To(Equal(uint64(maxConcurrentStreams)))
+			Expect(dynamicPool.GetCurrentActiveStreamsCount()).To(Equal(uint64(maxConcurrentStreams)))
 
 			// Get one more stream and expect an error.
-			stream, err := dynamicList.GetNextTopicGrpcManager()
+			stream, err := dynamicPool.GetNextTopicGrpcManager()
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("ClientResourceExhaustedError"))
 			Expect(stream).To(BeNil())
 
-			dynamicList.Close()
+			dynamicPool.Close()
 			cancel()
 			waitGroup.Wait()
 		})
@@ -326,12 +326,12 @@ var _ = Describe("retry topic-grpc-managers", Label(RETRY_LABEL, MOMENTO_LOCAL_L
 		It("Starts a burst of streams < max concurrent streams", func() {
 			numGrpcChannels := uint32(2)
 			maxConcurrentStreams := numGrpcChannels * uint32(config.MAX_CONCURRENT_STREAMS_PER_CHANNEL)
-			dynamicList, err := topic_manager_lists.NewDynamicStreamGrpcManagerPool(grpcManagerRequest, maxConcurrentStreams, log)
+			dynamicPool, err := topic_manager_lists.NewDynamicStreamGrpcManagerPool(grpcManagerRequest, maxConcurrentStreams, log)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(dynamicList).NotTo(BeNil())
+			Expect(dynamicPool).NotTo(BeNil())
 
 			// Dynamic list always starts with only one grpc manager.
-			Expect(dynamicList.GetCurrentNumberOfGrpcManagers()).To(Equal(1))
+			Expect(dynamicPool.GetCurrentNumberOfGrpcManagers()).To(Equal(1))
 
 			// Start a burst of streams to occupy just under half the max concurrent stream capacity.
 			// Shadow the shared ctx so this spec owns its streams' lifetime and
@@ -344,11 +344,11 @@ var _ = Describe("retry topic-grpc-managers", Label(RETRY_LABEL, MOMENTO_LOCAL_L
 				go func() {
 					defer GinkgoRecover()
 					defer waitGroup.Done()
-					streamManager, err := dynamicList.GetNextTopicGrpcManager()
+					reservation, err := dynamicPool.GetNextTopicGrpcManager()
 					Expect(err).ToNot(HaveOccurred())
-					Expect(streamManager).NotTo(BeNil())
+					Expect(reservation).NotTo(BeNil())
 
-					subscribeClient, subscribeErr := streamManager.Manager().StreamClient.Subscribe(ctx, subscriptionRequest)
+					subscribeClient, subscribeErr := reservation.Manager().StreamClient.Subscribe(ctx, subscriptionRequest)
 					Expect(subscribeErr).ToNot(HaveOccurred())
 					Expect(subscribeClient).NotTo(BeNil())
 
@@ -364,12 +364,12 @@ var _ = Describe("retry topic-grpc-managers", Label(RETRY_LABEL, MOMENTO_LOCAL_L
 			time.Sleep(500 * time.Millisecond)
 
 			// No new manager should have been added as we did not exceed a single channel's stream capacity.
-			Expect(dynamicList.GetCurrentNumberOfGrpcManagers()).To(Equal(1))
+			Expect(dynamicPool.GetCurrentNumberOfGrpcManagers()).To(Equal(1))
 
 			// Verify correct number of streams are active.
-			Expect(dynamicList.GetCurrentActiveStreamsCount()).To(Equal(uint64(maxConcurrentStreams/2 - 1)))
+			Expect(dynamicPool.GetCurrentActiveStreamsCount()).To(Equal(uint64(maxConcurrentStreams/2 - 1)))
 
-			dynamicList.Close()
+			dynamicPool.Close()
 			cancel()
 			streamsWaitGroup.Wait()
 		})
@@ -377,12 +377,12 @@ var _ = Describe("retry topic-grpc-managers", Label(RETRY_LABEL, MOMENTO_LOCAL_L
 		DescribeTable("Starts a burst of streams == max concurrent streams",
 			func(numGrpcChannels uint32) {
 				maxConcurrentStreams := numGrpcChannels * uint32(config.MAX_CONCURRENT_STREAMS_PER_CHANNEL)
-				dynamicList, err := topic_manager_lists.NewDynamicStreamGrpcManagerPool(grpcManagerRequest, maxConcurrentStreams, log)
+				dynamicPool, err := topic_manager_lists.NewDynamicStreamGrpcManagerPool(grpcManagerRequest, maxConcurrentStreams, log)
 				Expect(err).ToNot(HaveOccurred())
-				Expect(dynamicList).NotTo(BeNil())
+				Expect(dynamicPool).NotTo(BeNil())
 
 				// Dynamic list always starts with only one grpc manager.
-				Expect(dynamicList.GetCurrentNumberOfGrpcManagers()).To(Equal(1))
+				Expect(dynamicPool.GetCurrentNumberOfGrpcManagers()).To(Equal(1))
 
 				// Start a burst of streams to occupy the max concurrent stream capacity.
 				// Shadow the shared ctx so this spec owns its streams' lifetime and
@@ -395,11 +395,11 @@ var _ = Describe("retry topic-grpc-managers", Label(RETRY_LABEL, MOMENTO_LOCAL_L
 					go func() {
 						defer GinkgoRecover()
 						defer waitGroup.Done()
-						streamManager, err := dynamicList.GetNextTopicGrpcManager()
+						reservation, err := dynamicPool.GetNextTopicGrpcManager()
 						Expect(err).ToNot(HaveOccurred())
-						Expect(streamManager).NotTo(BeNil())
+						Expect(reservation).NotTo(BeNil())
 
-						subscribeClient, subscribeErr := streamManager.Manager().StreamClient.Subscribe(ctx, subscriptionRequest)
+						subscribeClient, subscribeErr := reservation.Manager().StreamClient.Subscribe(ctx, subscriptionRequest)
 						Expect(subscribeErr).ToNot(HaveOccurred())
 						Expect(subscribeClient).NotTo(BeNil())
 
@@ -415,12 +415,12 @@ var _ = Describe("retry topic-grpc-managers", Label(RETRY_LABEL, MOMENTO_LOCAL_L
 				time.Sleep(500 * time.Millisecond)
 
 				// New managers should have been added as needed to support the max number of concurrent streams.
-				Expect(dynamicList.GetCurrentNumberOfGrpcManagers()).To(Equal(int(numGrpcChannels)))
+				Expect(dynamicPool.GetCurrentNumberOfGrpcManagers()).To(Equal(int(numGrpcChannels)))
 
 				// Verify correct number of streams are active.
-				Expect(dynamicList.GetCurrentActiveStreamsCount()).To(Equal(uint64(maxConcurrentStreams)))
+				Expect(dynamicPool.GetCurrentActiveStreamsCount()).To(Equal(uint64(maxConcurrentStreams)))
 
-				dynamicList.Close()
+				dynamicPool.Close()
 				cancel()
 				streamsWaitGroup.Wait()
 			},
@@ -433,12 +433,12 @@ var _ = Describe("retry topic-grpc-managers", Label(RETRY_LABEL, MOMENTO_LOCAL_L
 		DescribeTable("Starts a burst of streams > max concurrent streams",
 			func(numGrpcChannels uint32) {
 				maxConcurrentStreams := numGrpcChannels * uint32(config.MAX_CONCURRENT_STREAMS_PER_CHANNEL)
-				dynamicList, err := topic_manager_lists.NewDynamicStreamGrpcManagerPool(grpcManagerRequest, maxConcurrentStreams, log)
+				dynamicPool, err := topic_manager_lists.NewDynamicStreamGrpcManagerPool(grpcManagerRequest, maxConcurrentStreams, log)
 				Expect(err).ToNot(HaveOccurred())
-				Expect(dynamicList).NotTo(BeNil())
+				Expect(dynamicPool).NotTo(BeNil())
 
 				// Dynamic list always starts with only one grpc manager.
-				Expect(dynamicList.GetCurrentNumberOfGrpcManagers()).To(Equal(1))
+				Expect(dynamicPool.GetCurrentNumberOfGrpcManagers()).To(Equal(1))
 
 				// Start a burst of streams to occupy 10 greater than the max concurrent stream capacity.
 				// Shadow the shared ctx so this spec owns its streams' lifetime and
@@ -452,13 +452,13 @@ var _ = Describe("retry topic-grpc-managers", Label(RETRY_LABEL, MOMENTO_LOCAL_L
 						defer GinkgoRecover()
 						defer waitGroup.Done()
 
-						streamManager, err := dynamicList.GetNextTopicGrpcManager()
+						reservation, err := dynamicPool.GetNextTopicGrpcManager()
 						if err != nil {
 							Expect(err.Error()).To(ContainSubstring("ClientResourceExhaustedError"))
 						} else {
-							Expect(streamManager).NotTo(BeNil())
+							Expect(reservation).NotTo(BeNil())
 
-							subscribeClient, subscribeErr := streamManager.Manager().StreamClient.Subscribe(ctx, subscriptionRequest)
+							subscribeClient, subscribeErr := reservation.Manager().StreamClient.Subscribe(ctx, subscriptionRequest)
 							Expect(subscribeErr).ToNot(HaveOccurred())
 							Expect(subscribeClient).NotTo(BeNil())
 
@@ -475,12 +475,12 @@ var _ = Describe("retry topic-grpc-managers", Label(RETRY_LABEL, MOMENTO_LOCAL_L
 				time.Sleep(500 * time.Millisecond)
 
 				// New managers should have been added as needed to support the max number of concurrent streams.
-				Expect(dynamicList.GetCurrentNumberOfGrpcManagers()).To(Equal(int(numGrpcChannels)))
+				Expect(dynamicPool.GetCurrentNumberOfGrpcManagers()).To(Equal(int(numGrpcChannels)))
 
 				// Verify correct number of streams are active.
-				Expect(dynamicList.GetCurrentActiveStreamsCount()).To(Equal(uint64(maxConcurrentStreams)))
+				Expect(dynamicPool.GetCurrentActiveStreamsCount()).To(Equal(uint64(maxConcurrentStreams)))
 
-				dynamicList.Close()
+				dynamicPool.Close()
 				cancel()
 				streamsWaitGroup.Wait()
 			},

--- a/momento/topic_manager_test.go
+++ b/momento/topic_manager_test.go
@@ -29,6 +29,36 @@ var (
 	log                 logger.MomentoLogger
 )
 
+// keepStreamAlive consumes heartbeats on its own goroutine until the stream
+// ends. It tolerates the shutdown errors produced by pool Close (connection
+// closing) and spec ctx cancellation; anything else fails the spec.
+func keepStreamAlive(ctx context.Context, subscribeClient pb.Pubsub_SubscribeClient, streams *sync.WaitGroup) {
+	streams.Add(1)
+	go func() {
+		defer GinkgoRecover()
+		defer streams.Done()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			default:
+				item, err := subscribeClient.Recv()
+				if err != nil {
+					// The test is ending: the pool closed the connection or the
+					// spec canceled its context.
+					if strings.Contains(err.Error(), "the client connection is closing") ||
+						strings.Contains(err.Error(), "context canceled") {
+						return
+					}
+					Expect(err).ToNot(HaveOccurred())
+				}
+				Expect(item).NotTo(BeNil())
+				time.Sleep(100 * time.Millisecond)
+			}
+		}
+	}()
+}
+
 var _ = Describe("retry topic-grpc-managers", Label(RETRY_LABEL, MOMENTO_LOCAL_LABEL), func() {
 	BeforeEach(func() {
 		ctx = context.Background()
@@ -87,33 +117,8 @@ var _ = Describe("retry topic-grpc-managers", Label(RETRY_LABEL, MOMENTO_LOCAL_L
 				Expect(subscribeErr).ToNot(HaveOccurred())
 				Expect(subscribeClient).NotTo(BeNil())
 
-				// keep the stream alive until end of test using a goroutine
-				waitGroup.Add(1)
-				go func() {
-					defer GinkgoRecover()
-					defer waitGroup.Done()
-					for {
-						select {
-						case <-ctx.Done():
-							return
-						default:
-							item, err := subscribeClient.Recv()
-
-							if err != nil {
-								// Test is ending if we get canceled error
-								if strings.Contains(err.Error(), "the client connection is closing") {
-									return
-								}
-								// Otherwise fail the test
-								Expect(err).ToNot(HaveOccurred())
-							}
-
-							// Otherwise we expect to receive heartbeats
-							Expect(item).NotTo(BeNil())
-							time.Sleep(100 * time.Millisecond)
-						}
-					}
-				}()
+				// keep the stream alive until the spec tears down
+				keepStreamAlive(ctx, subscribeClient, &waitGroup)
 			}
 			// Allow time for all streams to be established
 			time.Sleep(500 * time.Millisecond)
@@ -140,6 +145,10 @@ var _ = Describe("retry topic-grpc-managers", Label(RETRY_LABEL, MOMENTO_LOCAL_L
 			Expect(staticList).NotTo(BeNil())
 
 			// Start a burst of streams to occupy just under half the max concurrent stream capacity.
+			// Shadow the shared ctx so this spec owns its streams' lifetime and
+			// can wait out its keep-alive goroutines before the next spec runs.
+			ctx, cancel := context.WithCancel(ctx)
+			streamsWaitGroup := sync.WaitGroup{}
 			waitGroup := sync.WaitGroup{}
 			for i := 0; i < int(maxConcurrentStreams/2-1); i++ {
 				waitGroup.Add(1)
@@ -154,31 +163,8 @@ var _ = Describe("retry topic-grpc-managers", Label(RETRY_LABEL, MOMENTO_LOCAL_L
 					Expect(subscribeErr).ToNot(HaveOccurred())
 					Expect(subscribeClient).NotTo(BeNil())
 
-					// keep the stream alive using a goroutine
-					go func() {
-						defer GinkgoRecover()
-						for {
-							select {
-							case <-ctx.Done():
-								return
-							default:
-								item, err := subscribeClient.Recv()
-
-								if err != nil {
-									// Test is ending if we get canceled error
-									if strings.Contains(err.Error(), "the client connection is closing") {
-										return
-									}
-									// Otherwise fail the test
-									Expect(err).ToNot(HaveOccurred())
-								}
-
-								// Otherwise we expect to receive heartbeats
-								Expect(item).NotTo(BeNil())
-								time.Sleep(100 * time.Millisecond)
-							}
-						}
-					}()
+					// keep the stream alive until the spec tears down
+					keepStreamAlive(ctx, subscribeClient, &streamsWaitGroup)
 				}()
 			}
 
@@ -192,6 +178,8 @@ var _ = Describe("retry topic-grpc-managers", Label(RETRY_LABEL, MOMENTO_LOCAL_L
 			Expect(staticList.GetCurrentActiveStreamsCount()).To(Equal(uint64(maxConcurrentStreams/2 - 1)))
 
 			staticList.Close()
+			cancel()
+			streamsWaitGroup.Wait()
 		})
 
 		It("Starts a burst of streams == max concurrent streams", func() {
@@ -202,6 +190,10 @@ var _ = Describe("retry topic-grpc-managers", Label(RETRY_LABEL, MOMENTO_LOCAL_L
 			Expect(staticList).NotTo(BeNil())
 
 			// Start a burst of streams to occupy the max concurrent stream capacity.
+			// Shadow the shared ctx so this spec owns its streams' lifetime and
+			// can wait out its keep-alive goroutines before the next spec runs.
+			ctx, cancel := context.WithCancel(ctx)
+			streamsWaitGroup := sync.WaitGroup{}
 			waitGroup := sync.WaitGroup{}
 			for i := 0; i < int(maxConcurrentStreams); i++ {
 				waitGroup.Add(1)
@@ -216,31 +208,8 @@ var _ = Describe("retry topic-grpc-managers", Label(RETRY_LABEL, MOMENTO_LOCAL_L
 					Expect(subscribeErr).ToNot(HaveOccurred())
 					Expect(subscribeClient).NotTo(BeNil())
 
-					// keep the stream alive using a goroutine
-					go func() {
-						defer GinkgoRecover()
-						for {
-							select {
-							case <-ctx.Done():
-								return
-							default:
-								item, err := subscribeClient.Recv()
-
-								if err != nil {
-									// Test is ending if we get canceled error
-									if strings.Contains(err.Error(), "the client connection is closing") {
-										return
-									}
-									// Otherwise fail the test
-									Expect(err).ToNot(HaveOccurred())
-								}
-
-								// Otherwise we expect to receive heartbeats
-								Expect(item).NotTo(BeNil())
-								time.Sleep(100 * time.Millisecond)
-							}
-						}
-					}()
+					// keep the stream alive until the spec tears down
+					keepStreamAlive(ctx, subscribeClient, &streamsWaitGroup)
 				}()
 			}
 
@@ -254,6 +223,8 @@ var _ = Describe("retry topic-grpc-managers", Label(RETRY_LABEL, MOMENTO_LOCAL_L
 			Expect(staticList.GetCurrentActiveStreamsCount()).To(Equal(uint64(maxConcurrentStreams)))
 
 			staticList.Close()
+			cancel()
+			streamsWaitGroup.Wait()
 		})
 
 		It("Starts a burst of streams > max concurrent streams", func() {
@@ -264,6 +235,10 @@ var _ = Describe("retry topic-grpc-managers", Label(RETRY_LABEL, MOMENTO_LOCAL_L
 			Expect(staticList).NotTo(BeNil())
 
 			// Start a burst of streams for 10 greater than the max concurrent stream capacity.
+			// Shadow the shared ctx so this spec owns its streams' lifetime and
+			// can wait out its keep-alive goroutines before the next spec runs.
+			ctx, cancel := context.WithCancel(ctx)
+			streamsWaitGroup := sync.WaitGroup{}
 			waitGroup := sync.WaitGroup{}
 			for i := 0; i < int(maxConcurrentStreams+10); i++ {
 				waitGroup.Add(1)
@@ -281,31 +256,8 @@ var _ = Describe("retry topic-grpc-managers", Label(RETRY_LABEL, MOMENTO_LOCAL_L
 						Expect(subscribeErr).ToNot(HaveOccurred())
 						Expect(subscribeClient).NotTo(BeNil())
 
-						// keep the stream alive using a goroutine
-						go func() {
-							defer GinkgoRecover()
-							for {
-								select {
-								case <-ctx.Done():
-									return
-								default:
-									item, err := subscribeClient.Recv()
-
-									if err != nil {
-										// Test is ending if we get canceled error
-										if strings.Contains(err.Error(), "the client connection is closing") {
-											return
-										}
-										// Otherwise fail the test
-										Expect(err).ToNot(HaveOccurred())
-									}
-
-									// Otherwise we expect to receive heartbeats
-									Expect(item).NotTo(BeNil())
-									time.Sleep(100 * time.Millisecond)
-								}
-							}
-						}()
+						// keep the stream alive until the spec tears down
+						keepStreamAlive(ctx, subscribeClient, &streamsWaitGroup)
 					}
 				}()
 			}
@@ -320,11 +272,13 @@ var _ = Describe("retry topic-grpc-managers", Label(RETRY_LABEL, MOMENTO_LOCAL_L
 			Expect(staticList.GetCurrentActiveStreamsCount()).To(Equal(uint64(maxConcurrentStreams)))
 
 			staticList.Close()
+			cancel()
+			streamsWaitGroup.Wait()
 		})
 	})
 
 	Describe("DynamicStreamManagerList", func() {
-		It("Get one new stream at a timeuntil max concurrent streams reached", func() {
+		It("Get one new stream at a time until max concurrent streams reached", func() {
 			numGrpcChannels := uint32(2)
 			maxConcurrentStreams := numGrpcChannels * uint32(config.MAX_CONCURRENT_STREAMS_PER_CHANNEL)
 			dynamicList, err := topic_manager_lists.NewDynamicStreamGrpcManagerPool(grpcManagerRequest, maxConcurrentStreams, log)
@@ -346,33 +300,8 @@ var _ = Describe("retry topic-grpc-managers", Label(RETRY_LABEL, MOMENTO_LOCAL_L
 				Expect(subscribeErr).ToNot(HaveOccurred())
 				Expect(subscribeClient).NotTo(BeNil())
 
-				// keep the stream alive using a goroutine
-				waitGroup.Add(1)
-				go func() {
-					defer GinkgoRecover()
-					defer waitGroup.Done()
-					for {
-						select {
-						case <-ctx.Done():
-							return
-						default:
-							item, err := subscribeClient.Recv()
-
-							if err != nil {
-								// Test is ending if we get canceled error
-								if strings.Contains(err.Error(), "the client connection is closing") {
-									return
-								}
-								// Otherwise fail the test
-								Expect(err).ToNot(HaveOccurred())
-							}
-
-							// Otherwise we expect to receive heartbeats
-							Expect(item).NotTo(BeNil())
-							time.Sleep(100 * time.Millisecond)
-						}
-					}
-				}()
+				// keep the stream alive until the spec tears down
+				keepStreamAlive(ctx, subscribeClient, &waitGroup)
 			}
 			// Allow time for all streams to be established
 			time.Sleep(500 * time.Millisecond)
@@ -405,6 +334,10 @@ var _ = Describe("retry topic-grpc-managers", Label(RETRY_LABEL, MOMENTO_LOCAL_L
 			Expect(dynamicList.GetCurrentNumberOfGrpcManagers()).To(Equal(1))
 
 			// Start a burst of streams to occupy just under half the max concurrent stream capacity.
+			// Shadow the shared ctx so this spec owns its streams' lifetime and
+			// can wait out its keep-alive goroutines before the next spec runs.
+			ctx, cancel := context.WithCancel(ctx)
+			streamsWaitGroup := sync.WaitGroup{}
 			waitGroup := sync.WaitGroup{}
 			for i := 0; i < int(maxConcurrentStreams/2-1); i++ {
 				waitGroup.Add(1)
@@ -419,31 +352,8 @@ var _ = Describe("retry topic-grpc-managers", Label(RETRY_LABEL, MOMENTO_LOCAL_L
 					Expect(subscribeErr).ToNot(HaveOccurred())
 					Expect(subscribeClient).NotTo(BeNil())
 
-					// keep the stream alive using a goroutine
-					go func() {
-						defer GinkgoRecover()
-						for {
-							select {
-							case <-ctx.Done():
-								return
-							default:
-								item, err := subscribeClient.Recv()
-
-								if err != nil {
-									// Test is ending if we get canceled error
-									if strings.Contains(err.Error(), "the client connection is closing") {
-										return
-									}
-									// Otherwise fail the test
-									Expect(err).ToNot(HaveOccurred())
-								}
-
-								// Otherwise we expect to receive heartbeats
-								Expect(item).NotTo(BeNil())
-								time.Sleep(100 * time.Millisecond)
-							}
-						}
-					}()
+					// keep the stream alive until the spec tears down
+					keepStreamAlive(ctx, subscribeClient, &streamsWaitGroup)
 				}()
 			}
 
@@ -460,6 +370,8 @@ var _ = Describe("retry topic-grpc-managers", Label(RETRY_LABEL, MOMENTO_LOCAL_L
 			Expect(dynamicList.GetCurrentActiveStreamsCount()).To(Equal(uint64(maxConcurrentStreams/2 - 1)))
 
 			dynamicList.Close()
+			cancel()
+			streamsWaitGroup.Wait()
 		})
 
 		DescribeTable("Starts a burst of streams == max concurrent streams",
@@ -473,6 +385,10 @@ var _ = Describe("retry topic-grpc-managers", Label(RETRY_LABEL, MOMENTO_LOCAL_L
 				Expect(dynamicList.GetCurrentNumberOfGrpcManagers()).To(Equal(1))
 
 				// Start a burst of streams to occupy the max concurrent stream capacity.
+				// Shadow the shared ctx so this spec owns its streams' lifetime and
+				// can wait out its keep-alive goroutines before the next spec runs.
+				ctx, cancel := context.WithCancel(ctx)
+				streamsWaitGroup := sync.WaitGroup{}
 				waitGroup := sync.WaitGroup{}
 				for i := 0; i < int(maxConcurrentStreams); i++ {
 					waitGroup.Add(1)
@@ -487,31 +403,8 @@ var _ = Describe("retry topic-grpc-managers", Label(RETRY_LABEL, MOMENTO_LOCAL_L
 						Expect(subscribeErr).ToNot(HaveOccurred())
 						Expect(subscribeClient).NotTo(BeNil())
 
-						// keep the stream alive using a goroutine
-						go func() {
-							defer GinkgoRecover()
-							for {
-								select {
-								case <-ctx.Done():
-									return
-								default:
-									item, err := subscribeClient.Recv()
-
-									if err != nil {
-										// Test is ending if we get canceled error
-										if strings.Contains(err.Error(), "the client connection is closing") {
-											return
-										}
-										// Otherwise fail the test
-										Expect(err).ToNot(HaveOccurred())
-									}
-
-									// Otherwise we expect to receive heartbeats
-									Expect(item).NotTo(BeNil())
-									time.Sleep(100 * time.Millisecond)
-								}
-							}
-						}()
+						// keep the stream alive until the spec tears down
+						keepStreamAlive(ctx, subscribeClient, &streamsWaitGroup)
 					}()
 				}
 
@@ -528,6 +421,8 @@ var _ = Describe("retry topic-grpc-managers", Label(RETRY_LABEL, MOMENTO_LOCAL_L
 				Expect(dynamicList.GetCurrentActiveStreamsCount()).To(Equal(uint64(maxConcurrentStreams)))
 
 				dynamicList.Close()
+				cancel()
+				streamsWaitGroup.Wait()
 			},
 			Entry("using max 2 channels", uint32(2)),
 			Entry("using max 10 channels", uint32(10)),
@@ -546,6 +441,10 @@ var _ = Describe("retry topic-grpc-managers", Label(RETRY_LABEL, MOMENTO_LOCAL_L
 				Expect(dynamicList.GetCurrentNumberOfGrpcManagers()).To(Equal(1))
 
 				// Start a burst of streams to occupy 10 greater than the max concurrent stream capacity.
+				// Shadow the shared ctx so this spec owns its streams' lifetime and
+				// can wait out its keep-alive goroutines before the next spec runs.
+				ctx, cancel := context.WithCancel(ctx)
+				streamsWaitGroup := sync.WaitGroup{}
 				waitGroup := sync.WaitGroup{}
 				for i := 0; i < int(maxConcurrentStreams+10); i++ {
 					waitGroup.Add(1)
@@ -563,31 +462,8 @@ var _ = Describe("retry topic-grpc-managers", Label(RETRY_LABEL, MOMENTO_LOCAL_L
 							Expect(subscribeErr).ToNot(HaveOccurred())
 							Expect(subscribeClient).NotTo(BeNil())
 
-							// keep the stream alive using a goroutine
-							go func() {
-								defer GinkgoRecover()
-								for {
-									select {
-									case <-ctx.Done():
-										return
-									default:
-										item, err := subscribeClient.Recv()
-
-										if err != nil {
-											// Test is ending if we get canceled error
-											if strings.Contains(err.Error(), "the client connection is closing") {
-												return
-											}
-											// Otherwise fail the test
-											Expect(err).ToNot(HaveOccurred())
-										}
-
-										// Otherwise we expect to receive heartbeats
-										Expect(item).NotTo(BeNil())
-										time.Sleep(100 * time.Millisecond)
-									}
-								}
-							}()
+							// keep the stream alive until the spec tears down
+							keepStreamAlive(ctx, subscribeClient, &streamsWaitGroup)
 						}
 					}()
 				}
@@ -605,6 +481,8 @@ var _ = Describe("retry topic-grpc-managers", Label(RETRY_LABEL, MOMENTO_LOCAL_L
 				Expect(dynamicList.GetCurrentActiveStreamsCount()).To(Equal(uint64(maxConcurrentStreams)))
 
 				dynamicList.Close()
+				cancel()
+				streamsWaitGroup.Wait()
 			},
 			Entry("using max 2 channels", uint32(2)),
 			Entry("using max 10 channels", uint32(10)),

--- a/momento/topic_subscription.go
+++ b/momento/topic_subscription.go
@@ -143,8 +143,9 @@ func (s *topicSubscription) Event(ctx context.Context) (TopicEvent, error) {
 	for {
 		// Snapshot state once per iteration so every read in this loop body
 		// references the same Reservation/cancelContext/cancelFunction triple.
-		// A concurrent attemptReconnect Stores a new pointer; we pick it up
-		// on the next iteration.
+		// attemptReconnect (called below, same goroutine) Stores a new state
+		// that the next iteration picks up; the snapshot also keeps a
+		// concurrent Close, which Loads and cancels, from seeing a torn view.
 		state := s.state.Load()
 
 		// Callers can cancel ctx right after subscribing; check before Recv.
@@ -265,6 +266,12 @@ func (s *topicSubscription) attemptReconnect(ctx context.Context, err error) err
 			s.log.Info("Subscription closed during reconnect; aborting retry loop")
 			return momentoerrors.NewMomentoSvcErr(momentoerrors.CanceledError, "subscription closed", nil)
 		}
+		// A reconnected stream would be a child of ctx, so once ctx is dead a
+		// reconnect can never succeed; stop instead of retrying forever.
+		if ctx.Err() != nil {
+			s.log.Info("Context canceled during reconnect; aborting retry loop")
+			return momentoerrors.NewMomentoSvcErr(momentoerrors.CanceledError, "subscribe context canceled during reconnect", ctx.Err())
+		}
 
 		retryBackoffTime := s.retryStrategy.DetermineWhenToRetry(retry.StrategyProps{
 			GrpcStatusCode: grpcStatusCode(err),
@@ -281,7 +288,11 @@ func (s *topicSubscription) attemptReconnect(ctx context.Context, err error) err
 
 		if *retryBackoffTime > 0 {
 			s.log.Info("Waiting %s milliseconds before attempting to reconnect", fmt.Sprint(*retryBackoffTime))
-			time.Sleep(time.Duration(*retryBackoffTime) * time.Millisecond)
+			select {
+			case <-time.After(time.Duration(*retryBackoffTime) * time.Millisecond):
+			case <-ctx.Done():
+				return momentoerrors.NewMomentoSvcErr(momentoerrors.CanceledError, "subscribe context canceled during reconnect", ctx.Err())
+			}
 		}
 
 		s.log.Info("Attempting reconnecting to client stream")

--- a/momento/topic_subscription.go
+++ b/momento/topic_subscription.go
@@ -2,8 +2,8 @@ package momento
 
 import (
 	"context"
+	"errors"
 	"fmt"
-	"sync"
 	"sync/atomic"
 	"time"
 
@@ -15,10 +15,21 @@ import (
 	"google.golang.org/grpc/status"
 
 	"github.com/momentohq/client-sdk-go/config/logger"
-	"github.com/momentohq/client-sdk-go/internal/grpcmanagers"
+	"github.com/momentohq/client-sdk-go/internal/grpcmanagers/topic_manager_lists"
 	pb "github.com/momentohq/client-sdk-go/internal/protos"
 )
 
+// TopicSubscription is the consumer-side handle for an active topic subscription.
+//
+// Concurrency contract:
+//   - Item and Event must be called from a single goroutine at a time. The
+//     underlying gRPC stream's Recv is not safe for concurrent use, and the
+//     subscription tracks per-stream sequence state without locking on the
+//     hot path.
+//   - Close is safe to call concurrently with an in-flight Item/Event call,
+//     and is safe to call more than once. Close unblocks the consumer
+//     goroutine by cancelling the stream context; the consumer will then
+//     observe a cancelled-context error from Item/Event.
 type TopicSubscription interface {
 	// Item returns only subscription events that contain a string or byte message.
 	// Example:
@@ -66,17 +77,21 @@ type TopicSubscription interface {
 	Close()
 }
 
-type topicSubscription struct {
-	// mu guards topicManager, subscribeClient, cancelContext, and cancelFunction
-	// against cross-goroutine reads from Close while attemptReconnect (running
-	// in the Event goroutine) installs a new stream. Within the Event goroutine
-	// these fields are read without mu since reads and writes there are already
-	// sequenced by program order.
-	mu              sync.Mutex
-	topicManager    *grpcmanagers.TopicGrpcManager
+// subscribeMethodName is the request name reported to middleware for Subscribe
+// events.
+const subscribeMethodName = "Subscribe"
+
+// streamState bundles the fields swapped together on every (re)connect. Held
+// in an atomic.Pointer so readers see a consistent snapshot.
+type streamState struct {
+	reservation     *topic_manager_lists.Reservation
 	subscribeClient pb.Pubsub_SubscribeClient
 	cancelContext   context.Context
 	cancelFunction  context.CancelFunc
+}
+
+type topicSubscription struct {
+	state atomic.Pointer[streamState]
 
 	topicEventCallback      func(cacheName string, requestName string, event middleware.TopicSubscriptionEventType)
 	momentoTopicClient      *pubSubClient
@@ -86,25 +101,18 @@ type topicSubscription struct {
 	lastKnownSequenceNumber uint64
 	lastKnownSequencePage   uint64
 	retryStrategy           retry.Strategy
-	// released gates the per-stream release so it runs exactly once between
-	// successive allocations. It is set to true when the current stream's slot
-	// is released and reset to false on successful reconnect.
-	released atomic.Bool
-	// closed is set permanently to true by Close(). attemptReconnect checks it
-	// to bail out if Close races in while a reconnect is in flight, so a freshly
-	// allocated stream doesn't leak past Close.
+	// closed is set by Close. attemptReconnect bails out if it observes this set.
 	closed atomic.Bool
 }
 
-// grpcStatusCode returns the gRPC status code embedded in err, unwrapping a
-// MomentoSvcErr if needed. The first call to attemptReconnect receives a raw
-// gRPC error from Recv(); subsequent retries get a MomentoSvcErr back from
-// topicSubscribe — both need to produce the same code for the retry strategy.
+// grpcStatusCode returns the gRPC status code for err, unwrapping
+// MomentoSvcErr if the error came back through topicSubscribe.
 func grpcStatusCode(err error) codes.Code {
 	if err == nil {
 		return codes.OK
 	}
-	if svcErr, ok := err.(momentoerrors.MomentoSvcErr); ok {
+	var svcErr momentoerrors.MomentoSvcErr
+	if errors.As(err, &svcErr) {
 		if original := svcErr.OriginalErr(); original != nil {
 			return status.Code(original)
 		}
@@ -132,60 +140,61 @@ func (s *topicSubscription) Item(ctx context.Context) (TopicValue, error) {
 }
 
 func (s *topicSubscription) Event(ctx context.Context) (TopicEvent, error) {
-	methodName := "Subscribe"
-
 	for {
-		// Its totally possible a client just calls `cancel` on the `context` immediately after subscribing to an
-		// item, so we should check that here.
+		// Snapshot state once per iteration so every read in this loop body
+		// references the same Reservation/cancelContext/cancelFunction triple.
+		// A concurrent attemptReconnect Stores a new pointer; we pick it up
+		// on the next iteration.
+		state := s.state.Load()
+
+		// Callers can cancel ctx right after subscribing; check before Recv.
 		select {
 		case <-ctx.Done():
-			// Context has been canceled, return an error
-			decremented := s.decrementSubscriptionCount()
+			decremented := state.reservation.Release()
 			s.log.Debug(
 				"[Event] Context done, number of active streams on current grpc channel: %d",
 				decremented,
 			)
 			return nil, ctx.Err()
-		case <-s.cancelContext.Done():
-			// Context has been canceled, return an error
-			decremented := s.decrementSubscriptionCount()
+		case <-state.cancelContext.Done():
+			decremented := state.reservation.Release()
 			s.log.Debug(
 				"[Event] Context cancelled, number of active streams on current grpc channel: %d",
 				decremented,
 			)
-			return nil, s.cancelContext.Err()
+			return nil, state.cancelContext.Err()
 		default:
-			// Proceed as is
 		}
 
-		rawMsg, err := s.subscribeClient.Recv()
+		rawMsg, err := state.subscribeClient.Recv()
 		if err != nil {
 			select {
 			case <-ctx.Done():
 				{
-					decremented := s.decrementSubscriptionCount()
+					decremented := state.reservation.Release()
 					s.log.Debug(
 						"[Event RecvMsg] Context done, number of active streams on current grpc channel: %d",
 						decremented,
 					)
 					return nil, ctx.Err()
 				}
-			case <-s.cancelContext.Done():
+			case <-state.cancelContext.Done():
 				{
-					decremented := s.decrementSubscriptionCount()
+					decremented := state.reservation.Release()
 					s.log.Debug(
 						"[Event RecvMsg] Context cancelled, number of active streams on current grpc channel: %d",
 						decremented,
 					)
-					return nil, s.cancelContext.Err()
+					return nil, state.cancelContext.Err()
 				}
 			default:
 				{
-					s.onTopicEvent(methodName, middleware.ERROR)
-					// Disconnected, decrement and explicitly close the stream, then attempt to reconnect
+					s.onTopicEvent(subscribeMethodName, middleware.ERROR)
+					// Cancel the dead stream before releasing the slot so the
+					// server-side resources tear down promptly.
 					s.log.Error("Stream disconnected due to error: %s", err.Error())
-					s.cancelFunction()
-					decremented := s.decrementSubscriptionCount()
+					state.cancelFunction()
+					decremented := state.reservation.Release()
 					s.log.Debug(
 						"[Event RecvMsg] Default case, attempting to reconnect, number of active streams on current grpc channel: %d",
 						decremented,
@@ -204,14 +213,14 @@ func (s *topicSubscription) Event(ctx context.Context) (TopicEvent, error) {
 		switch typedMsg := rawMsg.Kind.(type) {
 		case *pb.XSubscriptionItem_Discontinuity:
 			s.log.Debug("received discontinuity item: %+v", typedMsg.Discontinuity)
-			s.onTopicEvent(methodName, middleware.DISCONTINUITY)
+			s.onTopicEvent(subscribeMethodName, middleware.DISCONTINUITY)
 			return NewTopicDiscontinuity(
 				typedMsg.Discontinuity.LastTopicSequence,
 				typedMsg.Discontinuity.NewTopicSequence,
 				typedMsg.Discontinuity.NewSequencePage,
 			), nil
 		case *pb.XSubscriptionItem_Item:
-			s.onTopicEvent(methodName, middleware.ITEM)
+			s.onTopicEvent(subscribeMethodName, middleware.ITEM)
 			s.lastKnownSequenceNumber = typedMsg.Item.GetTopicSequenceNumber()
 			s.lastKnownSequencePage = typedMsg.Item.GetSequencePage()
 			publisherId := typedMsg.Item.GetPublisherId()
@@ -229,7 +238,7 @@ func (s *topicSubscription) Event(ctx context.Context) (TopicEvent, error) {
 			}
 		case *pb.XSubscriptionItem_Heartbeat:
 			s.log.Trace("received heartbeat item")
-			s.onTopicEvent(methodName, middleware.HEARTBEAT)
+			s.onTopicEvent(subscribeMethodName, middleware.HEARTBEAT)
 			return TopicHeartbeat{}, nil
 		default:
 			s.log.Warn("Unrecognized response detected.",
@@ -243,16 +252,6 @@ func (s *topicSubscription) onTopicEvent(method string, event middleware.TopicSu
 	if s.topicEventCallback != nil {
 		s.topicEventCallback(s.cacheName, method, event)
 	}
-}
-
-func (s *topicSubscription) decrementSubscriptionCount() int64 {
-	s.mu.Lock()
-	mgr := s.topicManager
-	s.mu.Unlock()
-	if !s.released.CompareAndSwap(false, true) {
-		return mgr.NumActiveSubscriptions.Load()
-	}
-	return s.momentoTopicClient.streamGrpcConnectionPool.ReleaseTopicGrpcManager(mgr)
 }
 
 func (s *topicSubscription) attemptReconnect(ctx context.Context, err error) error {
@@ -278,7 +277,7 @@ func (s *topicSubscription) attemptReconnect(ctx context.Context, err error) err
 			return err
 		}
 
-		s.onTopicEvent("Subscribe", middleware.RECONNECT)
+		s.onTopicEvent(subscribeMethodName, middleware.RECONNECT)
 
 		if *retryBackoffTime > 0 {
 			s.log.Info("Waiting %s milliseconds before attempting to reconnect", fmt.Sprint(*retryBackoffTime))
@@ -286,7 +285,7 @@ func (s *topicSubscription) attemptReconnect(ctx context.Context, err error) err
 		}
 
 		s.log.Info("Attempting reconnecting to client stream")
-		topicManager, subscribeClient, cancelContext, cancelFunction, reconnectErr := s.momentoTopicClient.topicSubscribe(ctx, &TopicSubscribeRequest{
+		newState, reconnectErr := s.momentoTopicClient.topicSubscribe(ctx, &TopicSubscribeRequest{
 			CacheName:                   s.cacheName,
 			TopicName:                   s.topicName,
 			ResumeAtTopicSequenceNumber: s.lastKnownSequenceNumber,
@@ -301,49 +300,27 @@ func (s *topicSubscription) attemptReconnect(ctx context.Context, err error) err
 		}
 
 		s.log.Info("Successfully reconnected to subscription stream")
-		// Install the new stream under the mutex so that a concurrent Close
-		// observes either the old state or the new state, never a torn mix.
-		// Capture the closed flag under the same critical section so that any
-		// Close that ran before we unlock is guaranteed to be seen here.
-		s.mu.Lock()
-		s.topicManager = topicManager
-		s.subscribeClient = subscribeClient
-		s.cancelContext = cancelContext
-		s.cancelFunction = cancelFunction
-		// The new stream has its own release lifecycle; allow the next disconnect
-		// to perform its own decrement.
-		s.released.Store(false)
-		wasClosed := s.closed.Load()
-		s.mu.Unlock()
+		s.state.Store(newState)
 
-		// If Close() ran while we were reconnecting, the cancelFunction it called
-		// targeted the *old* (already-cancelled) cancelFunction, and the decrement
-		// it issued was a no-op against the still-true `released` flag. The new
-		// stream we just installed would otherwise leak past Close — tear it down
-		// here.
-		if wasClosed {
+		// Store before reading closed; Close stores closed before reading
+		// state. Either side observes the other's write, so a Close racing
+		// this reconnect always tears down the new stream.
+		if s.closed.Load() {
 			s.log.Info("Subscription closed during reconnect; tearing down newly established stream")
-			cancelFunction()
-			s.decrementSubscriptionCount()
+			newState.cancelFunction()
+			newState.reservation.Release()
 			return momentoerrors.NewMomentoSvcErr(momentoerrors.CanceledError, "subscription closed", nil)
 		}
 		return nil
 	}
 }
 
-// Close cancels the stream context and releases the per-channel and pool-wide
-// subscription slots. decrementSubscriptionCount is idempotent (guarded by the
-// `released` flag), so if an in-flight Event() loop also observes the cancel
-// and decrements, the counters stay correct. The `closed` flag is set first so
-// that an in-flight attemptReconnect notices and tears down any new stream it
-// allocates instead of leaking it past Close. The cancel function is snapshotted
-// under mu so a concurrent attemptReconnect can't reassign the field while we
-// read it.
+// Close cancels the stream and releases the slot. Safe to call concurrently
+// with Event or another Close; Reservation.Release is idempotent.
 func (s *topicSubscription) Close() {
+	// Set closed before reading state — see attemptReconnect for the inverse.
 	s.closed.Store(true)
-	s.mu.Lock()
-	cancel := s.cancelFunction
-	s.mu.Unlock()
-	cancel()
-	s.decrementSubscriptionCount()
+	state := s.state.Load()
+	state.cancelFunction()
+	state.reservation.Release()
 }

--- a/momento/topic_subscription.go
+++ b/momento/topic_subscription.go
@@ -359,6 +359,20 @@ func (s *topicSubscription) waitBackoff(ctx context.Context, backoff time.Durati
 	case <-timer.C:
 		return nil
 	case <-ctx.Done():
+		// A terminal signal that fired in the same instant wins the tie so
+		// the error carries the terminal cause. (reconnectFailure re-checks
+		// the terminal conditions either way, so classification never
+		// depends on this select.)
+		select {
+		case <-s.streamParentCtx.Done():
+			return momentoerrors.NewMomentoSvcErr(momentoerrors.CanceledError, "subscribe context canceled during reconnect", s.streamParentCtx.Err())
+		default:
+		}
+		select {
+		case <-s.closedSignal:
+			return momentoerrors.NewMomentoSvcErr(momentoerrors.CanceledError, "subscription closed", context.Canceled)
+		default:
+		}
 		return momentoerrors.NewMomentoSvcErr(momentoerrors.CanceledError, "event context canceled during reconnect", errEventCtxInterruptedReconnect)
 	case <-s.streamParentCtx.Done():
 		return momentoerrors.NewMomentoSvcErr(momentoerrors.CanceledError, "subscribe context canceled during reconnect", s.streamParentCtx.Err())
@@ -379,16 +393,17 @@ func (s *topicSubscription) attemptReconnect(ctx context.Context, err error) err
 			s.log.Info("Subscription closed during reconnect; aborting retry loop")
 			return momentoerrors.NewMomentoSvcErr(momentoerrors.CanceledError, "subscription closed", context.Canceled)
 		}
-		// A dead caller ctx pauses recovery (Event resumes it on the next
-		// call); a dead streamParentCtx is terminal since a stream parented
-		// to it can never come up.
-		if ctx.Err() != nil {
-			s.log.Info("Context canceled during reconnect; aborting retry loop")
-			return momentoerrors.NewMomentoSvcErr(momentoerrors.CanceledError, "event context canceled during reconnect", errEventCtxInterruptedReconnect)
-		}
+		// A dead streamParentCtx is terminal (a stream parented to it can
+		// never come up) and is checked before the caller's ctx so a tie
+		// carries the terminal cause; a dead caller ctx pauses recovery
+		// (Event resumes it on the next call).
 		if s.streamParentCtx.Err() != nil {
 			s.log.Info("Subscribe context canceled during reconnect; aborting retry loop")
 			return momentoerrors.NewMomentoSvcErr(momentoerrors.CanceledError, "subscribe context canceled during reconnect", s.streamParentCtx.Err())
+		}
+		if ctx.Err() != nil {
+			s.log.Info("Context canceled during reconnect; aborting retry loop")
+			return momentoerrors.NewMomentoSvcErr(momentoerrors.CanceledError, "event context canceled during reconnect", errEventCtxInterruptedReconnect)
 		}
 
 		retryBackoffTime := s.retryStrategy.DetermineWhenToRetry(retry.StrategyProps{

--- a/momento/topic_subscription.go
+++ b/momento/topic_subscription.go
@@ -31,9 +31,18 @@ import (
 //     an in-flight Item/Event call returns an error — immediately if blocked
 //     receiving, or at the next retry check if a reconnect is in flight
 //     (Close also interrupts a reconnect backoff wait).
-//   - A ctx error returned from Item/Event ends the subscription: the stream
-//     is torn down and its pool slot released. Start a new subscription via
-//     Subscribe to resume.
+//   - An error from the ctx YOU passed to Item/Event means only that the
+//     call stopped waiting: the subscription stays active and a later call
+//     with a live ctx resumes it, including resuming an interrupted
+//     reconnect. This matches the timeout semantics of comparable clients
+//     (NATS NextMsg, Kafka ReadMessage). A call blocked receiving notices
+//     the ctx at the next message/heartbeat boundary or stream event.
+//   - Terminal errors (Close was called, or the ctx passed to Subscribe
+//     ended) carry the CanceledError code and unwrap to the underlying
+//     context error; check your own ctx first to tell the two apart. The
+//     subscription holds a pool slot while it has a live stream; during a
+//     reconnect the slot is released and re-acquired, and an abandoned
+//     subscription holds its slot until Close.
 type TopicSubscription interface {
 	// Item returns only subscription events that contain a string or byte message.
 	// Example:
@@ -109,6 +118,12 @@ type topicSubscription struct {
 	// streams are parented to it so their lifetime matches the original
 	// stream's, not the ctx of whichever Event call triggered the reconnect.
 	streamParentCtx context.Context
+	// needsReconnect and lastStreamErr carry an interrupted recovery across
+	// Event calls: when the caller's ctx dies after a stream failure, the
+	// next call resumes the reconnect instead of the subscription dying.
+	// Only the Event goroutine touches them (see the concurrency contract).
+	needsReconnect bool
+	lastStreamErr  error
 	// closed is set by Close. attemptReconnect bails out if it observes this set.
 	closed atomic.Bool
 	// closedSignal wakes a reconnect backoff wait when Close is called. Only
@@ -152,6 +167,15 @@ func (s *topicSubscription) Item(ctx context.Context) (TopicValue, error) {
 
 func (s *topicSubscription) Event(ctx context.Context) (TopicEvent, error) {
 	for {
+		// A previous call's ctx may have died mid-recovery; resume the
+		// reconnect before reading so the subscription survives.
+		if s.needsReconnect {
+			if reconnectErr := s.resumeReconnect(ctx); reconnectErr != nil {
+				return nil, reconnectErr
+			}
+			continue // re-snapshot the freshly stored state
+		}
+
 		// Snapshot state once per iteration so every read in this loop body
 		// references the same Reservation/cancelContext/cancelFunction triple.
 		// attemptReconnect (called below, same goroutine) Stores a new state
@@ -162,22 +186,19 @@ func (s *topicSubscription) Event(ctx context.Context) (TopicEvent, error) {
 		// Callers can cancel ctx right after subscribing; check before Recv.
 		select {
 		case <-ctx.Done():
-			// A ctx error is terminal for the subscription: tear the stream
-			// down so the released slot isn't backed by a live stream.
-			state.cancelFunction()
-			decremented := state.reservation.Release()
-			s.log.Debug(
-				"[Event] Context done, number of active streams on current grpc channel: %d",
-				decremented,
-			)
+			// If the stream itself is already dead (Close or the Subscribe
+			// ctx ended), prefer the terminal path so the slot is released
+			// even when both contexts died together.
+			select {
+			case <-state.cancelContext.Done():
+				return nil, s.terminate(state)
+			default:
+			}
+			// The caller stopped waiting; the subscription and its slot stay
+			// intact, and the next Item/Event call picks up where we left off.
 			return nil, ctx.Err()
 		case <-state.cancelContext.Done():
-			decremented := state.reservation.Release()
-			s.log.Debug(
-				"[Event] Context cancelled, number of active streams on current grpc channel: %d",
-				decremented,
-			)
-			return nil, state.cancelContext.Err()
+			return nil, s.terminate(state)
 		default:
 		}
 
@@ -186,23 +207,22 @@ func (s *topicSubscription) Event(ctx context.Context) (TopicEvent, error) {
 			select {
 			case <-ctx.Done():
 				{
-					// Terminal, as in the pre-Recv check: cancel before release.
+					// The stream failed while the caller's ctx is dead: tear
+					// the dead stream down now (its slot must not stay
+					// counted), and let the next call resume via reconnect.
 					state.cancelFunction()
 					decremented := state.reservation.Release()
+					s.needsReconnect = true
+					s.lastStreamErr = err
 					s.log.Debug(
-						"[Event RecvMsg] Context done, number of active streams on current grpc channel: %d",
+						"[Event RecvMsg] Context done, reconnect deferred to the next call, number of active streams on current grpc channel: %d",
 						decremented,
 					)
 					return nil, ctx.Err()
 				}
 			case <-state.cancelContext.Done():
 				{
-					decremented := state.reservation.Release()
-					s.log.Debug(
-						"[Event RecvMsg] Context cancelled, number of active streams on current grpc channel: %d",
-						decremented,
-					)
-					return nil, state.cancelContext.Err()
+					return nil, s.terminate(state)
 				}
 			default:
 				{
@@ -217,17 +237,10 @@ func (s *topicSubscription) Event(ctx context.Context) (TopicEvent, error) {
 						decremented,
 					)
 
-					err := s.attemptReconnect(ctx, err)
-					if err != nil {
-						// attemptReconnect returns typed MomentoSvcErrs (e.g.
-						// CanceledError on Close); ConvertSvcErr would demote
-						// them to ClientSdkError since they carry no gRPC
-						// status, so pass them through unchanged.
-						var svcErr momentoerrors.MomentoSvcErr
-						if errors.As(err, &svcErr) {
-							return nil, svcErr
-						}
-						return nil, momentoerrors.ConvertSvcErr(err)
+					streamErr := err
+					reconnectErr := s.attemptReconnect(ctx, streamErr)
+					if reconnectErr != nil {
+						return nil, s.reconnectFailure(ctx, streamErr, reconnectErr)
 					}
 				}
 			}
@@ -273,6 +286,54 @@ func (s *topicSubscription) Event(ctx context.Context) (TopicEvent, error) {
 	}
 }
 
+// terminate releases the slot of a subscription whose stream context has
+// ended (Close, or the Subscribe-time ctx died) and returns the typed
+// terminal error. It wraps the context error so errors.Is still matches,
+// while the CanceledError code lets callers distinguish a dead subscription
+// from their own ctx expiring.
+func (s *topicSubscription) terminate(state *streamState) error {
+	decremented := state.reservation.Release()
+	s.log.Debug(
+		"[Event] Subscription stream context ended, number of active streams on current grpc channel: %d",
+		decremented,
+	)
+	return momentoerrors.NewMomentoSvcErr(momentoerrors.CanceledError, "subscription ended", state.cancelContext.Err())
+}
+
+// resumeReconnect re-enters an interrupted recovery at the top of Event.
+// Returns nil when the stream is re-established (needsReconnect cleared).
+func (s *topicSubscription) resumeReconnect(ctx context.Context) error {
+	if ctx.Err() != nil {
+		// Still no live ctx; stay paused.
+		return ctx.Err()
+	}
+	if reconnectErr := s.attemptReconnect(ctx, s.lastStreamErr); reconnectErr != nil {
+		return s.reconnectFailure(ctx, s.lastStreamErr, reconnectErr)
+	}
+	s.needsReconnect = false
+	s.lastStreamErr = nil
+	return nil
+}
+
+// reconnectFailure classifies a failed attemptReconnect: a dead caller ctx
+// pauses the recovery (the next call resumes it), anything else surfaces with
+// its typed code intact.
+func (s *topicSubscription) reconnectFailure(ctx context.Context, streamErr error, reconnectErr error) error {
+	if ctx.Err() != nil && !s.closed.Load() && s.streamParentCtx.Err() == nil {
+		s.needsReconnect = true
+		s.lastStreamErr = streamErr
+		return ctx.Err()
+	}
+	// attemptReconnect returns typed MomentoSvcErrs (e.g. CanceledError on
+	// Close); ConvertSvcErr would demote them to ClientSdkError since they
+	// carry no gRPC status, so pass them through unchanged.
+	var svcErr momentoerrors.MomentoSvcErr
+	if errors.As(reconnectErr, &svcErr) {
+		return svcErr
+	}
+	return momentoerrors.ConvertSvcErr(reconnectErr)
+}
+
 func (s *topicSubscription) onTopicEvent(method string, event middleware.TopicSubscriptionEventType) {
 	if s.topicEventCallback != nil {
 		s.topicEventCallback(s.cacheName, method, event)
@@ -290,9 +351,9 @@ func (s *topicSubscription) attemptReconnect(ctx context.Context, err error) err
 			s.log.Info("Subscription closed during reconnect; aborting retry loop")
 			return momentoerrors.NewMomentoSvcErr(momentoerrors.CanceledError, "subscription closed", nil)
 		}
-		// The caller's ctx is terminal for the subscription (see Event), and a
-		// stream parented to a dead streamParentCtx can never come up; stop
-		// instead of retrying forever.
+		// A dead caller ctx pauses recovery (Event resumes it on the next
+		// call); a dead streamParentCtx is terminal since a stream parented
+		// to it can never come up.
 		if ctx.Err() != nil {
 			s.log.Info("Context canceled during reconnect; aborting retry loop")
 			return momentoerrors.NewMomentoSvcErr(momentoerrors.CanceledError, "event context canceled during reconnect", ctx.Err())

--- a/momento/topic_subscription.go
+++ b/momento/topic_subscription.go
@@ -93,6 +93,12 @@ type TopicSubscription interface {
 // events.
 const subscribeMethodName = "Subscribe"
 
+// errEventCtxInterruptedReconnect marks attemptReconnect aborts caused by the
+// caller's per-call ctx dying. Event converts exactly these into a paused
+// recovery that the next call resumes; it wraps context.Canceled so the error
+// stays errors.Is-compatible on the terminal edges where it can escape.
+var errEventCtxInterruptedReconnect = fmt.Errorf("event context canceled during reconnect: %w", context.Canceled)
+
 // streamState bundles the fields swapped together on every (re)connect. Held
 // in an atomic.Pointer so readers see a consistent snapshot.
 type streamState struct {
@@ -318,7 +324,10 @@ func (s *topicSubscription) resumeReconnect(ctx context.Context) error {
 // pauses the recovery (the next call resumes it), anything else surfaces with
 // its typed code intact.
 func (s *topicSubscription) reconnectFailure(ctx context.Context, streamErr error, reconnectErr error) error {
-	if ctx.Err() != nil && !s.closed.Load() && s.streamParentCtx.Err() == nil {
+	// Pause only when the reconnect was interrupted by the caller's ctx; a
+	// give-up or terminal verdict that merely coincides with a dead ctx must
+	// surface as-is rather than being resurrected by the next call.
+	if errors.Is(reconnectErr, errEventCtxInterruptedReconnect) && !s.closed.Load() && s.streamParentCtx.Err() == nil {
 		s.needsReconnect = true
 		s.lastStreamErr = streamErr
 		return ctx.Err()
@@ -339,6 +348,26 @@ func (s *topicSubscription) onTopicEvent(method string, event middleware.TopicSu
 	}
 }
 
+// waitBackoff sleeps for the retry backoff, waking early when the caller's
+// ctx dies, the Subscribe-time ctx dies, or Close is called. The timer is
+// stopped on early exit so interrupted waits don't leave timers running
+// during reconnect storms with long backoffs.
+func (s *topicSubscription) waitBackoff(ctx context.Context, backoff time.Duration) error {
+	timer := time.NewTimer(backoff)
+	defer timer.Stop()
+	select {
+	case <-timer.C:
+		return nil
+	case <-ctx.Done():
+		return momentoerrors.NewMomentoSvcErr(momentoerrors.CanceledError, "event context canceled during reconnect", errEventCtxInterruptedReconnect)
+	case <-s.streamParentCtx.Done():
+		return momentoerrors.NewMomentoSvcErr(momentoerrors.CanceledError, "subscribe context canceled during reconnect", s.streamParentCtx.Err())
+	case <-s.closedSignal:
+		s.log.Info("Subscription closed during reconnect backoff; aborting retry loop")
+		return momentoerrors.NewMomentoSvcErr(momentoerrors.CanceledError, "subscription closed", context.Canceled)
+	}
+}
+
 func (s *topicSubscription) attemptReconnect(ctx context.Context, err error) error {
 	if s.retryStrategy == nil {
 		s.log.Info("No retry strategy provided, returning error")
@@ -348,14 +377,14 @@ func (s *topicSubscription) attemptReconnect(ctx context.Context, err error) err
 	for {
 		if s.closed.Load() {
 			s.log.Info("Subscription closed during reconnect; aborting retry loop")
-			return momentoerrors.NewMomentoSvcErr(momentoerrors.CanceledError, "subscription closed", nil)
+			return momentoerrors.NewMomentoSvcErr(momentoerrors.CanceledError, "subscription closed", context.Canceled)
 		}
 		// A dead caller ctx pauses recovery (Event resumes it on the next
 		// call); a dead streamParentCtx is terminal since a stream parented
 		// to it can never come up.
 		if ctx.Err() != nil {
 			s.log.Info("Context canceled during reconnect; aborting retry loop")
-			return momentoerrors.NewMomentoSvcErr(momentoerrors.CanceledError, "event context canceled during reconnect", ctx.Err())
+			return momentoerrors.NewMomentoSvcErr(momentoerrors.CanceledError, "event context canceled during reconnect", errEventCtxInterruptedReconnect)
 		}
 		if s.streamParentCtx.Err() != nil {
 			s.log.Info("Subscribe context canceled during reconnect; aborting retry loop")
@@ -377,15 +406,8 @@ func (s *topicSubscription) attemptReconnect(ctx context.Context, err error) err
 
 		if *retryBackoffTime > 0 {
 			s.log.Info("Waiting %s milliseconds before attempting to reconnect", fmt.Sprint(*retryBackoffTime))
-			select {
-			case <-time.After(time.Duration(*retryBackoffTime) * time.Millisecond):
-			case <-ctx.Done():
-				return momentoerrors.NewMomentoSvcErr(momentoerrors.CanceledError, "event context canceled during reconnect", ctx.Err())
-			case <-s.streamParentCtx.Done():
-				return momentoerrors.NewMomentoSvcErr(momentoerrors.CanceledError, "subscribe context canceled during reconnect", s.streamParentCtx.Err())
-			case <-s.closedSignal:
-				s.log.Info("Subscription closed during reconnect backoff; aborting retry loop")
-				return momentoerrors.NewMomentoSvcErr(momentoerrors.CanceledError, "subscription closed", nil)
+			if waitErr := s.waitBackoff(ctx, time.Duration(*retryBackoffTime)*time.Millisecond); waitErr != nil {
+				return waitErr
 			}
 		}
 
@@ -424,7 +446,7 @@ func (s *topicSubscription) attemptReconnect(ctx context.Context, err error) err
 			s.log.Info("Subscription closed during reconnect; tearing down newly established stream")
 			newState.cancelFunction()
 			newState.reservation.Release()
-			return momentoerrors.NewMomentoSvcErr(momentoerrors.CanceledError, "subscription closed", nil)
+			return momentoerrors.NewMomentoSvcErr(momentoerrors.CanceledError, "subscription closed", context.Canceled)
 		}
 		return nil
 	}

--- a/momento/topic_subscription.go
+++ b/momento/topic_subscription.go
@@ -220,6 +220,14 @@ func (s *topicSubscription) Event(ctx context.Context) (TopicEvent, error) {
 
 					err := s.attemptReconnect(ctx, err)
 					if err != nil {
+						// attemptReconnect returns typed MomentoSvcErrs (e.g.
+						// CanceledError on Close); ConvertSvcErr would demote
+						// them to ClientSdkError since they carry no gRPC
+						// status, so pass them through unchanged.
+						var svcErr momentoerrors.MomentoSvcErr
+						if errors.As(err, &svcErr) {
+							return nil, svcErr
+						}
 						return nil, momentoerrors.ConvertSvcErr(err)
 					}
 				}
@@ -288,7 +296,7 @@ func (s *topicSubscription) attemptReconnect(ctx context.Context, err error) err
 		// instead of retrying forever.
 		if ctx.Err() != nil {
 			s.log.Info("Context canceled during reconnect; aborting retry loop")
-			return momentoerrors.NewMomentoSvcErr(momentoerrors.CanceledError, "subscribe context canceled during reconnect", ctx.Err())
+			return momentoerrors.NewMomentoSvcErr(momentoerrors.CanceledError, "event context canceled during reconnect", ctx.Err())
 		}
 		if s.streamParentCtx.Err() != nil {
 			s.log.Info("Subscribe context canceled during reconnect; aborting retry loop")
@@ -313,7 +321,9 @@ func (s *topicSubscription) attemptReconnect(ctx context.Context, err error) err
 			select {
 			case <-time.After(time.Duration(*retryBackoffTime) * time.Millisecond):
 			case <-ctx.Done():
-				return momentoerrors.NewMomentoSvcErr(momentoerrors.CanceledError, "subscribe context canceled during reconnect", ctx.Err())
+				return momentoerrors.NewMomentoSvcErr(momentoerrors.CanceledError, "event context canceled during reconnect", ctx.Err())
+			case <-s.streamParentCtx.Done():
+				return momentoerrors.NewMomentoSvcErr(momentoerrors.CanceledError, "subscribe context canceled during reconnect", s.streamParentCtx.Err())
 			case <-s.closedSignal:
 				s.log.Info("Subscription closed during reconnect backoff; aborting retry loop")
 				return momentoerrors.NewMomentoSvcErr(momentoerrors.CanceledError, "subscription closed", nil)

--- a/momento/topic_subscription.go
+++ b/momento/topic_subscription.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -27,9 +28,13 @@ import (
 //     subscription tracks per-stream sequence state without locking on the
 //     hot path.
 //   - Close is safe to call concurrently with an in-flight Item/Event call,
-//     and is safe to call more than once. Close unblocks the consumer
-//     goroutine by cancelling the stream context; the consumer will then
-//     observe a cancelled-context error from Item/Event.
+//     and is safe to call more than once. Close cancels the stream context;
+//     an in-flight Item/Event call returns an error — immediately if blocked
+//     receiving, or at the next retry check if a reconnect is in flight
+//     (Close also interrupts a reconnect backoff wait).
+//   - A ctx error returned from Item/Event ends the subscription: the stream
+//     is torn down and its pool slot released. Start a new subscription via
+//     Subscribe to resume.
 type TopicSubscription interface {
 	// Item returns only subscription events that contain a string or byte message.
 	// Example:
@@ -101,8 +106,15 @@ type topicSubscription struct {
 	lastKnownSequenceNumber uint64
 	lastKnownSequencePage   uint64
 	retryStrategy           retry.Strategy
+	// streamParentCtx is the ctx the caller passed to Subscribe. Reconnected
+	// streams are parented to it so their lifetime matches the original
+	// stream's, not the ctx of whichever Event call triggered the reconnect.
+	streamParentCtx context.Context
 	// closed is set by Close. attemptReconnect bails out if it observes this set.
 	closed atomic.Bool
+	// closedSignal wakes a reconnect backoff wait when Close is called.
+	closedSignal    chan struct{}
+	closeSignalOnce sync.Once
 }
 
 // grpcStatusCode returns the gRPC status code for err, unwrapping
@@ -151,6 +163,9 @@ func (s *topicSubscription) Event(ctx context.Context) (TopicEvent, error) {
 		// Callers can cancel ctx right after subscribing; check before Recv.
 		select {
 		case <-ctx.Done():
+			// A ctx error is terminal for the subscription: tear the stream
+			// down so the released slot isn't backed by a live stream.
+			state.cancelFunction()
 			decremented := state.reservation.Release()
 			s.log.Debug(
 				"[Event] Context done, number of active streams on current grpc channel: %d",
@@ -172,6 +187,8 @@ func (s *topicSubscription) Event(ctx context.Context) (TopicEvent, error) {
 			select {
 			case <-ctx.Done():
 				{
+					// Terminal, as in the pre-Recv check: cancel before release.
+					state.cancelFunction()
 					decremented := state.reservation.Release()
 					s.log.Debug(
 						"[Event RecvMsg] Context done, number of active streams on current grpc channel: %d",
@@ -266,11 +283,16 @@ func (s *topicSubscription) attemptReconnect(ctx context.Context, err error) err
 			s.log.Info("Subscription closed during reconnect; aborting retry loop")
 			return momentoerrors.NewMomentoSvcErr(momentoerrors.CanceledError, "subscription closed", nil)
 		}
-		// A reconnected stream would be a child of ctx, so once ctx is dead a
-		// reconnect can never succeed; stop instead of retrying forever.
+		// The caller's ctx is terminal for the subscription (see Event), and a
+		// stream parented to a dead streamParentCtx can never come up; stop
+		// instead of retrying forever.
 		if ctx.Err() != nil {
 			s.log.Info("Context canceled during reconnect; aborting retry loop")
 			return momentoerrors.NewMomentoSvcErr(momentoerrors.CanceledError, "subscribe context canceled during reconnect", ctx.Err())
+		}
+		if s.streamParentCtx.Err() != nil {
+			s.log.Info("Subscribe context canceled during reconnect; aborting retry loop")
+			return momentoerrors.NewMomentoSvcErr(momentoerrors.CanceledError, "subscribe context canceled during reconnect", s.streamParentCtx.Err())
 		}
 
 		retryBackoffTime := s.retryStrategy.DetermineWhenToRetry(retry.StrategyProps{
@@ -292,11 +314,16 @@ func (s *topicSubscription) attemptReconnect(ctx context.Context, err error) err
 			case <-time.After(time.Duration(*retryBackoffTime) * time.Millisecond):
 			case <-ctx.Done():
 				return momentoerrors.NewMomentoSvcErr(momentoerrors.CanceledError, "subscribe context canceled during reconnect", ctx.Err())
+			case <-s.closedSignal:
+				s.log.Info("Subscription closed during reconnect backoff; aborting retry loop")
+				return momentoerrors.NewMomentoSvcErr(momentoerrors.CanceledError, "subscription closed", nil)
 			}
 		}
 
 		s.log.Info("Attempting reconnecting to client stream")
-		newState, reconnectErr := s.momentoTopicClient.topicSubscribe(ctx, &TopicSubscribeRequest{
+		// Parent the replacement stream to the Subscribe-time ctx, not this
+		// Event call's ctx, so the stream's lifetime is stable across Events.
+		newState, reconnectErr := s.momentoTopicClient.topicSubscribe(s.streamParentCtx, &TopicSubscribeRequest{
 			CacheName:                   s.cacheName,
 			TopicName:                   s.topicName,
 			ResumeAtTopicSequenceNumber: s.lastKnownSequenceNumber,
@@ -331,6 +358,7 @@ func (s *topicSubscription) attemptReconnect(ctx context.Context, err error) err
 func (s *topicSubscription) Close() {
 	// Set closed before reading state — see attemptReconnect for the inverse.
 	s.closed.Store(true)
+	s.closeSignalOnce.Do(func() { close(s.closedSignal) })
 	state := s.state.Load()
 	state.cancelFunction()
 	state.reservation.Release()

--- a/momento/topic_subscription.go
+++ b/momento/topic_subscription.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"sync"
 	"sync/atomic"
 	"time"
 
@@ -112,9 +111,9 @@ type topicSubscription struct {
 	streamParentCtx context.Context
 	// closed is set by Close. attemptReconnect bails out if it observes this set.
 	closed atomic.Bool
-	// closedSignal wakes a reconnect backoff wait when Close is called.
-	closedSignal    chan struct{}
-	closeSignalOnce sync.Once
+	// closedSignal wakes a reconnect backoff wait when Close is called. Only
+	// the Close that wins the closed CAS closes it.
+	closedSignal chan struct{}
 }
 
 // grpcStatusCode returns the gRPC status code for err, unwrapping
@@ -341,6 +340,14 @@ func (s *topicSubscription) attemptReconnect(ctx context.Context, err error) err
 		})
 
 		if reconnectErr != nil {
+			// A canceled reconnect can never succeed: the pool is shutting
+			// down or the stream's parent context is dead. Stop instead of
+			// burning retries (the legacy default strategy retries forever).
+			var svcErr momentoerrors.MomentoSvcErr
+			if errors.As(reconnectErr, &svcErr) && svcErr.Code() == momentoerrors.CanceledError {
+				s.log.Info("Reconnect attempt was canceled; aborting retry loop")
+				return reconnectErr
+			}
 			s.log.Warn("Failed to reconnect to stream: %s", reconnectErr.Error())
 			err = reconnectErr
 			attempt++
@@ -367,8 +374,10 @@ func (s *topicSubscription) attemptReconnect(ctx context.Context, err error) err
 // with Event or another Close; Reservation.Release is idempotent.
 func (s *topicSubscription) Close() {
 	// Set closed before reading state — see attemptReconnect for the inverse.
-	s.closed.Store(true)
-	s.closeSignalOnce.Do(func() { close(s.closedSignal) })
+	// The CAS doubles as the once-guard for closing the signal channel.
+	if s.closed.CompareAndSwap(false, true) {
+		close(s.closedSignal)
+	}
 	state := s.state.Load()
 	state.cancelFunction()
 	state.reservation.Release()

--- a/momento/topic_subscription.go
+++ b/momento/topic_subscription.go
@@ -31,12 +31,11 @@ import (
 //     an in-flight Item/Event call returns an error — immediately if blocked
 //     receiving, or at the next retry check if a reconnect is in flight
 //     (Close also interrupts a reconnect backoff wait).
-//   - An error from the ctx YOU passed to Item/Event means only that the
-//     call stopped waiting: the subscription stays active and a later call
-//     with a live ctx resumes it, including resuming an interrupted
-//     reconnect. This matches the timeout semantics of comparable clients
-//     (NATS NextMsg, Kafka ReadMessage). A call blocked receiving notices
-//     the ctx at the next message/heartbeat boundary or stream event.
+//   - An error from the ctx passed to Item/Event means only that the call
+//     stopped waiting: the subscription stays active and a later call with
+//     a live ctx resumes it, including resuming an interrupted reconnect.
+//     A call blocked receiving notices the ctx at the next
+//     message/heartbeat boundary or stream event.
 //   - Terminal errors (Close was called, or the ctx passed to Subscribe
 //     ended) carry the CanceledError code and unwrap to the underlying
 //     context error; check your own ctx first to tell the two apart. The

--- a/momento/topic_subscription_accounting_test.go
+++ b/momento/topic_subscription_accounting_test.go
@@ -740,6 +740,56 @@ func TestTopicSubscriptionReconnectUsesSubscribeContext(t *testing.T) {
 	assertAccounting(t, pool, 0)
 }
 
+// TestTopicSubscriptionCloseUnblocksEventBlockedInRecv pins the documented
+// Close contract: an Event call blocked in Recv returns promptly with an
+// error when Close cancels the stream context, with the slot released.
+func TestTopicSubscriptionCloseUnblocksEventBlockedInRecv(t *testing.T) {
+	recvBlocked := make(chan struct{})
+	var recvBlockedOnce sync.Once
+	streamClient := &testPubsubClient{
+		subscribe: func(ctx context.Context, _ *pb.XSubscriptionRequest, _ ...grpc.CallOption) (pb.Pubsub_SubscribeClient, error) {
+			heartbeatSent := false
+			return &testSubscribeClient{
+				recv: func() (*pb.XSubscriptionItem, error) {
+					if !heartbeatSent {
+						heartbeatSent = true
+						return heartbeatItem(), nil
+					}
+					recvBlockedOnce.Do(func() { close(recvBlocked) })
+					<-ctx.Done()
+					return nil, status.FromContextError(ctx.Err()).Err()
+				},
+			}, nil
+		},
+	}
+	client, pool := newAccountingTestClient(streamClient, time.Second)
+
+	sub, err := client.Subscribe(context.Background(), testSubscribeRequest())
+	if err != nil {
+		t.Fatalf("Subscribe returned error: %v", err)
+	}
+	assertAccounting(t, pool, 1)
+
+	eventDone := make(chan error, 1)
+	go func() {
+		_, eventErr := sub.Event(context.Background())
+		eventDone <- eventErr
+	}()
+
+	<-recvBlocked // Event is now blocked inside Recv
+	sub.Close()
+
+	select {
+	case eventErr := <-eventDone:
+		if eventErr == nil {
+			t.Fatal("expected Event to return an error after Close")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Event blocked in Recv did not return within 5s of Close")
+	}
+	assertAccounting(t, pool, 0)
+}
+
 // TestTopicSubscriptionReconnectStopsWhenPoolIsClosed verifies the retry loop
 // treats the pool's shutdown CanceledError as terminal: even an always-retry
 // strategy must not spin against a closed pool.

--- a/momento/topic_subscription_accounting_test.go
+++ b/momento/topic_subscription_accounting_test.go
@@ -520,4 +520,3 @@ func TestTopicPublishUnaryReleasesReservationOncePerCall(t *testing.T) {
 		t.Fatalf("releaseCount = %d, want %d (exactly one Release per publish)", got, publishCount)
 	}
 }
-

--- a/momento/topic_subscription_accounting_test.go
+++ b/momento/topic_subscription_accounting_test.go
@@ -103,6 +103,15 @@ func (g giveUpAfterRetryStrategy) DetermineWhenToRetry(props retry.StrategyProps
 	return &delay
 }
 
+// fixedBackoffRetryStrategy always retries after a fixed backoff.
+type fixedBackoffRetryStrategy struct {
+	backoffMs int
+}
+
+func (f fixedBackoffRetryStrategy) DetermineWhenToRetry(retry.StrategyProps) *int {
+	return &f.backoffMs
+}
+
 func newAccountingTestClient(streamClient pb.PubsubClient, timeout time.Duration) (defaultTopicClient, *testTopicGrpcConnectionPool) {
 	return newAccountingTestClientWithStrategy(streamClient, timeout, alwaysRetryStrategy{})
 }
@@ -486,6 +495,65 @@ func TestTopicSubscriptionReconnectGiveUpReleasesPoolCounters(t *testing.T) {
 
 	// Close after give-up must be a no-op and must not panic.
 	sub.Close()
+	assertAccounting(t, pool, 0)
+}
+
+// TestTopicSubscriptionReconnectAbortsWhenContextCanceled pins the retry
+// loop's response to user-context cancellation: Event must return promptly
+// with balanced counters instead of retrying (here, sleeping a 10-minute
+// backoff) against a context that can never produce a live stream again.
+func TestTopicSubscriptionReconnectAbortsWhenContextCanceled(t *testing.T) {
+	disconnectErr := status.Error(codes.Unavailable, "stream disconnected")
+	var subscribeCalls atomic.Uint64
+	streamClient := &testPubsubClient{
+		subscribe: func(context.Context, *pb.XSubscriptionRequest, ...grpc.CallOption) (pb.Pubsub_SubscribeClient, error) {
+			if subscribeCalls.Add(1) == 1 {
+				return &testSubscribeClient{
+					results: []recvResult{
+						{item: heartbeatItem()},
+						{err: disconnectErr},
+					},
+				}, nil
+			}
+			// Reconnect attempts keep failing so Event stays in the retry loop
+			// (sleeping the fixed backoff) until the context is canceled.
+			return nil, disconnectErr
+		},
+	}
+	client, pool := newAccountingTestClientWithStrategy(
+		streamClient,
+		time.Second,
+		fixedBackoffRetryStrategy{backoffMs: 10 * 60 * 1000},
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	sub, err := client.Subscribe(ctx, testSubscribeRequest())
+	if err != nil {
+		t.Fatalf("Subscribe returned error: %v", err)
+	}
+	assertAccounting(t, pool, 1)
+
+	eventDone := make(chan error, 1)
+	go func() {
+		_, eventErr := sub.Event(ctx)
+		eventDone <- eventErr
+	}()
+
+	// Give Event a moment to hit the disconnect and enter the backoff sleep,
+	// then cancel. Whichever point the loop has reached, cancellation must
+	// surface promptly; without the ctx checks this would block ~10 minutes.
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+
+	select {
+	case eventErr := <-eventDone:
+		if eventErr == nil {
+			t.Fatal("expected Event to return an error after context cancellation")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Event did not return within 5s of context cancellation")
+	}
 	assertAccounting(t, pool, 0)
 }
 

--- a/momento/topic_subscription_accounting_test.go
+++ b/momento/topic_subscription_accounting_test.go
@@ -37,7 +37,7 @@ func newTestTopicGrpcConnectionPool(streamClient pb.PubsubClient) *testTopicGrpc
 
 func (p *testTopicGrpcConnectionPool) GetNextTopicGrpcManager() (*topic_manager_lists.Reservation, momentoerrors.MomentoSvcErr) {
 	if p.closed.Load() {
-		return nil, momentoerrors.NewMomentoSvcErr(momentoerrors.CanceledError, "connection pool is shutting down", nil)
+		return nil, momentoerrors.NewMomentoSvcErr(momentoerrors.CanceledError, "connection pool is shutting down", context.Canceled)
 	}
 	p.manager.NumActiveSubscriptions.Add(1)
 	p.activeCount.Add(1)
@@ -366,6 +366,9 @@ func TestTopicSubscriptionCloseDuringReconnectTearsDownNewStream(t *testing.T) {
 		t.Fatal("expected Event to return an error after close-during-reconnect")
 	}
 	assertErrorCode(t, eventErr, momentoerrors.CanceledError)
+	if !errors.Is(eventErr, context.Canceled) {
+		t.Fatalf("terminal error should unwrap to context.Canceled, got %v", eventErr)
+	}
 	assertAccounting(t, pool, 0)
 }
 
@@ -634,6 +637,72 @@ func TestTopicSubscriptionEventAfterCloseReturnsTypedCanceled(t *testing.T) {
 	}
 }
 
+// TestTopicSubscriptionSubscribeCtxCancelEndsSubscription pins the other
+// terminal flavor: cancelling the ctx passed to Subscribe tears down an
+// established subscription. The blocked-Recv fake also pins stream lineage —
+// the stream context must be a child of the Subscribe ctx, so cancellation
+// unblocks a waiting Event, which returns the typed terminal error and
+// releases the slot.
+func TestTopicSubscriptionSubscribeCtxCancelEndsSubscription(t *testing.T) {
+	recvBlocked := make(chan struct{})
+	var recvBlockedOnce sync.Once
+	streamClient := &testPubsubClient{
+		subscribe: func(ctx context.Context, _ *pb.XSubscriptionRequest, _ ...grpc.CallOption) (pb.Pubsub_SubscribeClient, error) {
+			heartbeatSent := false
+			return &testSubscribeClient{
+				recv: func() (*pb.XSubscriptionItem, error) {
+					if !heartbeatSent {
+						heartbeatSent = true
+						return heartbeatItem(), nil
+					}
+					recvBlockedOnce.Do(func() { close(recvBlocked) })
+					<-ctx.Done()
+					return nil, status.FromContextError(ctx.Err()).Err()
+				},
+			}, nil
+		},
+	}
+	client, pool := newAccountingTestClient(streamClient, time.Second)
+
+	subscribeCtx, cancelSubscribeCtx := context.WithCancel(context.Background())
+	defer cancelSubscribeCtx()
+	sub, err := client.Subscribe(subscribeCtx, testSubscribeRequest())
+	if err != nil {
+		t.Fatalf("Subscribe returned error: %v", err)
+	}
+	assertAccounting(t, pool, 1)
+
+	eventDone := make(chan error, 1)
+	go func() {
+		_, eventErr := sub.Event(context.Background())
+		eventDone <- eventErr
+	}()
+
+	// Cancel the Subscribe-time ctx while Event is blocked in Recv. The
+	// stream context is its child, so the blocked call must return.
+	<-recvBlocked
+	cancelSubscribeCtx()
+
+	state := sub.(*topicSubscription).state.Load()
+	if state.cancelContext.Err() == nil {
+		t.Fatal("the stream context must be a child of the Subscribe ctx")
+	}
+
+	select {
+	case eventErr := <-eventDone:
+		if eventErr == nil {
+			t.Fatal("expected Event to return an error after Subscribe-ctx cancellation")
+		}
+		assertErrorCode(t, eventErr, momentoerrors.CanceledError)
+		if !errors.Is(eventErr, context.Canceled) {
+			t.Fatalf("terminal error should unwrap to context.Canceled, got %v", eventErr)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Event did not return within 5s of Subscribe-ctx cancellation")
+	}
+	assertAccounting(t, pool, 0)
+}
+
 // TestTopicSubscriptionReconnectPausesOnContextCancelAndResumes drives the
 // retry loop into a long backoff, cancels the caller's ctx (Event must return
 // promptly), then verifies the next call with a live ctx resumes the
@@ -830,6 +899,9 @@ func TestTopicSubscriptionCloseInterruptsReconnectBackoff(t *testing.T) {
 			t.Fatal("expected Event to return an error after Close")
 		}
 		assertErrorCode(t, eventErr, momentoerrors.CanceledError)
+		if !errors.Is(eventErr, context.Canceled) {
+			t.Fatalf("terminal error should unwrap to context.Canceled, got %v", eventErr)
+		}
 	case <-time.After(5 * time.Second):
 		t.Fatal("Event did not return within 5s of Close (backoff not interrupted)")
 	}
@@ -987,6 +1059,9 @@ func TestTopicSubscriptionReconnectStopsWhenPoolIsClosed(t *testing.T) {
 			t.Fatal("expected Event to return an error after the pool closed")
 		}
 		assertErrorCode(t, eventErr, momentoerrors.CanceledError)
+		if !errors.Is(eventErr, context.Canceled) {
+			t.Fatalf("terminal error should unwrap to context.Canceled, got %v", eventErr)
+		}
 	case <-time.After(5 * time.Second):
 		t.Fatal("Event did not return within 5s; reconnect loop is spinning against a closed pool")
 	}

--- a/momento/topic_subscription_accounting_test.go
+++ b/momento/topic_subscription_accounting_test.go
@@ -162,6 +162,18 @@ func topicItem(sequenceNumber uint64) *pb.XSubscriptionItem {
 	}
 }
 
+// assertErrorCode fails unless err is a MomentoSvcErr carrying the given code.
+func assertErrorCode(t *testing.T, err error, code string) {
+	t.Helper()
+	svcErr, ok := err.(momentoerrors.MomentoSvcErr)
+	if !ok {
+		t.Fatalf("error %v (%T) is not a MomentoSvcErr", err, err)
+	}
+	if svcErr.Code() != code {
+		t.Fatalf("error code = %s, want %s (err: %v)", svcErr.Code(), code, err)
+	}
+}
+
 func assertAccounting(t *testing.T, pool *testTopicGrpcConnectionPool, activeCount int64) {
 	t.Helper()
 	if got := pool.activeCount.Load(); got != activeCount {
@@ -205,6 +217,7 @@ func TestSubscribeReleasesPoolCountersWhenFirstMessageRecvFails(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected Subscribe to return an error")
 	}
+	assertErrorCode(t, err, momentoerrors.ServerUnavailableError)
 	if sub != nil {
 		t.Fatal("expected subscription to be nil")
 	}
@@ -225,6 +238,7 @@ func TestSubscribeReleasesPoolCountersWhenFirstMessageIsNotHeartbeat(t *testing.
 	if err == nil {
 		t.Fatal("expected Subscribe to return an error")
 	}
+	assertErrorCode(t, err, momentoerrors.InternalServerError)
 	if sub != nil {
 		t.Fatal("expected subscription to be nil")
 	}
@@ -311,9 +325,11 @@ func TestTopicSubscriptionCloseDuringReconnectTearsDownNewStream(t *testing.T) {
 	// releases the new Reservation.
 	close(unblockReconnect)
 
-	if eventErr := <-eventDone; eventErr == nil {
+	eventErr := <-eventDone
+	if eventErr == nil {
 		t.Fatal("expected Event to return an error after close-during-reconnect")
 	}
+	assertErrorCode(t, eventErr, momentoerrors.CanceledError)
 	assertAccounting(t, pool, 0)
 }
 
@@ -329,7 +345,9 @@ func TestManyConcurrentSubscriptionsKeepsPoolBalanced(t *testing.T) {
 			}, nil
 		},
 	}
-	client, pool := newAccountingTestClient(streamClient, time.Second)
+	// Generous timeout: the fake handshake is synchronous, so the watchdog
+	// must never fire even on an oversubscribed -race CI runner.
+	client, pool := newAccountingTestClient(streamClient, 30*time.Second)
 
 	subs := make([]TopicSubscription, numSubs)
 	var wg sync.WaitGroup
@@ -373,7 +391,7 @@ func TestConcurrentCloseOnSameSubscription(t *testing.T) {
 			}, nil
 		},
 	}
-	client, pool := newAccountingTestClient(streamClient, time.Second)
+	client, pool := newAccountingTestClient(streamClient, 30*time.Second)
 
 	sub, err := client.Subscribe(context.Background(), testSubscribeRequest())
 	if err != nil {
@@ -487,10 +505,10 @@ func TestTopicSubscriptionReconnectGiveUpReleasesPoolCounters(t *testing.T) {
 	}
 
 	// Original slot released by Event before reconnect; each failed reconnect
-	// attempt released its slot on the early-return path.
+	// attempt released its slot on the early-return path: 1 + allowedAttempts.
 	assertAccounting(t, pool, 0)
-	if got := pool.releaseCount.Load(); got == 0 {
-		t.Fatal("expected at least one release after subscribe + give-up")
+	if got := pool.releaseCount.Load(); got != int64(1+allowedAttempts) {
+		t.Fatalf("releaseCount = %d, want %d (one per failed attempt plus the original slot)", got, 1+allowedAttempts)
 	}
 
 	// Close after give-up must be a no-op and must not panic.
@@ -634,6 +652,7 @@ func TestTopicSubscriptionCloseInterruptsReconnectBackoff(t *testing.T) {
 		if eventErr == nil {
 			t.Fatal("expected Event to return an error after Close")
 		}
+		assertErrorCode(t, eventErr, momentoerrors.CanceledError)
 	case <-time.After(5 * time.Second):
 		t.Fatal("Event did not return within 5s of Close (backoff not interrupted)")
 	}

--- a/momento/topic_subscription_accounting_test.go
+++ b/momento/topic_subscription_accounting_test.go
@@ -2,6 +2,7 @@ package momento
 
 import (
 	"context"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -9,6 +10,7 @@ import (
 	"github.com/momentohq/client-sdk-go/config/logger"
 	"github.com/momentohq/client-sdk-go/config/retry"
 	"github.com/momentohq/client-sdk-go/internal/grpcmanagers"
+	"github.com/momentohq/client-sdk-go/internal/grpcmanagers/topic_manager_lists"
 	"github.com/momentohq/client-sdk-go/internal/momentoerrors"
 	pb "github.com/momentohq/client-sdk-go/internal/protos"
 	"google.golang.org/grpc"
@@ -30,13 +32,14 @@ func newTestTopicGrpcConnectionPool(streamClient pb.PubsubClient) *testTopicGrpc
 	}
 }
 
-func (p *testTopicGrpcConnectionPool) GetNextTopicGrpcManager() (*grpcmanagers.TopicGrpcManager, momentoerrors.MomentoSvcErr) {
+func (p *testTopicGrpcConnectionPool) GetNextTopicGrpcManager() (*topic_manager_lists.Reservation, momentoerrors.MomentoSvcErr) {
 	p.manager.NumActiveSubscriptions.Add(1)
 	p.activeCount.Add(1)
-	return p.manager, nil
+	return topic_manager_lists.NewReservation(p.manager, p.releaseManager), nil
 }
 
-func (p *testTopicGrpcConnectionPool) ReleaseTopicGrpcManager(manager *grpcmanagers.TopicGrpcManager) int64 {
+// releaseManager mirrors the real stream pool's release for accounting.
+func (p *testTopicGrpcConnectionPool) releaseManager(manager *grpcmanagers.TopicGrpcManager) int64 {
 	p.releaseCount.Add(1)
 	p.activeCount.Add(-1)
 	return manager.NumActiveSubscriptions.Add(-1)
@@ -86,7 +89,29 @@ func (alwaysRetryStrategy) DetermineWhenToRetry(retry.StrategyProps) *int {
 	return &delay
 }
 
+// giveUpAfterRetryStrategy retries up to `attempts` times, then returns nil
+// to signal give-up.
+type giveUpAfterRetryStrategy struct {
+	attempts int
+}
+
+func (g giveUpAfterRetryStrategy) DetermineWhenToRetry(props retry.StrategyProps) *int {
+	if props.AttemptNumber > g.attempts {
+		return nil
+	}
+	delay := 0
+	return &delay
+}
+
 func newAccountingTestClient(streamClient pb.PubsubClient, timeout time.Duration) (defaultTopicClient, *testTopicGrpcConnectionPool) {
+	return newAccountingTestClientWithStrategy(streamClient, timeout, alwaysRetryStrategy{})
+}
+
+func newAccountingTestClientWithStrategy(
+	streamClient pb.PubsubClient,
+	timeout time.Duration,
+	strategy retry.Strategy,
+) (defaultTopicClient, *testTopicGrpcConnectionPool) {
 	pool := newTestTopicGrpcConnectionPool(streamClient)
 	client := defaultTopicClient{
 		pubSubClient: &pubSubClient{
@@ -94,7 +119,7 @@ func newAccountingTestClient(streamClient pb.PubsubClient, timeout time.Duration
 		},
 		log:            logger.NewNoopMomentoLoggerFactory().GetLogger("topic-subscription-accounting-test"),
 		requestTimeout: timeout,
-		retryStrategy:  alwaysRetryStrategy{},
+		retryStrategy:  strategy,
 	}
 	return client, pool
 }
@@ -147,7 +172,7 @@ func TestTopicSubscribeReleasesPoolCountersWhenStreamOpenFails(t *testing.T) {
 	_, pool := newAccountingTestClient(streamClient, time.Second)
 	client := &pubSubClient{streamGrpcConnectionPool: pool}
 
-	_, _, _, _, err := client.topicSubscribe(context.Background(), testSubscribeRequest())
+	_, err := client.topicSubscribe(context.Background(), testSubscribeRequest())
 	if err == nil {
 		t.Fatal("expected topicSubscribe to return an error")
 	}
@@ -217,6 +242,155 @@ func TestTopicSubscriptionCloseReleasesPoolCountersWithoutEvent(t *testing.T) {
 	assertAccounting(t, pool, 0)
 }
 
+// TestTopicSubscriptionCloseDuringReconnectTearsDownNewStream covers the
+// close-during-reconnect race: Close sets closed=true while attemptReconnect
+// holds a new Reservation. The post-Store check must release that new
+// Reservation rather than leaking it. The subscribe function is gated so
+// Close runs deterministically inside the race window.
+func TestTopicSubscriptionCloseDuringReconnectTearsDownNewStream(t *testing.T) {
+	reconnectEntered := make(chan struct{})
+	unblockReconnect := make(chan struct{})
+	var subscribeCalls atomic.Uint64
+
+	streamClient := &testPubsubClient{
+		subscribe: func(context.Context, *pb.XSubscriptionRequest, ...grpc.CallOption) (pb.Pubsub_SubscribeClient, error) {
+			call := subscribeCalls.Add(1)
+			switch call {
+			case 1:
+				// Handshake heartbeat, then a disconnect to drive Event into
+				// attemptReconnect.
+				return &testSubscribeClient{
+					results: []recvResult{
+						{item: heartbeatItem()},
+						{err: status.Error(codes.Unavailable, "disconnected")},
+					},
+				}, nil
+			case 2:
+				// Reconnect: signal the test that a new Reservation is held,
+				// then block so Close can race with this in-flight reconnect.
+				close(reconnectEntered)
+				<-unblockReconnect
+				return &testSubscribeClient{
+					results: []recvResult{{item: heartbeatItem()}},
+				}, nil
+			default:
+				return nil, status.Error(codes.Canceled, "test: subscribe should not be called after Close")
+			}
+		},
+	}
+
+	client, pool := newAccountingTestClient(streamClient, time.Second)
+	sub, err := client.Subscribe(context.Background(), testSubscribeRequest())
+	if err != nil {
+		t.Fatalf("Subscribe returned error: %v", err)
+	}
+	assertAccounting(t, pool, 1)
+
+	eventDone := make(chan error, 1)
+	go func() {
+		_, err := sub.Event(context.Background())
+		eventDone <- err
+	}()
+
+	<-reconnectEntered
+
+	// Close while reconnect is mid-flight. Sets closed=true; the old
+	// Reservation was already released by Event before attemptReconnect ran.
+	sub.Close()
+
+	// Let reconnect proceed. The post-Store check observes closed=true and
+	// releases the new Reservation.
+	close(unblockReconnect)
+
+	if eventErr := <-eventDone; eventErr == nil {
+		t.Fatal("expected Event to return an error after close-during-reconnect")
+	}
+	assertAccounting(t, pool, 0)
+}
+
+// TestManyConcurrentSubscriptionsKeepsPoolBalanced stresses the pool counter
+// with parallel Subscribe and Close calls.
+func TestManyConcurrentSubscriptionsKeepsPoolBalanced(t *testing.T) {
+	const numSubs = 100
+
+	streamClient := &testPubsubClient{
+		subscribe: func(context.Context, *pb.XSubscriptionRequest, ...grpc.CallOption) (pb.Pubsub_SubscribeClient, error) {
+			return &testSubscribeClient{
+				results: []recvResult{{item: heartbeatItem()}},
+			}, nil
+		},
+	}
+	client, pool := newAccountingTestClient(streamClient, time.Second)
+
+	subs := make([]TopicSubscription, numSubs)
+	var wg sync.WaitGroup
+	wg.Add(numSubs)
+	for i := 0; i < numSubs; i++ {
+		go func(i int) {
+			defer wg.Done()
+			sub, err := client.Subscribe(context.Background(), testSubscribeRequest())
+			if err != nil {
+				t.Errorf("Subscribe %d returned error: %v", i, err)
+				return
+			}
+			subs[i] = sub
+		}(i)
+	}
+	wg.Wait()
+	assertAccounting(t, pool, numSubs)
+
+	wg.Add(numSubs)
+	for i := 0; i < numSubs; i++ {
+		go func(i int) {
+			defer wg.Done()
+			if subs[i] != nil {
+				subs[i].Close()
+			}
+		}(i)
+	}
+	wg.Wait()
+	assertAccounting(t, pool, 0)
+}
+
+// TestConcurrentCloseOnSameSubscription verifies many goroutines calling
+// Close on the same subscription release the pool slot exactly once.
+func TestConcurrentCloseOnSameSubscription(t *testing.T) {
+	const goroutines = 64
+
+	streamClient := &testPubsubClient{
+		subscribe: func(context.Context, *pb.XSubscriptionRequest, ...grpc.CallOption) (pb.Pubsub_SubscribeClient, error) {
+			return &testSubscribeClient{
+				results: []recvResult{{item: heartbeatItem()}},
+			}, nil
+		},
+	}
+	client, pool := newAccountingTestClient(streamClient, time.Second)
+
+	sub, err := client.Subscribe(context.Background(), testSubscribeRequest())
+	if err != nil {
+		t.Fatalf("Subscribe returned error: %v", err)
+	}
+	assertAccounting(t, pool, 1)
+
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			<-start
+			sub.Close()
+		}()
+	}
+	close(start)
+	wg.Wait()
+
+	assertAccounting(t, pool, 0)
+	if got := pool.releaseCount.Load(); got != 1 {
+		t.Fatalf("releaseCount = %d, want 1 (concurrent Close should release exactly once)", got)
+	}
+}
+
 func TestTopicSubscriptionReconnectKeepsPoolCountersBalanced(t *testing.T) {
 	disconnectErr := status.Error(codes.Unavailable, "stream disconnected")
 	var subscribeCalls atomic.Uint64
@@ -261,3 +435,89 @@ func TestTopicSubscriptionReconnectKeepsPoolCountersBalanced(t *testing.T) {
 	sub.Close()
 	assertAccounting(t, pool, 0)
 }
+
+// TestTopicSubscriptionReconnectGiveUpReleasesPoolCounters drives
+// attemptReconnect to give up after the retry strategy returns nil. Counters
+// must be balanced when Event surfaces the error, and a subsequent Close
+// must be a no-op on the already-released Reservation.
+func TestTopicSubscriptionReconnectGiveUpReleasesPoolCounters(t *testing.T) {
+	const allowedAttempts = 3
+	disconnectErr := status.Error(codes.Unavailable, "stream disconnected")
+	var subscribeCalls atomic.Uint64
+
+	streamClient := &testPubsubClient{
+		subscribe: func(context.Context, *pb.XSubscriptionRequest, ...grpc.CallOption) (pb.Pubsub_SubscribeClient, error) {
+			call := subscribeCalls.Add(1)
+			if call == 1 {
+				return &testSubscribeClient{
+					results: []recvResult{
+						{item: heartbeatItem()},
+						{err: disconnectErr},
+					},
+				}, nil
+			}
+			// Every reconnect attempt fails so the retry strategy is exhausted.
+			return nil, disconnectErr
+		},
+	}
+	client, pool := newAccountingTestClientWithStrategy(
+		streamClient,
+		time.Second,
+		giveUpAfterRetryStrategy{attempts: allowedAttempts},
+	)
+
+	sub, err := client.Subscribe(context.Background(), testSubscribeRequest())
+	if err != nil {
+		t.Fatalf("Subscribe returned error: %v", err)
+	}
+	assertAccounting(t, pool, 1)
+
+	_, eventErr := sub.Event(context.Background())
+	if eventErr == nil {
+		t.Fatal("expected Event to surface the give-up error from attemptReconnect")
+	}
+
+	// Original slot released by Event before reconnect; each failed reconnect
+	// attempt released its slot on the early-return path.
+	assertAccounting(t, pool, 0)
+	if got := pool.releaseCount.Load(); got == 0 {
+		t.Fatal("expected at least one release after subscribe + give-up")
+	}
+
+	// Close after give-up must be a no-op and must not panic.
+	sub.Close()
+	assertAccounting(t, pool, 0)
+}
+
+// TestTopicPublishUnaryReleasesReservationOncePerCall verifies the unary
+// path's defer reservation.Release() runs exactly once per publish.
+func TestTopicPublishUnaryReleasesReservationOncePerCall(t *testing.T) {
+	streamClient := &testPubsubClient{
+		subscribe: func(context.Context, *pb.XSubscriptionRequest, ...grpc.CallOption) (pb.Pubsub_SubscribeClient, error) {
+			return nil, status.Error(codes.Internal, "Subscribe should not be called from a publish-only test")
+		},
+	}
+	pool := newTestTopicGrpcConnectionPool(streamClient)
+	client := &pubSubClient{
+		unaryGrpcConnectionPool: pool,
+		log:                     logger.NewNoopMomentoLoggerFactory().GetLogger("unary-publish-test"),
+		requestTimeout:          time.Second,
+	}
+
+	const publishCount = 50
+	for i := 0; i < publishCount; i++ {
+		err := client.topicPublish(context.Background(), &TopicPublishRequest{
+			CacheName: "cache",
+			TopicName: "topic",
+			Value:     String("payload"),
+		})
+		if err != nil {
+			t.Fatalf("topicPublish %d returned error: %v", i, err)
+		}
+	}
+
+	if got := pool.releaseCount.Load(); got != publishCount {
+		t.Fatalf("releaseCount = %d, want %d (exactly one Release per publish)", got, publishCount)
+	}
+}
+

--- a/momento/topic_subscription_accounting_test.go
+++ b/momento/topic_subscription_accounting_test.go
@@ -210,6 +210,14 @@ func assertErrorCode(t *testing.T, err error, code string) {
 	}
 }
 
+func discontinuityItem() *pb.XSubscriptionItem {
+	return &pb.XSubscriptionItem{
+		Kind: &pb.XSubscriptionItem_Discontinuity{
+			Discontinuity: &pb.XDiscontinuity{},
+		},
+	}
+}
+
 func assertAccounting(t *testing.T, pool *testTopicGrpcConnectionPool, activeCount int64) {
 	t.Helper()
 	if got := pool.activeCount.Load(); got != activeCount {
@@ -703,6 +711,99 @@ func TestTopicSubscriptionSubscribeCtxCancelEndsSubscription(t *testing.T) {
 	assertAccounting(t, pool, 0)
 }
 
+// TestTopicSubscriptionItemSkipsNonMessageEvents pins Item's contract: it
+// swallows heartbeats and discontinuities and returns the next message value.
+func TestTopicSubscriptionItemSkipsNonMessageEvents(t *testing.T) {
+	streamClient := &testPubsubClient{
+		subscribe: func(context.Context, *pb.XSubscriptionRequest, ...grpc.CallOption) (pb.Pubsub_SubscribeClient, error) {
+			return &testSubscribeClient{
+				results: []recvResult{
+					{item: heartbeatItem()}, // handshake
+					{item: heartbeatItem()},
+					{item: discontinuityItem()},
+					{item: topicItem(2)},
+				},
+			}, nil
+		},
+	}
+	client, pool := newAccountingTestClient(streamClient, time.Second)
+
+	sub, err := client.Subscribe(context.Background(), testSubscribeRequest())
+	if err != nil {
+		t.Fatalf("Subscribe returned error: %v", err)
+	}
+
+	value, err := sub.Item(context.Background())
+	if err != nil {
+		t.Fatalf("Item returned error: %v", err)
+	}
+	if got, ok := value.(String); !ok || got != String("value") {
+		t.Fatalf("Item = %v (%T), want String(\"value\")", value, value)
+	}
+
+	sub.Close()
+	assertAccounting(t, pool, 0)
+}
+
+// TestTopicSubscriptionSubscribeCtxCancelDuringBackoffIsTerminal pins the
+// asymmetry between the two context flavors mid-backoff: the Subscribe-time
+// ctx dying ends the subscription (typed CanceledError, no pause), unlike the
+// per-call ctx, which pauses recovery for the next call.
+func TestTopicSubscriptionSubscribeCtxCancelDuringBackoffIsTerminal(t *testing.T) {
+	disconnectErr := status.Error(codes.Unavailable, "stream disconnected")
+	streamClient := &testPubsubClient{
+		subscribe: func(context.Context, *pb.XSubscriptionRequest, ...grpc.CallOption) (pb.Pubsub_SubscribeClient, error) {
+			return &testSubscribeClient{
+				results: []recvResult{
+					{item: heartbeatItem()},
+					{err: disconnectErr},
+				},
+			}, nil
+		},
+	}
+	strategy := newSignalingBackoffRetryStrategy(10 * 60 * 1000)
+	client, pool := newAccountingTestClientWithStrategy(streamClient, time.Second, strategy)
+
+	subscribeCtx, cancelSubscribeCtx := context.WithCancel(context.Background())
+	defer cancelSubscribeCtx()
+	sub, err := client.Subscribe(subscribeCtx, testSubscribeRequest())
+	if err != nil {
+		t.Fatalf("Subscribe returned error: %v", err)
+	}
+	assertAccounting(t, pool, 1)
+
+	eventDone := make(chan error, 1)
+	go func() {
+		_, eventErr := sub.Event(context.Background())
+		eventDone <- eventErr
+	}()
+
+	<-strategy.entered
+	cancelSubscribeCtx()
+
+	select {
+	case eventErr := <-eventDone:
+		if eventErr == nil {
+			t.Fatal("expected Event to return an error after Subscribe-ctx cancellation")
+		}
+		assertErrorCode(t, eventErr, momentoerrors.CanceledError)
+		if !errors.Is(eventErr, context.Canceled) {
+			t.Fatalf("terminal error should unwrap to context.Canceled, got %v", eventErr)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Event did not return within 5s of Subscribe-ctx cancellation")
+	}
+	assertAccounting(t, pool, 0)
+
+	// Terminal, not paused: a later call must report the dead subscription,
+	// not retry the reconnect.
+	_, eventErr := sub.Event(context.Background())
+	if eventErr == nil {
+		t.Fatal("expected the subscription to stay terminal")
+	}
+	assertErrorCode(t, eventErr, momentoerrors.CanceledError)
+}
+
 // TestTopicSubscriptionReconnectPausesOnContextCancelAndResumes drives the
 // retry loop into a long backoff, cancels the caller's ctx (Event must return
 // promptly), then verifies the next call with a live ctx resumes the
@@ -759,6 +860,14 @@ func TestTopicSubscriptionReconnectPausesOnContextCancelAndResumes(t *testing.T)
 		t.Fatal("Event did not return within 5s of context cancellation")
 	}
 	// The failed stream's slot was released; recovery is paused, not dead.
+	assertAccounting(t, pool, 0)
+
+	// A call with another dead ctx stays paused rather than resuming.
+	deadCtx, cancelDead := context.WithCancel(context.Background())
+	cancelDead()
+	if _, pausedErr := sub.Event(deadCtx); pausedErr == nil {
+		t.Fatal("expected a dead-ctx call on a paused subscription to return an error")
+	}
 	assertAccounting(t, pool, 0)
 
 	// A live ctx resumes the reconnect (zero backoff on the second
@@ -1095,7 +1204,30 @@ func TestTopicPublishUnaryReleasesReservationOncePerCall(t *testing.T) {
 		}
 	}
 
-	if got := pool.releaseCount.Load(); got != publishCount {
-		t.Fatalf("releaseCount = %d, want %d (exactly one Release per publish)", got, publishCount)
+	// The Bytes branch and the unsupported-value branch release too.
+	if err := client.topicPublish(context.Background(), &TopicPublishRequest{
+		CacheName: "cache",
+		TopicName: "topic",
+		Value:     Bytes("payload"),
+	}); err != nil {
+		t.Fatalf("topicPublish with Bytes returned error: %v", err)
+	}
+	err := client.topicPublish(context.Background(), &TopicPublishRequest{
+		CacheName: "cache",
+		TopicName: "topic",
+		Value:     unsupportedTopicValue{},
+	})
+	if err == nil {
+		t.Fatal("expected an error for an unsupported topic value type")
+	}
+	assertErrorCode(t, err, momentoerrors.InvalidArgumentError)
+
+	if got := pool.releaseCount.Load(); got != publishCount+2 {
+		t.Fatalf("releaseCount = %d, want %d (exactly one Release per publish)", got, publishCount+2)
 	}
 }
+
+// unsupportedTopicValue drives topicPublish's default branch.
+type unsupportedTopicValue struct{}
+
+func (unsupportedTopicValue) isTopicValue() {}

--- a/momento/topic_subscription_accounting_test.go
+++ b/momento/topic_subscription_accounting_test.go
@@ -557,6 +557,150 @@ func TestTopicSubscriptionReconnectAbortsWhenContextCanceled(t *testing.T) {
 	assertAccounting(t, pool, 0)
 }
 
+// TestTopicSubscriptionEventContextCancelTearsDownStream verifies a ctx error
+// from Event is terminal: the slot is released AND the stream context is
+// canceled, so the pool's freed slot isn't backed by a still-open stream.
+func TestTopicSubscriptionEventContextCancelTearsDownStream(t *testing.T) {
+	streamClient := &testPubsubClient{
+		subscribe: func(context.Context, *pb.XSubscriptionRequest, ...grpc.CallOption) (pb.Pubsub_SubscribeClient, error) {
+			return &testSubscribeClient{
+				results: []recvResult{{item: heartbeatItem()}},
+			}, nil
+		},
+	}
+	client, pool := newAccountingTestClient(streamClient, time.Second)
+
+	sub, err := client.Subscribe(context.Background(), testSubscribeRequest())
+	if err != nil {
+		t.Fatalf("Subscribe returned error: %v", err)
+	}
+	assertAccounting(t, pool, 1)
+
+	canceledCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, eventErr := sub.Event(canceledCtx); eventErr == nil {
+		t.Fatal("expected Event to return an error for a canceled context")
+	}
+	assertAccounting(t, pool, 0)
+
+	state := sub.(*topicSubscription).state.Load()
+	if state.cancelContext.Err() == nil {
+		t.Fatal("expected the stream context to be torn down with the released slot")
+	}
+}
+
+// TestTopicSubscriptionCloseInterruptsReconnectBackoff verifies Close wakes a
+// reconnect backoff wait instead of letting it sleep out the full interval.
+func TestTopicSubscriptionCloseInterruptsReconnectBackoff(t *testing.T) {
+	disconnectErr := status.Error(codes.Unavailable, "stream disconnected")
+	var subscribeCalls atomic.Uint64
+	streamClient := &testPubsubClient{
+		subscribe: func(context.Context, *pb.XSubscriptionRequest, ...grpc.CallOption) (pb.Pubsub_SubscribeClient, error) {
+			if subscribeCalls.Add(1) == 1 {
+				return &testSubscribeClient{
+					results: []recvResult{
+						{item: heartbeatItem()},
+						{err: disconnectErr},
+					},
+				}, nil
+			}
+			return nil, disconnectErr
+		},
+	}
+	client, pool := newAccountingTestClientWithStrategy(
+		streamClient,
+		time.Second,
+		fixedBackoffRetryStrategy{backoffMs: 10 * 60 * 1000},
+	)
+
+	sub, err := client.Subscribe(context.Background(), testSubscribeRequest())
+	if err != nil {
+		t.Fatalf("Subscribe returned error: %v", err)
+	}
+	assertAccounting(t, pool, 1)
+
+	eventDone := make(chan error, 1)
+	go func() {
+		_, eventErr := sub.Event(context.Background())
+		eventDone <- eventErr
+	}()
+
+	// Let Event hit the disconnect and enter the 10-minute backoff, then Close.
+	time.Sleep(50 * time.Millisecond)
+	sub.Close()
+
+	select {
+	case eventErr := <-eventDone:
+		if eventErr == nil {
+			t.Fatal("expected Event to return an error after Close")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Event did not return within 5s of Close (backoff not interrupted)")
+	}
+	assertAccounting(t, pool, 0)
+}
+
+// TestTopicSubscriptionReconnectUsesSubscribeContext pins stream-context
+// lineage: reconnected streams are parented to the ctx passed to Subscribe,
+// so canceling the Event ctx that happened to drive the reconnect must not
+// kill the replacement stream.
+func TestTopicSubscriptionReconnectUsesSubscribeContext(t *testing.T) {
+	disconnectErr := status.Error(codes.Unavailable, "stream disconnected")
+	var subscribeCalls atomic.Uint64
+	streamClient := &testPubsubClient{
+		subscribe: func(context.Context, *pb.XSubscriptionRequest, ...grpc.CallOption) (pb.Pubsub_SubscribeClient, error) {
+			if subscribeCalls.Add(1) == 1 {
+				return &testSubscribeClient{
+					results: []recvResult{
+						{item: heartbeatItem()},
+						{err: disconnectErr},
+					},
+				}, nil
+			}
+			return &testSubscribeClient{
+				results: []recvResult{
+					{item: topicItem(2)},
+					{item: topicItem(3)},
+				},
+			}, nil
+		},
+	}
+	client, pool := newAccountingTestClient(streamClient, time.Second)
+
+	sub, err := client.Subscribe(context.Background(), testSubscribeRequest())
+	if err != nil {
+		t.Fatalf("Subscribe returned error: %v", err)
+	}
+	assertAccounting(t, pool, 1)
+
+	// This Event call drives the disconnect -> reconnect -> item(2) sequence.
+	eventCtx, cancelEventCtx := context.WithCancel(context.Background())
+	event, eventErr := sub.Event(eventCtx)
+	if eventErr != nil {
+		t.Fatalf("Event returned error: %v", eventErr)
+	}
+	if _, ok := event.(TopicItem); !ok {
+		t.Fatalf("Event = %T, want TopicItem after reconnect", event)
+	}
+	assertAccounting(t, pool, 1)
+
+	// Cancel the ctx that drove the reconnect; the reconnected stream must
+	// survive because it is parented to the Subscribe-time ctx.
+	cancelEventCtx()
+
+	event, eventErr = sub.Event(context.Background())
+	if eventErr != nil {
+		t.Fatalf("Event after canceling the reconnect-driving ctx returned error: %v", eventErr)
+	}
+	if _, ok := event.(TopicItem); !ok {
+		t.Fatalf("Event = %T, want TopicItem from the surviving stream", event)
+	}
+	assertAccounting(t, pool, 1)
+
+	sub.Close()
+	assertAccounting(t, pool, 0)
+}
+
 // TestTopicPublishUnaryReleasesReservationOncePerCall verifies the unary
 // path's defer reservation.Release() runs exactly once per publish.
 func TestTopicPublishUnaryReleasesReservationOncePerCall(t *testing.T) {

--- a/momento/topic_subscription_accounting_test.go
+++ b/momento/topic_subscription_accounting_test.go
@@ -2,6 +2,7 @@ package momento
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -115,6 +116,24 @@ type signalingBackoffRetryStrategy struct {
 	backoffMs int
 	entered   chan struct{}
 	once      sync.Once
+}
+
+// firstCallBackoffRetryStrategy returns a long backoff on the first retry
+// consultation (closing entered), then zero for all subsequent ones, so a
+// paused reconnect can resume promptly.
+type firstCallBackoffRetryStrategy struct {
+	firstBackoffMs int
+	calls          atomic.Int64
+	entered        chan struct{}
+}
+
+func (s *firstCallBackoffRetryStrategy) DetermineWhenToRetry(retry.StrategyProps) *int {
+	if s.calls.Add(1) == 1 {
+		close(s.entered)
+		return &s.firstBackoffMs
+	}
+	zero := 0
+	return &zero
 }
 
 func newSignalingBackoffRetryStrategy(backoffMs int) *signalingBackoffRetryStrategy {
@@ -533,74 +552,19 @@ func TestTopicSubscriptionReconnectGiveUpReleasesPoolCounters(t *testing.T) {
 	assertAccounting(t, pool, 0)
 }
 
-// TestTopicSubscriptionReconnectAbortsWhenContextCanceled pins the retry
-// loop's response to user-context cancellation: Event must return promptly
-// with balanced counters instead of retrying (here, sleeping a 10-minute
-// backoff) against a context that can never produce a live stream again.
-func TestTopicSubscriptionReconnectAbortsWhenContextCanceled(t *testing.T) {
-	disconnectErr := status.Error(codes.Unavailable, "stream disconnected")
-	var subscribeCalls atomic.Uint64
-	streamClient := &testPubsubClient{
-		subscribe: func(context.Context, *pb.XSubscriptionRequest, ...grpc.CallOption) (pb.Pubsub_SubscribeClient, error) {
-			if subscribeCalls.Add(1) == 1 {
-				return &testSubscribeClient{
-					results: []recvResult{
-						{item: heartbeatItem()},
-						{err: disconnectErr},
-					},
-				}, nil
-			}
-			// Reconnect attempts keep failing so Event stays in the retry loop
-			// (sleeping the fixed backoff) until the context is canceled.
-			return nil, disconnectErr
-		},
-	}
-	strategy := newSignalingBackoffRetryStrategy(10 * 60 * 1000)
-	client, pool := newAccountingTestClientWithStrategy(
-		streamClient,
-		time.Second,
-		strategy,
-	)
-
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	sub, err := client.Subscribe(ctx, testSubscribeRequest())
-	if err != nil {
-		t.Fatalf("Subscribe returned error: %v", err)
-	}
-	assertAccounting(t, pool, 1)
-
-	eventDone := make(chan error, 1)
-	go func() {
-		_, eventErr := sub.Event(ctx)
-		eventDone <- eventErr
-	}()
-
-	// Wait until the retry loop has committed to the 10-minute backoff, then
-	// cancel. Cancellation must surface promptly; without the ctx-aware wait
-	// this would block ~10 minutes.
-	<-strategy.entered
-	cancel()
-
-	select {
-	case eventErr := <-eventDone:
-		if eventErr == nil {
-			t.Fatal("expected Event to return an error after context cancellation")
-		}
-	case <-time.After(5 * time.Second):
-		t.Fatal("Event did not return within 5s of context cancellation")
-	}
-	assertAccounting(t, pool, 0)
-}
-
-// TestTopicSubscriptionEventContextCancelTearsDownStream verifies a ctx error
-// from Event is terminal: the slot is released AND the stream context is
-// canceled, so the pool's freed slot isn't backed by a still-open stream.
-func TestTopicSubscriptionEventContextCancelTearsDownStream(t *testing.T) {
+// TestTopicSubscriptionEventContextErrorKeepsSubscriptionAlive pins the
+// non-terminal per-call ctx contract: an expired or canceled Event ctx stops
+// only that call. The stream and its pool slot stay intact and a later call
+// with a live ctx receives messages, matching the timeout semantics of
+// comparable clients (NATS NextMsg, Kafka ReadMessage).
+func TestTopicSubscriptionEventContextErrorKeepsSubscriptionAlive(t *testing.T) {
 	streamClient := &testPubsubClient{
 		subscribe: func(context.Context, *pb.XSubscriptionRequest, ...grpc.CallOption) (pb.Pubsub_SubscribeClient, error) {
 			return &testSubscribeClient{
-				results: []recvResult{{item: heartbeatItem()}},
+				results: []recvResult{
+					{item: heartbeatItem()},
+					{item: topicItem(2)},
+				},
 			}, nil
 		},
 	}
@@ -617,12 +581,205 @@ func TestTopicSubscriptionEventContextCancelTearsDownStream(t *testing.T) {
 	if _, eventErr := sub.Event(canceledCtx); eventErr == nil {
 		t.Fatal("expected Event to return an error for a canceled context")
 	}
+
+	// The slot stays held and the stream stays alive.
+	assertAccounting(t, pool, 1)
+	state := sub.(*topicSubscription).state.Load()
+	if state.cancelContext.Err() != nil {
+		t.Fatal("a per-call ctx error must not cancel the stream context")
+	}
+
+	// A later call with a live ctx picks up where we left off.
+	event, eventErr := sub.Event(context.Background())
+	if eventErr != nil {
+		t.Fatalf("Event after a per-call ctx error returned error: %v", eventErr)
+	}
+	if _, ok := event.(TopicItem); !ok {
+		t.Fatalf("Event = %T, want TopicItem from the surviving stream", event)
+	}
+	assertAccounting(t, pool, 1)
+
+	sub.Close()
+	assertAccounting(t, pool, 0)
+}
+
+// TestTopicSubscriptionEventAfterCloseReturnsTypedCanceled pins the terminal
+// error contract: after Close, Event returns a CanceledError that still
+// unwraps to context.Canceled, so callers can distinguish a dead subscription
+// from their own ctx expiring.
+func TestTopicSubscriptionEventAfterCloseReturnsTypedCanceled(t *testing.T) {
+	streamClient := &testPubsubClient{
+		subscribe: func(context.Context, *pb.XSubscriptionRequest, ...grpc.CallOption) (pb.Pubsub_SubscribeClient, error) {
+			return &testSubscribeClient{
+				results: []recvResult{{item: heartbeatItem()}},
+			}, nil
+		},
+	}
+	client, pool := newAccountingTestClient(streamClient, time.Second)
+
+	sub, err := client.Subscribe(context.Background(), testSubscribeRequest())
+	if err != nil {
+		t.Fatalf("Subscribe returned error: %v", err)
+	}
+	sub.Close()
 	assertAccounting(t, pool, 0)
 
-	state := sub.(*topicSubscription).state.Load()
-	if state.cancelContext.Err() == nil {
-		t.Fatal("expected the stream context to be torn down with the released slot")
+	_, eventErr := sub.Event(context.Background())
+	if eventErr == nil {
+		t.Fatal("expected Event after Close to return an error")
 	}
+	assertErrorCode(t, eventErr, momentoerrors.CanceledError)
+	if !errors.Is(eventErr, context.Canceled) {
+		t.Fatalf("terminal error should unwrap to context.Canceled, got %v", eventErr)
+	}
+}
+
+// TestTopicSubscriptionReconnectPausesOnContextCancelAndResumes drives the
+// retry loop into a long backoff, cancels the caller's ctx (Event must return
+// promptly), then verifies the next call with a live ctx resumes the
+// interrupted reconnect instead of the subscription dying.
+func TestTopicSubscriptionReconnectPausesOnContextCancelAndResumes(t *testing.T) {
+	disconnectErr := status.Error(codes.Unavailable, "stream disconnected")
+	var subscribeCalls atomic.Uint64
+	streamClient := &testPubsubClient{
+		subscribe: func(context.Context, *pb.XSubscriptionRequest, ...grpc.CallOption) (pb.Pubsub_SubscribeClient, error) {
+			if subscribeCalls.Add(1) == 1 {
+				return &testSubscribeClient{
+					results: []recvResult{
+						{item: heartbeatItem()},
+						{err: disconnectErr},
+					},
+				}, nil
+			}
+			return &testSubscribeClient{
+				results: []recvResult{{item: topicItem(2)}},
+			}, nil
+		},
+	}
+	strategy := &firstCallBackoffRetryStrategy{
+		firstBackoffMs: 10 * 60 * 1000,
+		entered:        make(chan struct{}),
+	}
+	client, pool := newAccountingTestClientWithStrategy(streamClient, time.Second, strategy)
+
+	sub, err := client.Subscribe(context.Background(), testSubscribeRequest())
+	if err != nil {
+		t.Fatalf("Subscribe returned error: %v", err)
+	}
+	assertAccounting(t, pool, 1)
+
+	eventCtx, cancelEventCtx := context.WithCancel(context.Background())
+	eventDone := make(chan error, 1)
+	go func() {
+		_, eventErr := sub.Event(eventCtx)
+		eventDone <- eventErr
+	}()
+
+	// Wait until the retry loop has committed to the 10-minute backoff, then
+	// cancel. Event must return promptly; without the ctx-aware wait this
+	// would block ~10 minutes.
+	<-strategy.entered
+	cancelEventCtx()
+
+	select {
+	case eventErr := <-eventDone:
+		if eventErr == nil {
+			t.Fatal("expected Event to return an error after context cancellation")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Event did not return within 5s of context cancellation")
+	}
+	// The failed stream's slot was released; recovery is paused, not dead.
+	assertAccounting(t, pool, 0)
+
+	// A live ctx resumes the reconnect (zero backoff on the second
+	// consultation) and delivers from the new stream.
+	event, eventErr := sub.Event(context.Background())
+	if eventErr != nil {
+		t.Fatalf("Event after paused reconnect returned error: %v", eventErr)
+	}
+	if _, ok := event.(TopicItem); !ok {
+		t.Fatalf("Event = %T, want TopicItem from the resumed stream", event)
+	}
+	assertAccounting(t, pool, 1)
+
+	sub.Close()
+	assertAccounting(t, pool, 0)
+}
+
+// TestTopicSubscriptionStreamErrorWithDeadContextResumesNextCall covers the
+// other pause entry: the stream fails while the caller's ctx is already dead.
+// The dead stream's slot is released immediately and the next call with a
+// live ctx reconnects.
+func TestTopicSubscriptionStreamErrorWithDeadContextResumesNextCall(t *testing.T) {
+	disconnectErr := status.Error(codes.Unavailable, "stream disconnected")
+	gate := make(chan struct{})
+	recvBlocked := make(chan struct{})
+	var recvBlockedOnce sync.Once
+	var subscribeCalls atomic.Uint64
+	streamClient := &testPubsubClient{
+		subscribe: func(context.Context, *pb.XSubscriptionRequest, ...grpc.CallOption) (pb.Pubsub_SubscribeClient, error) {
+			if subscribeCalls.Add(1) == 1 {
+				heartbeatSent := false
+				return &testSubscribeClient{
+					recv: func() (*pb.XSubscriptionItem, error) {
+						if !heartbeatSent {
+							heartbeatSent = true
+							return heartbeatItem(), nil
+						}
+						recvBlockedOnce.Do(func() { close(recvBlocked) })
+						<-gate
+						return nil, disconnectErr
+					},
+				}, nil
+			}
+			return &testSubscribeClient{
+				results: []recvResult{{item: topicItem(2)}},
+			}, nil
+		},
+	}
+	client, pool := newAccountingTestClient(streamClient, time.Second)
+
+	sub, err := client.Subscribe(context.Background(), testSubscribeRequest())
+	if err != nil {
+		t.Fatalf("Subscribe returned error: %v", err)
+	}
+	assertAccounting(t, pool, 1)
+
+	eventCtx, cancelEventCtx := context.WithCancel(context.Background())
+	eventDone := make(chan error, 1)
+	go func() {
+		_, eventErr := sub.Event(eventCtx)
+		eventDone <- eventErr
+	}()
+
+	// Kill the caller's ctx while Event is blocked in Recv, then fail the
+	// stream: Event observes the dead ctx on the error path.
+	<-recvBlocked
+	cancelEventCtx()
+	close(gate)
+
+	select {
+	case eventErr := <-eventDone:
+		if eventErr == nil {
+			t.Fatal("expected Event to return an error")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Event did not return within 5s")
+	}
+	assertAccounting(t, pool, 0)
+
+	event, eventErr := sub.Event(context.Background())
+	if eventErr != nil {
+		t.Fatalf("Event after deferred reconnect returned error: %v", eventErr)
+	}
+	if _, ok := event.(TopicItem); !ok {
+		t.Fatalf("Event = %T, want TopicItem from the reconnected stream", event)
+	}
+	assertAccounting(t, pool, 1)
+
+	sub.Close()
+	assertAccounting(t, pool, 0)
 }
 
 // TestTopicSubscriptionCloseInterruptsReconnectBackoff verifies Close wakes a

--- a/momento/topic_subscription_accounting_test.go
+++ b/momento/topic_subscription_accounting_test.go
@@ -22,6 +22,8 @@ type testTopicGrpcConnectionPool struct {
 	manager      *grpcmanagers.TopicGrpcManager
 	activeCount  atomic.Int64
 	releaseCount atomic.Int64
+	// closed makes GetNextTopicGrpcManager fail like a real pool after Close.
+	closed atomic.Bool
 }
 
 func newTestTopicGrpcConnectionPool(streamClient pb.PubsubClient) *testTopicGrpcConnectionPool {
@@ -33,6 +35,9 @@ func newTestTopicGrpcConnectionPool(streamClient pb.PubsubClient) *testTopicGrpc
 }
 
 func (p *testTopicGrpcConnectionPool) GetNextTopicGrpcManager() (*topic_manager_lists.Reservation, momentoerrors.MomentoSvcErr) {
+	if p.closed.Load() {
+		return nil, momentoerrors.NewMomentoSvcErr(momentoerrors.CanceledError, "connection pool is shutting down", nil)
+	}
 	p.manager.NumActiveSubscriptions.Add(1)
 	p.activeCount.Add(1)
 	return topic_manager_lists.NewReservation(p.manager, p.releaseManager), nil
@@ -103,13 +108,25 @@ func (g giveUpAfterRetryStrategy) DetermineWhenToRetry(props retry.StrategyProps
 	return &delay
 }
 
-// fixedBackoffRetryStrategy always retries after a fixed backoff.
-type fixedBackoffRetryStrategy struct {
+// signalingBackoffRetryStrategy always retries after a fixed backoff and
+// closes entered the first time the retry loop commits to that backoff, so
+// tests can deterministically race Close/cancel against the backoff wait.
+type signalingBackoffRetryStrategy struct {
 	backoffMs int
+	entered   chan struct{}
+	once      sync.Once
 }
 
-func (f fixedBackoffRetryStrategy) DetermineWhenToRetry(retry.StrategyProps) *int {
-	return &f.backoffMs
+func newSignalingBackoffRetryStrategy(backoffMs int) *signalingBackoffRetryStrategy {
+	return &signalingBackoffRetryStrategy{
+		backoffMs: backoffMs,
+		entered:   make(chan struct{}),
+	}
+}
+
+func (s *signalingBackoffRetryStrategy) DetermineWhenToRetry(retry.StrategyProps) *int {
+	s.once.Do(func() { close(s.entered) })
+	return &s.backoffMs
 }
 
 func newAccountingTestClient(streamClient pb.PubsubClient, timeout time.Duration) (defaultTopicClient, *testTopicGrpcConnectionPool) {
@@ -538,10 +555,11 @@ func TestTopicSubscriptionReconnectAbortsWhenContextCanceled(t *testing.T) {
 			return nil, disconnectErr
 		},
 	}
+	strategy := newSignalingBackoffRetryStrategy(10 * 60 * 1000)
 	client, pool := newAccountingTestClientWithStrategy(
 		streamClient,
 		time.Second,
-		fixedBackoffRetryStrategy{backoffMs: 10 * 60 * 1000},
+		strategy,
 	)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -558,10 +576,10 @@ func TestTopicSubscriptionReconnectAbortsWhenContextCanceled(t *testing.T) {
 		eventDone <- eventErr
 	}()
 
-	// Give Event a moment to hit the disconnect and enter the backoff sleep,
-	// then cancel. Whichever point the loop has reached, cancellation must
-	// surface promptly; without the ctx checks this would block ~10 minutes.
-	time.Sleep(50 * time.Millisecond)
+	// Wait until the retry loop has committed to the 10-minute backoff, then
+	// cancel. Cancellation must surface promptly; without the ctx-aware wait
+	// this would block ~10 minutes.
+	<-strategy.entered
 	cancel()
 
 	select {
@@ -625,10 +643,11 @@ func TestTopicSubscriptionCloseInterruptsReconnectBackoff(t *testing.T) {
 			return nil, disconnectErr
 		},
 	}
+	strategy := newSignalingBackoffRetryStrategy(10 * 60 * 1000)
 	client, pool := newAccountingTestClientWithStrategy(
 		streamClient,
 		time.Second,
-		fixedBackoffRetryStrategy{backoffMs: 10 * 60 * 1000},
+		strategy,
 	)
 
 	sub, err := client.Subscribe(context.Background(), testSubscribeRequest())
@@ -643,8 +662,9 @@ func TestTopicSubscriptionCloseInterruptsReconnectBackoff(t *testing.T) {
 		eventDone <- eventErr
 	}()
 
-	// Let Event hit the disconnect and enter the 10-minute backoff, then Close.
-	time.Sleep(50 * time.Millisecond)
+	// Wait until the retry loop has committed to the 10-minute backoff, then
+	// Close. The closedSignal case must interrupt the wait promptly.
+	<-strategy.entered
 	sub.Close()
 
 	select {
@@ -717,6 +737,52 @@ func TestTopicSubscriptionReconnectUsesSubscribeContext(t *testing.T) {
 	assertAccounting(t, pool, 1)
 
 	sub.Close()
+	assertAccounting(t, pool, 0)
+}
+
+// TestTopicSubscriptionReconnectStopsWhenPoolIsClosed verifies the retry loop
+// treats the pool's shutdown CanceledError as terminal: even an always-retry
+// strategy must not spin against a closed pool.
+func TestTopicSubscriptionReconnectStopsWhenPoolIsClosed(t *testing.T) {
+	disconnectErr := status.Error(codes.Unavailable, "stream disconnected")
+	streamClient := &testPubsubClient{
+		subscribe: func(context.Context, *pb.XSubscriptionRequest, ...grpc.CallOption) (pb.Pubsub_SubscribeClient, error) {
+			return &testSubscribeClient{
+				results: []recvResult{
+					{item: heartbeatItem()},
+					{err: disconnectErr},
+				},
+			}, nil
+		},
+	}
+	client, pool := newAccountingTestClient(streamClient, time.Second)
+
+	sub, err := client.Subscribe(context.Background(), testSubscribeRequest())
+	if err != nil {
+		t.Fatalf("Subscribe returned error: %v", err)
+	}
+	assertAccounting(t, pool, 1)
+
+	// Shut the pool down, then drive Event into the disconnect. Every
+	// reconnect attempt now fails with the pool's CanceledError; the
+	// always-retry strategy must not loop on it.
+	pool.closed.Store(true)
+
+	eventDone := make(chan error, 1)
+	go func() {
+		_, eventErr := sub.Event(context.Background())
+		eventDone <- eventErr
+	}()
+
+	select {
+	case eventErr := <-eventDone:
+		if eventErr == nil {
+			t.Fatal("expected Event to return an error after the pool closed")
+		}
+		assertErrorCode(t, eventErr, momentoerrors.CanceledError)
+	case <-time.After(5 * time.Second):
+		t.Fatal("Event did not return within 5s; reconnect loop is spinning against a closed pool")
+	}
 	assertAccounting(t, pool, 0)
 }
 


### PR DESCRIPTION
Refactors topic gRPC connection pool accounting so slots are acquired and released exactly once on every reconnect/close path and on subscribe failures. Fixes slot leaks, double releases (counters going negative), and a few shutdown bugs where subscriptions could retry forever. (One known leak remains at this PR's head — a Subscribe that times out waiting for the first heartbeat — and is fixed by the stacked follow-up #678.)

### Behavior changes

1. A context error from `Item`/`Event` no longer kills the pool accounting, and the subscription survives it. Previously the call returned `context.Canceled`/`context.DeadlineExceeded` but released the subscription's pool slot while leaving the stream open, so the accounting drifted every time it happened. Now an error from the context you pass to `Item`/`Event` means only that the call stopped waiting: the stream and its slot stay intact and a later call with a live context picks up where you left off, including resuming an interrupted reconnect. One migration note: cancelling a per-call context no longer frees the pool slot as a side effect, so call `Close()` (idempotent) when abandoning a subscription.

2. Terminal errors are now typed. After `Close()`, or after the context passed to `Subscribe` ends, `Item`/`Event` returns a `CanceledError` (previously a raw `context.Canceled`). The error unwraps to `context.Canceled`, so `errors.Is` still matches; only identity or string comparisons need to change:

   ```go
   _, err := sub.Item(ctx) // after sub.Close()

   // before: matched on the old SDK, silently stops matching after upgrade
   if err == context.Canceled { ... }
   if err.Error() == "context canceled" { ... }

   // after: works on both old and new SDK
   if errors.Is(err, context.Canceled) { ... }
   ```

   The typed code is what lets a consumer loop tell a dead subscription apart from its own per-call context expiring (which now leaves the subscription usable, per behavior change 1 above):

   ```go
   var merr momento.MomentoError
   if ctx.Err() != nil {
       // my ctx expired; subscription still alive, call again when ready
   } else if errors.As(err, &merr) && merr.Code() == momento.CanceledError {
       // subscription ended: Close() was called or the Subscribe ctx ended
   }
   ```

### Other user-facing fixes

- `Close()` interrupts an in-flight reconnect backoff instead of waiting out the full interval
- a subscription no longer reconnect-loops forever after `TopicClient.Close()` under the default retry strategy
- reconnected streams stay parented to the Subscribe ctx; previously a reconnect re-parented the stream to whichever Event call triggered it
- topics errors now implement `Unwrap()`, so `errors.Is(err, context.Canceled)` works through the `CanceledError` values returned by Subscribe/Item/Event (the public converted-error type used by cache-client paths is a follow-up)
- reconnect failures keep their real error codes instead of being demoted to a generic `ClientSdkError`
- Subscribe during client shutdown returns `CanceledError` instead of a racy `ClientSdkError`, and calling `TopicClient.Close()` twice can't panic anymore
- pool capacity errors are never stale (a freed slot is visible to the next Subscribe) and an idle client no longer reports one phantom active stream per pool

### What changed internally

- new `Reservation` type (`topic_manager_lists/reservation.go`) wraps the acquired manager with an idempotent CAS-guarded `Release()`. `GetNextTopicGrpcManager()` now returns `*Reservation` and the old `ReleaseTopicGrpcManager` method is gone. The unary pool's release is a no-op for contract uniformity.
- the static and dynamic stream pools share a mutex-serialized `streamPoolCore` that replaces the prefetch dispatcher goroutine + unbuffered channel. Capacity is evaluated at call time against live counters; the pool types just hold their capacity policy (fixed vs grow-on-demand).
- `topicSubscription` drops its mutex for an `atomic.Pointer[streamState]` snapshot. Close-during-reconnect is handled with a store/load ordering on closed/state so either side observes the other's write.
- a reconnect interrupted by the caller's ctx dying is carried across calls as a paused recovery (`needsReconnect`/`lastStreamErr`, owned by the single Event goroutine per the documented contract); the next call with a live ctx resumes it.
- `TopicGrpcManager.Close()` no longer resets `NumActiveSubscriptions` to 0, since late `Release` calls would push it negative.

### Tests

The new unit tests run without credentials (grpc dials lazily): reservation idempotency under contention; stream pool exhaustion/close/growth/per-channel-cap invariants plus the unary pool's lifecycle; and a lifecycle accounting suite that pins exact error codes and release counts on every subscribe/event/reconnect/close path above, several of them mutation-verified. The momento-local pool specs now assert exact counts (the old assertions encoded the dispatcher's prefetch), the three static burst specs are one DescribeTable, and `make test`/`prod-test` run the internal packages too. 73/73 momento-local retry specs pass.

Note for reviewers: the commit history shows the design evolving (an early dispatcher patch gets superseded by the mutex core later in the stack), so it's easier to review the final diff than commit by commit.








