### PR TITLE
feat(errors): implement Unwrap on momentoSvcError (topics stack 2/5)

### DIFF
--- a/internal/momentoerrors/types.go
+++ b/internal/momentoerrors/types.go
@@ -42,3 +42,9 @@ func (err momentoSvcError) Error() string {
 	}
 	return fmt.Sprintf("%s: %s", err.code, err.message)
 }
+
+// Unwrap exposes the underlying cause to errors.Is/errors.As, e.g. so a
+// caller can match context.Canceled behind a CanceledError.
+func (err momentoSvcError) Unwrap() error {
+	return err.originalErr
+}

--- a/internal/momentoerrors/types_test.go
+++ b/internal/momentoerrors/types_test.go
@@ -1,0 +1,53 @@
+package momentoerrors
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func TestMomentoSvcErrorUnwrapExposesCause(t *testing.T) {
+	t.Parallel()
+
+	cause := context.Canceled
+	err := NewMomentoSvcErr(CanceledError, "subscribe context canceled", cause)
+
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("errors.Is(err, context.Canceled) = false, want true (err: %v)", err)
+	}
+
+	var svcErr MomentoSvcErr
+	if !errors.As(err, &svcErr) || svcErr.Code() != CanceledError {
+		t.Fatalf("errors.As did not recover the MomentoSvcErr (err: %v)", err)
+	}
+}
+
+func TestMomentoSvcErrorUnwrapNilCause(t *testing.T) {
+	t.Parallel()
+
+	err := NewMomentoSvcErr(TimeoutError, "no cause", nil)
+	if errors.Unwrap(err) != nil {
+		t.Fatalf("Unwrap() = %v, want nil", errors.Unwrap(err))
+	}
+}
+
+// TestConvertSvcErrUnwrapsToGrpcStatus pins the behavior change Unwrap
+// introduces in ConvertSvcErr: a MomentoSvcErr wrapping a gRPC status error
+// now re-converts by the inner status code instead of falling back to
+// ClientSdkError.
+func TestConvertSvcErrUnwrapsToGrpcStatus(t *testing.T) {
+	t.Parallel()
+
+	wrapped := NewMomentoSvcErr(ServerUnavailableError, "stream disconnected", status.Error(codes.Unavailable, "unavailable"))
+	if got := ConvertSvcErr(wrapped).Code(); got != ServerUnavailableError {
+		t.Fatalf("ConvertSvcErr(wrapped grpc status).Code() = %s, want %s", got, ServerUnavailableError)
+	}
+
+	plain := NewMomentoSvcErr(CanceledError, "subscription closed", nil)
+	if got := ConvertSvcErr(plain).Code(); got != ClientSdkError {
+		t.Fatalf("ConvertSvcErr(no-status MomentoSvcErr).Code() = %s, want %s (documented fallback)", got, ClientSdkError)
+	}
+}


### PR DESCRIPTION
Part 2 of 5 of the topics connection-management stack.

`momentoSvcError` implements `Unwrap()`: `errors.Is`/`errors.As` can now see through a `MomentoSvcErr` to its cause (e.g. `context.Canceled` behind a `CanceledError`), and `ConvertSvcErr` re-derives the code from a wrapped gRPC status error instead of falling back to `ClientSdkError`. Tests pin both behaviors.

Groundwork for #4, whose typed terminal errors wrap context errors. Note this covers the internal topics error type; the public converted-error type used by cache-client paths is a known follow-up.

Stack: #679 → **#680 (this)** → #681 pool Reservation+core → #682 subscription lifecycle → #683 subscribe watchdog.

