### PR TITLE
feat(topics): Reservation slot handle and mutex-serialized pool core (topics stack 3/5)

### DIFF
--- a/internal/grpcmanagers/topic_manager.go
+++ b/internal/grpcmanagers/topic_manager.go
@@ -45,6 +45,8 @@ func NewStreamTopicGrpcManager(request *models.TopicStreamGrpcManagerRequest) (*
 }
 
 func (topicManager *TopicGrpcManager) Close() momentoerrors.MomentoSvcErr {
-	topicManager.NumActiveSubscriptions.Store(0)
+	// Don't reset NumActiveSubscriptions: outstanding Reservation.Release
+	// calls may still decrement it after Close, and a reset would race with
+	// them and push the counter negative.
 	return momentoerrors.ConvertSvcErr(topicManager.Conn.Close())
 }

--- a/internal/grpcmanagers/topic_manager_lists/dynamic_stream_grpc_manager_pool.go
+++ b/internal/grpcmanagers/topic_manager_lists/dynamic_stream_grpc_manager_pool.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"sync"
 	"sync/atomic"
 
 	"github.com/momentohq/client-sdk-go/config"
@@ -13,18 +14,28 @@ import (
 	"github.com/momentohq/client-sdk-go/internal/momentoerrors"
 )
 
-// dynamicStreamGrpcManagerPool manages a dynamic pool of gRPC channels for stream pubsub requests.
+// dynamicStreamGrpcManagerPool manages a dynamic pool of gRPC channels for
+// stream pubsub requests.
+//
+// makeNextManagerAvailable is the sole writer to grpcManagers; numGrpcManagers
+// mirrors the length atomically for external readers. Close waits on
+// dispatcherDone before iterating grpcManagers, so neither racing append nor
+// racing send is possible.
 type dynamicStreamGrpcManagerPool struct {
 	grpcManagers                    []*grpcmanagers.TopicGrpcManager
+	numGrpcManagers                 atomic.Int32
 	managerIndex                    atomic.Uint64
-	maxManagerCount                 int    // maximum number of grpc channels that can be created
-	currentMaxConcurrentStreams     uint32 // current number of grpc channels * MAX_CONCURRENT_STREAMS_PER_CHANNEL
+	maxManagerCount                 int    // max grpc channels
+	currentMaxConcurrentStreams     uint32 // grpc channels * MAX_CONCURRENT_STREAMS_PER_CHANNEL
 	currentActiveStreamsCount       atomic.Uint64
 	logger                          logger.MomentoLogger
 	newTopicManagerProps            *models.TopicStreamGrpcManagerRequest
 	nextAvailableGrpcManagerChannel chan *StreamGrpcManagerRequest
 	ctx                             context.Context
 	cancel                          context.CancelFunc
+	// dispatcherDone is closed when makeNextManagerAvailable returns.
+	dispatcherDone chan struct{}
+	closeOnce      sync.Once
 }
 
 // GetNextTopicGrpcManager returns the next available TopicGrpcManager from the pool
@@ -33,7 +44,7 @@ type dynamicStreamGrpcManagerPool struct {
 // Only the makeNextManagerAvailable goroutine started in NewDynamicStreamGrpcManagerPool
 // places the next available stream manager on the channel (or an error if no stream manager
 // is available).
-func (d *dynamicStreamGrpcManagerPool) GetNextTopicGrpcManager() (*grpcmanagers.TopicGrpcManager, momentoerrors.MomentoSvcErr) {
+func (d *dynamicStreamGrpcManagerPool) GetNextTopicGrpcManager() (*Reservation, momentoerrors.MomentoSvcErr) {
 	select {
 	// If the context was cancelled, we should no longer return any topic managers
 	case <-d.ctx.Done():
@@ -50,20 +61,25 @@ func (d *dynamicStreamGrpcManagerPool) GetNextTopicGrpcManager() (*grpcmanagers.
 		if topicManagerRequest.Err != nil {
 			return nil, topicManagerRequest.Err
 		}
-		return topicManagerRequest.TopicManager, nil
+		return NewReservation(topicManagerRequest.TopicManager, d.releaseManager), nil
 	}
 }
 
-// Close shuts down all the grpc connections in the pool.
+// Close shuts down all gRPC connections. Safe to call multiple times.
+// Cancels the dispatcher context, waits for the dispatcher to exit, closes
+// the manager channel, then tears down each connection.
 func (d *dynamicStreamGrpcManagerPool) Close() {
-	d.cancel() // Cancel context first to stop goroutines
-	close(d.nextAvailableGrpcManagerChannel)
-	for _, topicManager := range d.grpcManagers {
-		err := topicManager.Close()
-		if err != nil {
-			d.logger.Error("Error closing topic manager: %s", err.Error())
+	d.closeOnce.Do(func() {
+		d.cancel()
+		<-d.dispatcherDone
+		close(d.nextAvailableGrpcManagerChannel)
+		for _, topicManager := range d.grpcManagers {
+			err := topicManager.Close()
+			if err != nil {
+				d.logger.Error("Error closing topic manager: %s", err.Error())
+			}
 		}
-	}
+	})
 }
 
 // GetCurrentActiveStreamsCount returns the current number of active streams in the pool.
@@ -71,10 +87,10 @@ func (d *dynamicStreamGrpcManagerPool) GetCurrentActiveStreamsCount() uint64 {
 	return d.currentActiveStreamsCount.Load()
 }
 
-// ReleaseTopicGrpcManager decrements both the per-channel NumActiveSubscriptions counter
-// on the given manager and the pool-wide currentActiveStreamsCount, freeing up the slot
-// so future GetNextTopicGrpcManager calls see capacity. Returns the new per-channel count.
-func (d *dynamicStreamGrpcManagerPool) ReleaseTopicGrpcManager(manager *grpcmanagers.TopicGrpcManager) int64 {
+// releaseManager backs Reservation.Release for this pool. Decrements the
+// per-channel and pool-wide counters; the pool-wide CAS bottoms at zero so
+// it can't go negative.
+func (d *dynamicStreamGrpcManagerPool) releaseManager(manager *grpcmanagers.TopicGrpcManager) int64 {
 	newCount := manager.NumActiveSubscriptions.Add(-1)
 	for {
 		current := d.currentActiveStreamsCount.Load()
@@ -90,7 +106,7 @@ func (d *dynamicStreamGrpcManagerPool) ReleaseTopicGrpcManager(manager *grpcmana
 
 // GetCurrentNumberOfGrpcManagers returns the current number of grpc managers in the pool.
 func (d *dynamicStreamGrpcManagerPool) GetCurrentNumberOfGrpcManagers() int {
-	return len(d.grpcManagers)
+	return int(d.numGrpcManagers.Load())
 }
 
 // NewDynamicStreamGrpcManagerPool creates a new pool with a dynamic number of grpc managers for stream pubsub requests.
@@ -121,10 +137,13 @@ func NewDynamicStreamGrpcManagerPool(request *models.TopicStreamGrpcManagerReque
 		nextAvailableGrpcManagerChannel: nextAvailableGrpcManagerChannel,
 		ctx:                             ctx,
 		cancel:                          cancel,
+		dispatcherDone:                  make(chan struct{}),
 	}
 
-	// Start goroutine to continually make the next available stream manager
-	// available on the streamManagerRequestQueue
+	pool.numGrpcManagers.Store(int32(len(streamTopicManagers)))
+
+	// Start the dispatcher goroutine that keeps the unbuffered channel fed
+	// with the next available manager.
 	go pool.makeNextManagerAvailable()
 
 	return pool, nil
@@ -140,6 +159,7 @@ func NewDynamicStreamGrpcManagerPool(request *models.TopicStreamGrpcManagerReque
 // only be able to pull one topic grpc manager from the channel at a time to allocate
 // to each subscribe request.
 func (d *dynamicStreamGrpcManagerPool) makeNextManagerAvailable() {
+	defer close(d.dispatcherDone)
 	for {
 		select {
 		case <-d.ctx.Done():
@@ -148,6 +168,11 @@ func (d *dynamicStreamGrpcManagerPool) makeNextManagerAvailable() {
 			topicManager, err := d.getNextManager()
 			select {
 			case <-d.ctx.Done():
+				// Close interrupted a prepared envelope: return the prefetched
+				// slot so the counters stay exact. Error envelopes hold no slot.
+				if topicManager != nil {
+					d.releaseManager(topicManager)
+				}
 				return
 			case d.nextAvailableGrpcManagerChannel <- &StreamGrpcManagerRequest{
 				TopicManager: topicManager,
@@ -232,6 +257,7 @@ func (d *dynamicStreamGrpcManagerPool) addManager() momentoerrors.MomentoSvcErr 
 		return err
 	}
 	d.grpcManagers = append(d.grpcManagers, streamTopicManager)
+	d.numGrpcManagers.Store(int32(len(d.grpcManagers)))
 	d.currentMaxConcurrentStreams = uint32(len(d.grpcManagers)) * uint32(config.MAX_CONCURRENT_STREAMS_PER_CHANNEL)
 	return nil
 }

--- a/internal/grpcmanagers/topic_manager_lists/dynamic_stream_grpc_manager_pool.go
+++ b/internal/grpcmanagers/topic_manager_lists/dynamic_stream_grpc_manager_pool.go
@@ -1,11 +1,8 @@
 package topic_manager_lists
 
 import (
-	"context"
 	"fmt"
 	"math"
-	"sync"
-	"sync/atomic"
 
 	"github.com/momentohq/client-sdk-go/config"
 	"github.com/momentohq/client-sdk-go/config/logger"
@@ -15,98 +12,20 @@ import (
 )
 
 // dynamicStreamGrpcManagerPool manages a dynamic pool of gRPC channels for
-// stream pubsub requests.
+// stream pubsub requests. Allocation, release, and Close live in the embedded
+// streamPoolCore; this type supplies the grow-on-demand capacity policy.
 //
-// makeNextManagerAvailable is the sole writer to grpcManagers; numGrpcManagers
-// mirrors the length atomically for external readers. Close waits on
-// dispatcherDone before iterating grpcManagers, so neither racing append nor
-// racing send is possible.
+// grpcManagers and currentMaxConcurrentStreams are only mutated by addManager
+// under the core's mutex.
 type dynamicStreamGrpcManagerPool struct {
-	grpcManagers                    []*grpcmanagers.TopicGrpcManager
-	numGrpcManagers                 atomic.Int32
-	managerIndex                    atomic.Uint64
-	maxManagerCount                 int    // max grpc channels
-	currentMaxConcurrentStreams     uint32 // grpc channels * MAX_CONCURRENT_STREAMS_PER_CHANNEL
-	currentActiveStreamsCount       atomic.Uint64
-	logger                          logger.MomentoLogger
-	newTopicManagerProps            *models.TopicStreamGrpcManagerRequest
-	nextAvailableGrpcManagerChannel chan *StreamGrpcManagerRequest
-	ctx                             context.Context
-	cancel                          context.CancelFunc
-	// dispatcherDone is closed when makeNextManagerAvailable returns.
-	dispatcherDone chan struct{}
-	closeOnce      sync.Once
-}
-
-// GetNextTopicGrpcManager returns the next available TopicGrpcManager from the pool
-// by pulling from the nextAvailableGrpcManagerChannel.
-//
-// Only the makeNextManagerAvailable goroutine started in NewDynamicStreamGrpcManagerPool
-// places the next available stream manager on the channel (or an error if no stream manager
-// is available).
-func (d *dynamicStreamGrpcManagerPool) GetNextTopicGrpcManager() (*Reservation, momentoerrors.MomentoSvcErr) {
-	select {
-	// If the context was cancelled, we should no longer return any topic managers
-	case <-d.ctx.Done():
-		return nil, momentoerrors.NewMomentoSvcErr(momentoerrors.CanceledError, "Context cancelled", nil)
-	default:
-		topicManagerRequest := <-d.nextAvailableGrpcManagerChannel
-
-		// If the channel is closed, we'll receive a zero value (nil in this case since it's a pointer type).
-		// This means that the pool is shutting down and we should no longer return any topic managers.
-		if topicManagerRequest == nil {
-			return nil, momentoerrors.NewMomentoSvcErr(momentoerrors.ClientSdkError, "Received nil from nextAvailableGrpcManagerChannel", nil)
-		}
-
-		if topicManagerRequest.Err != nil {
-			return nil, topicManagerRequest.Err
-		}
-		return NewReservation(topicManagerRequest.TopicManager, d.releaseManager), nil
-	}
-}
-
-// Close shuts down all gRPC connections. Safe to call multiple times.
-// Cancels the dispatcher context, waits for the dispatcher to exit, closes
-// the manager channel, then tears down each connection.
-func (d *dynamicStreamGrpcManagerPool) Close() {
-	d.closeOnce.Do(func() {
-		d.cancel()
-		<-d.dispatcherDone
-		close(d.nextAvailableGrpcManagerChannel)
-		for _, topicManager := range d.grpcManagers {
-			err := topicManager.Close()
-			if err != nil {
-				d.logger.Error("Error closing topic manager: %s", err.Error())
-			}
-		}
-	})
-}
-
-// GetCurrentActiveStreamsCount returns the current number of active streams in the pool.
-func (d *dynamicStreamGrpcManagerPool) GetCurrentActiveStreamsCount() uint64 {
-	return d.currentActiveStreamsCount.Load()
-}
-
-// releaseManager backs Reservation.Release for this pool. Decrements the
-// per-channel and pool-wide counters; the pool-wide CAS bottoms at zero so
-// it can't go negative.
-func (d *dynamicStreamGrpcManagerPool) releaseManager(manager *grpcmanagers.TopicGrpcManager) int64 {
-	newCount := manager.NumActiveSubscriptions.Add(-1)
-	for {
-		current := d.currentActiveStreamsCount.Load()
-		if current == 0 {
-			break
-		}
-		if d.currentActiveStreamsCount.CompareAndSwap(current, current-1) {
-			break
-		}
-	}
-	return newCount
-}
-
-// GetCurrentNumberOfGrpcManagers returns the current number of grpc managers in the pool.
-func (d *dynamicStreamGrpcManagerPool) GetCurrentNumberOfGrpcManagers() int {
-	return int(d.numGrpcManagers.Load())
+	streamPoolCore
+	grpcManagers []*grpcmanagers.TopicGrpcManager
+	// managerIndex is only touched by getNextManager under the core's mutex.
+	managerIndex                uint64
+	maxManagerCount             int    // max grpc channels
+	currentMaxConcurrentStreams uint32 // grpc channels * MAX_CONCURRENT_STREAMS_PER_CHANNEL
+	logger                      logger.MomentoLogger
+	newTopicManagerProps        *models.TopicStreamGrpcManagerRequest
 }
 
 // NewDynamicStreamGrpcManagerPool creates a new pool with a dynamic number of grpc managers for stream pubsub requests.
@@ -123,67 +42,29 @@ func NewDynamicStreamGrpcManagerPool(request *models.TopicStreamGrpcManagerReque
 	streamTopicManagers = append(streamTopicManagers, streamTopicManager)
 	logger.Debug("Max subscriptions: %d, max manager count: %d", maxSubscriptions, int(math.Ceil(float64(maxSubscriptions)/float64(config.MAX_CONCURRENT_STREAMS_PER_CHANNEL))))
 
-	// Unbuffered channel so the stream manager list will block on sending the next
-	// available stream manager until the most recent request is processed.
-	nextAvailableGrpcManagerChannel := make(chan *StreamGrpcManagerRequest)
-	ctx, cancel := context.WithCancel(context.Background())
-
 	pool := &dynamicStreamGrpcManagerPool{
-		grpcManagers:                    streamTopicManagers,
-		maxManagerCount:                 int(math.Ceil(float64(maxSubscriptions) / float64(config.MAX_CONCURRENT_STREAMS_PER_CHANNEL))),
-		currentMaxConcurrentStreams:     uint32(config.MAX_CONCURRENT_STREAMS_PER_CHANNEL), // for one channel
-		logger:                          logger,
-		newTopicManagerProps:            request,
-		nextAvailableGrpcManagerChannel: nextAvailableGrpcManagerChannel,
-		ctx:                             ctx,
-		cancel:                          cancel,
-		dispatcherDone:                  make(chan struct{}),
+		grpcManagers:                streamTopicManagers,
+		maxManagerCount:             int(math.Ceil(float64(maxSubscriptions) / float64(config.MAX_CONCURRENT_STREAMS_PER_CHANNEL))),
+		currentMaxConcurrentStreams: uint32(config.MAX_CONCURRENT_STREAMS_PER_CHANNEL), // for one channel
+		logger:                      logger,
+		newTopicManagerProps:        request,
 	}
-
-	pool.numGrpcManagers.Store(int32(len(streamTopicManagers)))
-
-	// Start the dispatcher goroutine that keeps the unbuffered channel fed
-	// with the next available manager.
-	go pool.makeNextManagerAvailable()
-
+	pool.initStreamPoolCore(pool.getNextManager, func() {
+		closeAllManagers(pool.grpcManagers, logger)
+	})
 	return pool, nil
 }
 
-// makeNextManagerAvailable continually places the next available stream manager
-// on the nextAvailableGrpcManagerChannel.
-//
-// The nextAvailableGrpcManagerChannel is unbuffered, so the dynamicStreamGrpcManagerPool
-// will block on sending the next available stream manager until the most recent request
-// is processed.
-// So even if there is a burst of concurrent subscribe requests, the pubsub client should
-// only be able to pull one topic grpc manager from the channel at a time to allocate
-// to each subscribe request.
-func (d *dynamicStreamGrpcManagerPool) makeNextManagerAvailable() {
-	defer close(d.dispatcherDone)
-	for {
-		select {
-		case <-d.ctx.Done():
-			return
-		default:
-			topicManager, err := d.getNextManager()
-			select {
-			case <-d.ctx.Done():
-				// Close interrupted a prepared envelope: return the prefetched
-				// slot so the counters stay exact. Error envelopes hold no slot.
-				if topicManager != nil {
-					d.releaseManager(topicManager)
-				}
-				return
-			case d.nextAvailableGrpcManagerChannel <- &StreamGrpcManagerRequest{
-				TopicManager: topicManager,
-				Err:          err,
-			}:
-			}
-		}
-	}
+// GetCurrentNumberOfGrpcManagers returns the current number of grpc managers in the pool.
+func (d *dynamicStreamGrpcManagerPool) GetCurrentNumberOfGrpcManagers() int {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return len(d.grpcManagers)
 }
 
-// getNextManager is used by makeNextManagerAvailable to return the next available stream manager from the pool.
+// getNextManager returns the next available stream manager from the pool,
+// reserving a slot on it and growing the pool if needed. Called by
+// streamPoolCore under its mutex.
 func (d *dynamicStreamGrpcManagerPool) getNextManager() (*grpcmanagers.TopicGrpcManager, momentoerrors.MomentoSvcErr) {
 	// First check if there is enough grpc stream capacity to make a new subscription
 	err := d.checkNumConcurrentStreams()
@@ -191,19 +72,10 @@ func (d *dynamicStreamGrpcManagerPool) getNextManager() (*grpcmanagers.TopicGrpc
 		return nil, err
 	}
 
-	// Max number of attempts is set to the max number of concurrent streams in order to preserve
-	// the round-robin system (incrementing nextManagerIndex) but to not cut short the number
-	//  of attempts in case there are many subscriptions starting up at the same time.
-	for i := 0; uint32(i) < d.currentMaxConcurrentStreams; i++ {
-		nextManagerIndex := d.managerIndex.Add(1)
-		topicManager := d.grpcManagers[nextManagerIndex%uint64(len(d.grpcManagers))]
-		newCount := topicManager.NumActiveSubscriptions.Add(1)
-		if newCount <= int64(config.MAX_CONCURRENT_STREAMS_PER_CHANNEL) {
-			d.logger.Debug("Starting new subscription on grpc channel %d which now has %d streams", nextManagerIndex%uint64(len(d.grpcManagers)), newCount)
-			d.currentActiveStreamsCount.Add(1)
-			return topicManager, nil
-		}
-		topicManager.NumActiveSubscriptions.Add(-1)
+	// The attempt bound is generous: allocation is serialized by the core
+	// mutex, so one pass over every channel would suffice.
+	if topicManager := d.reserveSlot(d.grpcManagers, &d.managerIndex, d.currentMaxConcurrentStreams, d.logger); topicManager != nil {
+		return topicManager, nil
 	}
 
 	// If there are no more streams available, return an error
@@ -217,7 +89,7 @@ func (d *dynamicStreamGrpcManagerPool) getNextManager() (*grpcmanagers.TopicGrpc
 // If both maximums have been reached, it will return a ClientResourceExhaustedError.
 func (d *dynamicStreamGrpcManagerPool) checkNumConcurrentStreams() momentoerrors.MomentoSvcErr {
 	numActiveStreams := d.currentActiveStreamsCount.Load()
-	d.logger.Debug("Current number of active subscriptions: %d", d.currentActiveStreamsCount.Load())
+	d.logger.Debug("Current number of active subscriptions: %d", numActiveStreams)
 
 	numStreamManagers := len(d.grpcManagers)
 
@@ -257,7 +129,6 @@ func (d *dynamicStreamGrpcManagerPool) addManager() momentoerrors.MomentoSvcErr 
 		return err
 	}
 	d.grpcManagers = append(d.grpcManagers, streamTopicManager)
-	d.numGrpcManagers.Store(int32(len(d.grpcManagers)))
 	d.currentMaxConcurrentStreams = uint32(len(d.grpcManagers)) * uint32(config.MAX_CONCURRENT_STREAMS_PER_CHANNEL)
 	return nil
 }

--- a/internal/grpcmanagers/topic_manager_lists/pool_close_test.go
+++ b/internal/grpcmanagers/topic_manager_lists/pool_close_test.go
@@ -1,0 +1,355 @@
+package topic_manager_lists
+
+import (
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/momentohq/client-sdk-go/auth"
+	"github.com/momentohq/client-sdk-go/config"
+	"github.com/momentohq/client-sdk-go/config/logger"
+	"github.com/momentohq/client-sdk-go/internal/grpcmanagers"
+	"github.com/momentohq/client-sdk-go/internal/models"
+	"github.com/momentohq/client-sdk-go/internal/momentoerrors"
+)
+
+// newTestManagerRequest builds a manager request against momento-local
+// defaults. grpc.NewClient dials lazily, so these tests never need a running
+// server: no RPC is ever issued.
+func newTestManagerRequest(t *testing.T) *models.TopicStreamGrpcManagerRequest {
+	t.Helper()
+	credProvider, err := auth.NewMomentoLocalProvider(&auth.MomentoLocalConfig{})
+	if err != nil {
+		t.Fatalf("NewMomentoLocalProvider returned error: %v", err)
+	}
+	return &models.TopicStreamGrpcManagerRequest{
+		GrpcConfiguration:  config.NewTopicsStaticGrpcConfiguration(&config.TopicsGrpcConfigurationProps{}),
+		CredentialProvider: credProvider,
+	}
+}
+
+func newStaticTestPool(t *testing.T, numChannels uint32) *staticStreamGrpcManagerPool {
+	t.Helper()
+	pool, err := NewStaticStreamGrpcManagerPool(
+		newTestManagerRequest(t),
+		numChannels,
+		logger.NewNoopMomentoLoggerFactory().GetLogger("pool-test"),
+	)
+	if err != nil {
+		t.Fatalf("NewStaticStreamGrpcManagerPool returned error: %v", err)
+	}
+	return pool
+}
+
+// TestTopicStreamPoolHoldsNoSlotsWhileIdle pins the exact-counting contract:
+// an idle pool reports zero active streams, each reservation counts exactly
+// one, and a release is immediately visible.
+func TestTopicStreamPoolHoldsNoSlotsWhileIdle(t *testing.T) {
+	t.Parallel()
+
+	pool := newStaticTestPool(t, 1)
+	defer pool.Close()
+
+	if got := pool.GetCurrentActiveStreamsCount(); got != 0 {
+		t.Fatalf("idle active streams count = %d, want 0", got)
+	}
+
+	reservation, err := pool.GetNextTopicGrpcManager()
+	if err != nil {
+		t.Fatalf("GetNextTopicGrpcManager returned error: %v", err)
+	}
+	if got := pool.GetCurrentActiveStreamsCount(); got != 1 {
+		t.Fatalf("active streams count with one reservation = %d, want 1", got)
+	}
+
+	reservation.Release()
+	if got := pool.GetCurrentActiveStreamsCount(); got != 0 {
+		t.Fatalf("active streams count after release = %d, want 0", got)
+	}
+}
+
+// TestTopicStreamPoolExhaustionErrorIsNeverStale verifies capacity is
+// evaluated per call: a pool that just returned ResourceExhausted hands out a
+// manager on the very next call once a slot frees.
+func TestTopicStreamPoolExhaustionErrorIsNeverStale(t *testing.T) {
+	t.Parallel()
+
+	pool := newStaticTestPool(t, 1)
+	defer pool.Close()
+
+	reservations := make([]*Reservation, 0, config.MAX_CONCURRENT_STREAMS_PER_CHANNEL)
+	for i := 0; i < config.MAX_CONCURRENT_STREAMS_PER_CHANNEL; i++ {
+		reservation, err := pool.GetNextTopicGrpcManager()
+		if err != nil {
+			t.Fatalf("GetNextTopicGrpcManager %d returned error: %v", i, err)
+		}
+		reservations = append(reservations, reservation)
+	}
+
+	if _, err := pool.GetNextTopicGrpcManager(); err == nil {
+		t.Fatal("expected ResourceExhausted error from a full pool")
+	} else if err.Code() != momentoerrors.ClientResourceExhaustedError {
+		t.Fatalf("error code = %s, want %s", err.Code(), momentoerrors.ClientResourceExhaustedError)
+	}
+
+	// Free one slot; the next call must succeed immediately.
+	reservations[0].Release()
+	reservation, err := pool.GetNextTopicGrpcManager()
+	if err != nil {
+		t.Fatalf("GetNextTopicGrpcManager after release returned error: %v", err)
+	}
+	reservation.Release()
+	for _, r := range reservations[1:] {
+		r.Release()
+	}
+	if got := pool.GetCurrentActiveStreamsCount(); got != 0 {
+		t.Fatalf("active streams count after releasing all = %d, want 0", got)
+	}
+}
+
+// TestTopicStreamPoolGetAfterCloseReturnsCanceled verifies shutdown behavior:
+// Close is idempotent (including concurrently) and subsequent reservations
+// are refused with CanceledError.
+func TestTopicStreamPoolGetAfterCloseReturnsCanceled(t *testing.T) {
+	t.Parallel()
+
+	pool := newStaticTestPool(t, 1)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		pool.Close()
+	}()
+	pool.Close()
+	<-done
+	pool.Close()
+
+	reservation, err := pool.GetNextTopicGrpcManager()
+	if err == nil {
+		t.Fatal("expected GetNextTopicGrpcManager to fail after Close")
+	}
+	if err.Code() != momentoerrors.CanceledError {
+		t.Fatalf("error code = %s, want %s", err.Code(), momentoerrors.CanceledError)
+	}
+	if reservation != nil {
+		t.Fatal("expected nil reservation after Close")
+	}
+	if got := pool.GetCurrentActiveStreamsCount(); got != 0 {
+		t.Fatalf("active streams count after Close = %d, want 0", got)
+	}
+}
+
+// TestTopicStreamPoolGetRacingCloseIsSafe hammers GetNextTopicGrpcManager
+// while Close runs: every call must return either a usable Reservation or a
+// shutdown/capacity error — never panic or hang — and releasing everything
+// drains the counters to zero.
+func TestTopicStreamPoolGetRacingCloseIsSafe(t *testing.T) {
+	t.Parallel()
+
+	const goroutines = 32
+	const perGoroutine = 25
+
+	pool := newStaticTestPool(t, 2)
+
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	wg.Add(goroutines + 1)
+	for g := 0; g < goroutines; g++ {
+		go func() {
+			defer wg.Done()
+			<-start
+			for i := 0; i < perGoroutine; i++ {
+				reservation, err := pool.GetNextTopicGrpcManager()
+				if err != nil {
+					if code := err.Code(); code != momentoerrors.CanceledError && code != momentoerrors.ClientResourceExhaustedError {
+						t.Errorf("unexpected error code %s: %v", code, err)
+					}
+					continue
+				}
+				reservation.Release()
+			}
+		}()
+	}
+	go func() {
+		defer wg.Done()
+		<-start
+		pool.Close()
+	}()
+	close(start)
+	wg.Wait()
+
+	if got := pool.GetCurrentActiveStreamsCount(); got != 0 {
+		t.Fatalf("active streams count after race = %d, want 0", got)
+	}
+}
+
+// TestTopicUnaryPoolReservationLifecycle covers the real unary pool, which
+// the subscription tests only exercise through fakes: reservations hand out
+// managers round-robin, Release is a no-op returning zero, and Close is
+// idempotent.
+func TestTopicUnaryPoolReservationLifecycle(t *testing.T) {
+	t.Parallel()
+
+	pool, err := NewStaticUnaryGrpcManagerPool(
+		newTestManagerRequest(t),
+		2,
+		logger.NewNoopMomentoLoggerFactory().GetLogger("unary-pool-test"),
+	)
+	if err != nil {
+		t.Fatalf("NewStaticUnaryGrpcManagerPool returned error: %v", err)
+	}
+
+	seen := make(map[*grpcmanagers.TopicGrpcManager]bool)
+	for i := 0; i < 4; i++ {
+		reservation, getErr := pool.GetNextTopicGrpcManager()
+		if getErr != nil {
+			t.Fatalf("GetNextTopicGrpcManager %d returned error: %v", i, getErr)
+		}
+		if reservation.Manager() == nil {
+			t.Fatal("reservation manager is nil")
+		}
+		seen[reservation.Manager()] = true
+		if got := reservation.Release(); got != 0 {
+			t.Fatalf("unary Release returned %d, want 0 (no-op)", got)
+		}
+		if got := reservation.Manager().NumActiveSubscriptions.Load(); got != 0 {
+			t.Fatalf("unary reservations must not touch subscription counts, got %d", got)
+		}
+	}
+	if len(seen) != 2 {
+		t.Fatalf("round-robin visited %d managers, want 2", len(seen))
+	}
+
+	pool.Close()
+	pool.Close() // idempotent
+}
+
+// TestTopicStreamPoolRespectsPerChannelCap fills a multi-channel pool to
+// capacity and checks the invariant the round-robin reservation must hold:
+// no channel ever exceeds MAX_CONCURRENT_STREAMS_PER_CHANNEL, and a full pool
+// lands exactly at the cap on every channel.
+func TestTopicStreamPoolRespectsPerChannelCap(t *testing.T) {
+	t.Parallel()
+
+	const numChannels = 3
+	pool := newStaticTestPool(t, numChannels)
+	defer pool.Close()
+
+	perChannel := int64(config.MAX_CONCURRENT_STREAMS_PER_CHANNEL)
+	total := numChannels * config.MAX_CONCURRENT_STREAMS_PER_CHANNEL
+	reservations := make([]*Reservation, 0, total)
+	for i := 0; i < total; i++ {
+		reservation, err := pool.GetNextTopicGrpcManager()
+		if err != nil {
+			t.Fatalf("GetNextTopicGrpcManager %d returned error: %v", i, err)
+		}
+		reservations = append(reservations, reservation)
+		for channel, manager := range pool.grpcManagers {
+			if got := manager.NumActiveSubscriptions.Load(); got > perChannel {
+				t.Fatalf("channel %d exceeded the per-channel cap after %d reservations: %d > %d", channel, i+1, got, perChannel)
+			}
+		}
+	}
+	for channel, manager := range pool.grpcManagers {
+		if got := manager.NumActiveSubscriptions.Load(); got != perChannel {
+			t.Fatalf("channel %d subscription count at full pool = %d, want exactly %d", channel, got, perChannel)
+		}
+	}
+
+	for _, reservation := range reservations {
+		reservation.Release()
+	}
+	if got := pool.GetCurrentActiveStreamsCount(); got != 0 {
+		t.Fatalf("active streams count after releasing all = %d, want 0", got)
+	}
+}
+
+// TestTopicDynamicStreamPoolGrowsOnDemand verifies the dynamic pool adds a
+// channel when the current capacity is consumed, with exact counters and no
+// RPCs (slots are reserved without opening streams).
+func TestTopicDynamicStreamPoolGrowsOnDemand(t *testing.T) {
+	t.Parallel()
+
+	perChannel := config.MAX_CONCURRENT_STREAMS_PER_CHANNEL
+	pool, err := NewDynamicStreamGrpcManagerPool(
+		newTestManagerRequest(t),
+		uint32(perChannel+50), // maxManagerCount = 2
+		logger.NewNoopMomentoLoggerFactory().GetLogger("pool-test"),
+	)
+	if err != nil {
+		t.Fatalf("NewDynamicStreamGrpcManagerPool returned error: %v", err)
+	}
+	defer pool.Close()
+
+	if got := pool.GetCurrentNumberOfGrpcManagers(); got != 1 {
+		t.Fatalf("initial manager count = %d, want 1", got)
+	}
+
+	reservations := make([]*Reservation, 0, perChannel+1)
+	for i := 0; i < perChannel; i++ {
+		reservation, getErr := pool.GetNextTopicGrpcManager()
+		if getErr != nil {
+			t.Fatalf("GetNextTopicGrpcManager %d returned error: %v", i, getErr)
+		}
+		reservations = append(reservations, reservation)
+	}
+	if got := pool.GetCurrentNumberOfGrpcManagers(); got != 1 {
+		t.Fatalf("manager count at exactly one channel's capacity = %d, want 1", got)
+	}
+
+	// One past the first channel's capacity forces growth.
+	reservation, getErr := pool.GetNextTopicGrpcManager()
+	if getErr != nil {
+		t.Fatalf("GetNextTopicGrpcManager past capacity returned error: %v", getErr)
+	}
+	reservations = append(reservations, reservation)
+	if got := pool.GetCurrentNumberOfGrpcManagers(); got != 2 {
+		t.Fatalf("manager count after growth = %d, want 2", got)
+	}
+	if got := pool.GetCurrentActiveStreamsCount(); got != uint64(perChannel+1) {
+		t.Fatalf("active streams count after growth = %d, want %d", got, perChannel+1)
+	}
+
+	for _, r := range reservations {
+		r.Release()
+	}
+	if got := pool.GetCurrentActiveStreamsCount(); got != 0 {
+		t.Fatalf("active streams count after releasing all = %d, want 0", got)
+	}
+}
+
+// TestTopicDynamicStreamPoolStopsAtMaxSubscriptions verifies the dynamic pool
+// refuses reservations past maxSubscriptions with a fresh error message.
+func TestTopicDynamicStreamPoolStopsAtMaxSubscriptions(t *testing.T) {
+	t.Parallel()
+
+	perChannel := config.MAX_CONCURRENT_STREAMS_PER_CHANNEL
+	pool, err := NewDynamicStreamGrpcManagerPool(
+		newTestManagerRequest(t),
+		uint32(perChannel), // a single channel, no growth allowed
+		logger.NewNoopMomentoLoggerFactory().GetLogger("pool-test"),
+	)
+	if err != nil {
+		t.Fatalf("NewDynamicStreamGrpcManagerPool returned error: %v", err)
+	}
+	defer pool.Close()
+
+	for i := 0; i < perChannel; i++ {
+		if _, getErr := pool.GetNextTopicGrpcManager(); getErr != nil {
+			t.Fatalf("GetNextTopicGrpcManager %d returned error: %v", i, getErr)
+		}
+	}
+	_, getErr := pool.GetNextTopicGrpcManager()
+	if getErr == nil {
+		t.Fatal("expected error past maxSubscriptions")
+	}
+	if getErr.Code() != momentoerrors.ClientResourceExhaustedError {
+		t.Fatalf("error code = %s, want %s", getErr.Code(), momentoerrors.ClientResourceExhaustedError)
+	}
+	if !strings.Contains(getErr.Error(), "maximum number of concurrent grpc streams") {
+		t.Fatalf("unexpected error message: %v", getErr)
+	}
+	if got := pool.GetCurrentNumberOfGrpcManagers(); got != 1 {
+		t.Fatalf("manager count = %d, want 1 (growth not allowed)", got)
+	}
+}

--- a/internal/grpcmanagers/topic_manager_lists/reservation.go
+++ b/internal/grpcmanagers/topic_manager_lists/reservation.go
@@ -1,0 +1,44 @@
+package topic_manager_lists
+
+import (
+	"sync/atomic"
+
+	"github.com/momentohq/client-sdk-go/internal/grpcmanagers"
+)
+
+// Reservation is an acquired stream slot from a TopicGrpcConnectionPool.
+// Call Release when done; redundant calls are safe. Decrement and leak
+// semantics come from the pool's release function (the unary pool's is a
+// no-op). Dropping a stream-pool Reservation without calling Release leaks
+// the slot for the lifetime of the pool.
+type Reservation struct {
+	manager  *grpcmanagers.TopicGrpcManager
+	release  func(*grpcmanagers.TopicGrpcManager) int64
+	released atomic.Bool
+}
+
+// NewReservation builds a Reservation backed by release. Both args must be non-nil.
+func NewReservation(
+	manager *grpcmanagers.TopicGrpcManager,
+	release func(*grpcmanagers.TopicGrpcManager) int64,
+) *Reservation {
+	return &Reservation{
+		manager: manager,
+		release: release,
+	}
+}
+
+func (r *Reservation) Manager() *grpcmanagers.TopicGrpcManager {
+	return r.manager
+}
+
+// Release returns the slot to the pool. Only the first call invokes the
+// pool's release; subsequent calls return the live per-channel count without
+// effect. That value is advisory — a concurrent winning Release may not have
+// performed its decrement yet.
+func (r *Reservation) Release() int64 {
+	if !r.released.CompareAndSwap(false, true) {
+		return r.manager.NumActiveSubscriptions.Load()
+	}
+	return r.release(r.manager)
+}

--- a/internal/grpcmanagers/topic_manager_lists/reservation_test.go
+++ b/internal/grpcmanagers/topic_manager_lists/reservation_test.go
@@ -1,0 +1,125 @@
+package topic_manager_lists
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/momentohq/client-sdk-go/internal/grpcmanagers"
+)
+
+// newCountingReleaser returns a release function that increments a counter
+// each time it is invoked, plus the counter so tests can observe invocations.
+func newCountingReleaser() (func(*grpcmanagers.TopicGrpcManager) int64, *atomic.Int64) {
+	var calls atomic.Int64
+	release := func(mgr *grpcmanagers.TopicGrpcManager) int64 {
+		calls.Add(1)
+		return mgr.NumActiveSubscriptions.Add(-1)
+	}
+	return release, &calls
+}
+
+func TestReservation_ReleaseIsIdempotent(t *testing.T) {
+	t.Parallel()
+
+	mgr := &grpcmanagers.TopicGrpcManager{}
+	mgr.NumActiveSubscriptions.Store(1)
+
+	release, calls := newCountingReleaser()
+	r := NewReservation(mgr, release)
+
+	first := r.Release()
+	if first != 0 {
+		t.Fatalf("first Release returned %d, want 0 (manager counter after decrement)", first)
+	}
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("release function called %d times after first Release, want 1", got)
+	}
+
+	// Redundant calls must not double-decrement.
+	for i := 0; i < 5; i++ {
+		r.Release()
+	}
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("release function called %d times after repeated Release, want 1", got)
+	}
+	if got := mgr.NumActiveSubscriptions.Load(); got != 0 {
+		t.Fatalf("NumActiveSubscriptions = %d, want 0 (only one decrement should have occurred)", got)
+	}
+}
+
+func TestReservation_ReleaseReportsCurrentCountOnSubsequentCalls(t *testing.T) {
+	t.Parallel()
+
+	mgr := &grpcmanagers.TopicGrpcManager{}
+	mgr.NumActiveSubscriptions.Store(3)
+
+	release, _ := newCountingReleaser()
+	r := NewReservation(mgr, release)
+
+	first := r.Release()
+	if first != 2 {
+		t.Fatalf("first Release returned %d, want 2 (started at 3, decremented once)", first)
+	}
+
+	// External actor adjusts the counter to simulate other subscriptions. The
+	// second Release should report whatever the live value is, without
+	// performing another decrement.
+	mgr.NumActiveSubscriptions.Add(5)
+	second := r.Release()
+	if second != 7 {
+		t.Fatalf("second Release returned %d, want 7 (live counter value, no decrement)", second)
+	}
+}
+
+func TestReservation_ManagerReturnsUnderlying(t *testing.T) {
+	t.Parallel()
+
+	mgr := &grpcmanagers.TopicGrpcManager{}
+	release, _ := newCountingReleaser()
+	r := NewReservation(mgr, release)
+
+	if r.Manager() != mgr {
+		t.Fatal("Manager() should return the manager passed to NewReservation")
+	}
+
+	r.Release()
+	if r.Manager() != mgr {
+		t.Fatal("Manager() should remain accessible after Release for in-flight callers")
+	}
+}
+
+func TestReservation_ConcurrentReleaseDecrementsOnce(t *testing.T) {
+	t.Parallel()
+
+	// Run many concurrent Release calls on the same Reservation; only the
+	// first should perform the decrement. Validates the CAS guarantee under
+	// contention and exercises the race detector when -race is enabled.
+	const goroutines = 256
+
+	mgr := &grpcmanagers.TopicGrpcManager{}
+	mgr.NumActiveSubscriptions.Store(int64(goroutines + 10))
+
+	release, calls := newCountingReleaser()
+	r := NewReservation(mgr, release)
+
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			<-start
+			r.Release()
+		}()
+	}
+	close(start)
+	wg.Wait()
+
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("release function called %d times, want 1 under concurrent Release", got)
+	}
+	if got := mgr.NumActiveSubscriptions.Load(); got != int64(goroutines+9) {
+		t.Fatalf("NumActiveSubscriptions = %d, want %d (started at goroutines+10, exactly one decrement)", got, goroutines+9)
+	}
+}

--- a/internal/grpcmanagers/topic_manager_lists/static_stream_grpc_manager_pool.go
+++ b/internal/grpcmanagers/topic_manager_lists/static_stream_grpc_manager_pool.go
@@ -3,6 +3,7 @@ package topic_manager_lists
 import (
 	"context"
 	"fmt"
+	"sync"
 	"sync/atomic"
 
 	"github.com/momentohq/client-sdk-go/config"
@@ -22,6 +23,9 @@ type staticStreamGrpcManagerPool struct {
 	nextAvailableGrpcManagerChannel chan *StreamGrpcManagerRequest
 	ctx                             context.Context
 	cancel                          context.CancelFunc
+	// dispatcherDone is closed when makeNextManagerAvailable returns.
+	dispatcherDone chan struct{}
+	closeOnce      sync.Once
 }
 
 // GetNextTopicGrpcManager returns the next available TopicGrpcManager from the pool
@@ -30,7 +34,7 @@ type staticStreamGrpcManagerPool struct {
 // Only the makeNextManagerAvailable goroutine started in NewStaticStreamGrpcManagerPool
 // places the next available stream manager on the channel (or an error if no stream manager
 // is available).
-func (s *staticStreamGrpcManagerPool) GetNextTopicGrpcManager() (*grpcmanagers.TopicGrpcManager, momentoerrors.MomentoSvcErr) {
+func (s *staticStreamGrpcManagerPool) GetNextTopicGrpcManager() (*Reservation, momentoerrors.MomentoSvcErr) {
 	select {
 	// If the context was cancelled, we should no longer return any topic managers
 	case <-s.ctx.Done():
@@ -47,20 +51,25 @@ func (s *staticStreamGrpcManagerPool) GetNextTopicGrpcManager() (*grpcmanagers.T
 		if topicManagerRequest.Err != nil {
 			return nil, topicManagerRequest.Err
 		}
-		return topicManagerRequest.TopicManager, nil
+		return NewReservation(topicManagerRequest.TopicManager, s.releaseManager), nil
 	}
 }
 
-// Close shuts down all the grpc connections in the pool.
+// Close shuts down all gRPC connections. Safe to call multiple times.
+// Cancels the dispatcher context, waits for the dispatcher to exit, closes
+// the manager channel, then tears down each connection.
 func (s *staticStreamGrpcManagerPool) Close() {
-	s.cancel() // Cancel context first to stop goroutine
-	close(s.nextAvailableGrpcManagerChannel)
-	for _, topicManager := range s.grpcManagers {
-		err := topicManager.Close()
-		if err != nil {
-			s.logger.Error("Error closing topic manager: %v", err)
+	s.closeOnce.Do(func() {
+		s.cancel()
+		<-s.dispatcherDone
+		close(s.nextAvailableGrpcManagerChannel)
+		for _, topicManager := range s.grpcManagers {
+			err := topicManager.Close()
+			if err != nil {
+				s.logger.Error("Error closing topic manager: %v", err)
+			}
 		}
-	}
+	})
 }
 
 // GetCurrentActiveStreamsCount returns the current number of active streams in the pool.
@@ -68,10 +77,10 @@ func (s *staticStreamGrpcManagerPool) GetCurrentActiveStreamsCount() uint64 {
 	return s.currentActiveStreamsCount.Load()
 }
 
-// ReleaseTopicGrpcManager decrements both the per-channel NumActiveSubscriptions counter
-// on the given manager and the pool-wide currentActiveStreamsCount, freeing up the slot
-// so future GetNextTopicGrpcManager calls see capacity. Returns the new per-channel count.
-func (s *staticStreamGrpcManagerPool) ReleaseTopicGrpcManager(manager *grpcmanagers.TopicGrpcManager) int64 {
+// releaseManager backs Reservation.Release for this pool. Decrements the
+// per-channel and pool-wide counters; the pool-wide CAS bottoms at zero so
+// it can't go negative.
+func (s *staticStreamGrpcManagerPool) releaseManager(manager *grpcmanagers.TopicGrpcManager) int64 {
 	newCount := manager.NumActiveSubscriptions.Add(-1)
 	for {
 		current := s.currentActiveStreamsCount.Load()
@@ -112,6 +121,7 @@ func NewStaticStreamGrpcManagerPool(
 		nextAvailableGrpcManagerChannel: nextAvailableGrpcManagerChannel,
 		ctx:                             ctx,
 		cancel:                          cancel,
+		dispatcherDone:                  make(chan struct{}),
 	}
 
 	go pool.makeNextManagerAvailable()
@@ -128,6 +138,7 @@ func NewStaticStreamGrpcManagerPool(
 // only be able to pull one topic grpc manager from the channel at a time to allocate
 // to each subscribe request.
 func (s *staticStreamGrpcManagerPool) makeNextManagerAvailable() {
+	defer close(s.dispatcherDone)
 	for {
 		select {
 		case <-s.ctx.Done():
@@ -136,6 +147,11 @@ func (s *staticStreamGrpcManagerPool) makeNextManagerAvailable() {
 			topicManager, err := s.getNextManager()
 			select {
 			case <-s.ctx.Done():
+				// Close interrupted a prepared envelope: return the prefetched
+				// slot so the counters stay exact. Error envelopes hold no slot.
+				if topicManager != nil {
+					s.releaseManager(topicManager)
+				}
 				return
 			case s.nextAvailableGrpcManagerChannel <- &StreamGrpcManagerRequest{
 				TopicManager: topicManager,

--- a/internal/grpcmanagers/topic_manager_lists/static_stream_grpc_manager_pool.go
+++ b/internal/grpcmanagers/topic_manager_lists/static_stream_grpc_manager_pool.go
@@ -1,10 +1,7 @@
 package topic_manager_lists
 
 import (
-	"context"
 	"fmt"
-	"sync"
-	"sync/atomic"
 
 	"github.com/momentohq/client-sdk-go/config"
 	"github.com/momentohq/client-sdk-go/config/logger"
@@ -13,85 +10,16 @@ import (
 	"github.com/momentohq/client-sdk-go/internal/momentoerrors"
 )
 
-// staticStreamGrpcManagerPool manages a static pool of gRPC channels for stream pubsub requests.
+// staticStreamGrpcManagerPool manages a static pool of gRPC channels for
+// stream pubsub requests. Allocation, release, and Close live in the embedded
+// streamPoolCore; this type supplies the fixed-size capacity policy.
 type staticStreamGrpcManagerPool struct {
-	grpcManagers                    []*grpcmanagers.TopicGrpcManager
-	managerIndex                    atomic.Uint64
-	currentActiveStreamsCount       atomic.Uint64
-	maxConcurrentStreams            uint32
-	logger                          logger.MomentoLogger
-	nextAvailableGrpcManagerChannel chan *StreamGrpcManagerRequest
-	ctx                             context.Context
-	cancel                          context.CancelFunc
-	// dispatcherDone is closed when makeNextManagerAvailable returns.
-	dispatcherDone chan struct{}
-	closeOnce      sync.Once
-}
-
-// GetNextTopicGrpcManager returns the next available TopicGrpcManager from the pool
-// by pulling from the nextAvailableGrpcManagerChannel.
-//
-// Only the makeNextManagerAvailable goroutine started in NewStaticStreamGrpcManagerPool
-// places the next available stream manager on the channel (or an error if no stream manager
-// is available).
-func (s *staticStreamGrpcManagerPool) GetNextTopicGrpcManager() (*Reservation, momentoerrors.MomentoSvcErr) {
-	select {
-	// If the context was cancelled, we should no longer return any topic managers
-	case <-s.ctx.Done():
-		return nil, momentoerrors.NewMomentoSvcErr(momentoerrors.CanceledError, "Context cancelled", nil)
-	default:
-		topicManagerRequest := <-s.nextAvailableGrpcManagerChannel
-
-		// If the channel is closed, we'll receive a zero value (nil in this case since it's a pointer type).
-		// This means that the pool is shutting down and we should no longer return any topic managers.
-		if topicManagerRequest == nil {
-			return nil, momentoerrors.NewMomentoSvcErr(momentoerrors.ClientSdkError, "Received nil from nextAvailableGrpcManagerChannel", nil)
-		}
-
-		if topicManagerRequest.Err != nil {
-			return nil, topicManagerRequest.Err
-		}
-		return NewReservation(topicManagerRequest.TopicManager, s.releaseManager), nil
-	}
-}
-
-// Close shuts down all gRPC connections. Safe to call multiple times.
-// Cancels the dispatcher context, waits for the dispatcher to exit, closes
-// the manager channel, then tears down each connection.
-func (s *staticStreamGrpcManagerPool) Close() {
-	s.closeOnce.Do(func() {
-		s.cancel()
-		<-s.dispatcherDone
-		close(s.nextAvailableGrpcManagerChannel)
-		for _, topicManager := range s.grpcManagers {
-			err := topicManager.Close()
-			if err != nil {
-				s.logger.Error("Error closing topic manager: %v", err)
-			}
-		}
-	})
-}
-
-// GetCurrentActiveStreamsCount returns the current number of active streams in the pool.
-func (s *staticStreamGrpcManagerPool) GetCurrentActiveStreamsCount() uint64 {
-	return s.currentActiveStreamsCount.Load()
-}
-
-// releaseManager backs Reservation.Release for this pool. Decrements the
-// per-channel and pool-wide counters; the pool-wide CAS bottoms at zero so
-// it can't go negative.
-func (s *staticStreamGrpcManagerPool) releaseManager(manager *grpcmanagers.TopicGrpcManager) int64 {
-	newCount := manager.NumActiveSubscriptions.Add(-1)
-	for {
-		current := s.currentActiveStreamsCount.Load()
-		if current == 0 {
-			break
-		}
-		if s.currentActiveStreamsCount.CompareAndSwap(current, current-1) {
-			break
-		}
-	}
-	return newCount
+	streamPoolCore
+	grpcManagers []*grpcmanagers.TopicGrpcManager
+	// managerIndex is only touched by getNextManager under the core's mutex.
+	managerIndex         uint64
+	maxConcurrentStreams uint32
+	logger               logger.MomentoLogger
 }
 
 // NewStaticStreamGrpcManagerPool creates a new pool with a fixed number of grpc managers for stream pubsub requests.
@@ -109,57 +37,15 @@ func NewStaticStreamGrpcManagerPool(
 		streamTopicManagers = append(streamTopicManagers, streamTopicManager)
 	}
 
-	// Use an unbuffered channel here so the staticStreamGrpcManagerPool will block on sending
-	// the next available stream manager until the most recent request is processed.
-	nextAvailableGrpcManagerChannel := make(chan *StreamGrpcManagerRequest)
-	ctx, cancel := context.WithCancel(context.Background())
-
 	pool := &staticStreamGrpcManagerPool{
-		grpcManagers:                    streamTopicManagers,
-		maxConcurrentStreams:            numStreamChannels * uint32(config.MAX_CONCURRENT_STREAMS_PER_CHANNEL),
-		logger:                          logger,
-		nextAvailableGrpcManagerChannel: nextAvailableGrpcManagerChannel,
-		ctx:                             ctx,
-		cancel:                          cancel,
-		dispatcherDone:                  make(chan struct{}),
+		grpcManagers:         streamTopicManagers,
+		maxConcurrentStreams: numStreamChannels * uint32(config.MAX_CONCURRENT_STREAMS_PER_CHANNEL),
+		logger:               logger,
 	}
-
-	go pool.makeNextManagerAvailable()
+	pool.initStreamPoolCore(pool.getNextManager, func() {
+		closeAllManagers(pool.grpcManagers, logger)
+	})
 	return pool, nil
-}
-
-// makeNextManagerAvailable continually places the next available stream manager
-// on the nextAvailableGrpcManagerChannel.
-//
-// The nextAvailableGrpcManagerChannel is unbuffered, so the staticStreamGrpcManagerPool
-// will block on sending the next available stream manager until the most recent request
-// is processed.
-// So even if there is a burst of concurrent subscribe requests, the pubsub client should
-// only be able to pull one topic grpc manager from the channel at a time to allocate
-// to each subscribe request.
-func (s *staticStreamGrpcManagerPool) makeNextManagerAvailable() {
-	defer close(s.dispatcherDone)
-	for {
-		select {
-		case <-s.ctx.Done():
-			return
-		default:
-			topicManager, err := s.getNextManager()
-			select {
-			case <-s.ctx.Done():
-				// Close interrupted a prepared envelope: return the prefetched
-				// slot so the counters stay exact. Error envelopes hold no slot.
-				if topicManager != nil {
-					s.releaseManager(topicManager)
-				}
-				return
-			case s.nextAvailableGrpcManagerChannel <- &StreamGrpcManagerRequest{
-				TopicManager: topicManager,
-				Err:          err,
-			}:
-			}
-		}
-	}
 }
 
 // checkNumConcurrentStreams checks the number of concurrent streams before starting a new subscription
@@ -182,7 +68,8 @@ func (s *staticStreamGrpcManagerPool) checkNumConcurrentStreams() momentoerrors.
 	return nil
 }
 
-// getNextManager is used by makeNextManagerAvailable to return the next available stream manager from the pool.
+// getNextManager returns the next available stream manager from the pool,
+// reserving a slot on it. Called by streamPoolCore under its mutex.
 func (s *staticStreamGrpcManagerPool) getNextManager() (*grpcmanagers.TopicGrpcManager, momentoerrors.MomentoSvcErr) {
 	// First check if there is enough grpc stream capacity to make a new subscription
 	err := s.checkNumConcurrentStreams()
@@ -190,19 +77,10 @@ func (s *staticStreamGrpcManagerPool) getNextManager() (*grpcmanagers.TopicGrpcM
 		return nil, err
 	}
 
-	// Max number of attempts is set to the max number of concurrent streams in order to preserve
-	// the round-robin system (incrementing nextManagerIndex) but to not cut short the number
-	//  of attempts in case there are many subscriptions starting up at the same time.
-	for i := 0; uint32(i) < s.maxConcurrentStreams; i++ {
-		nextManagerIndex := s.managerIndex.Add(1)
-		topicManager := s.grpcManagers[nextManagerIndex%uint64(len(s.grpcManagers))]
-		newCount := topicManager.NumActiveSubscriptions.Add(1)
-		if newCount <= int64(config.MAX_CONCURRENT_STREAMS_PER_CHANNEL) {
-			s.logger.Debug("Starting new subscription on grpc channel %d which now has %d streams", nextManagerIndex%uint64(len(s.grpcManagers)), newCount)
-			s.currentActiveStreamsCount.Add(1)
-			return topicManager, nil
-		}
-		topicManager.NumActiveSubscriptions.Add(-1)
+	// The attempt bound is generous: allocation is serialized by the core
+	// mutex, so one pass over every channel would suffice.
+	if topicManager := s.reserveSlot(s.grpcManagers, &s.managerIndex, s.maxConcurrentStreams, s.logger); topicManager != nil {
+		return topicManager, nil
 	}
 
 	// If there are no more streams available, return an error

--- a/internal/grpcmanagers/topic_manager_lists/static_unary_grpc_manager_pool.go
+++ b/internal/grpcmanagers/topic_manager_lists/static_unary_grpc_manager_pool.go
@@ -32,12 +32,7 @@ func (list *staticUnaryGrpcManagerPool) releaseManager(_ *grpcmanagers.TopicGrpc
 // Close shuts down all gRPC connections. Safe to call multiple times.
 func (list *staticUnaryGrpcManagerPool) Close() {
 	list.closeOnce.Do(func() {
-		for _, topicManager := range list.grpcManagers {
-			err := topicManager.Close()
-			if err != nil {
-				list.logger.Error("Error closing topic manager: %v", err)
-			}
-		}
+		closeAllManagers(list.grpcManagers, list.logger)
 	})
 }
 

--- a/internal/grpcmanagers/topic_manager_lists/static_unary_grpc_manager_pool.go
+++ b/internal/grpcmanagers/topic_manager_lists/static_unary_grpc_manager_pool.go
@@ -1,6 +1,7 @@
 package topic_manager_lists
 
 import (
+	"sync"
 	"sync/atomic"
 
 	"github.com/momentohq/client-sdk-go/config/logger"
@@ -14,34 +15,30 @@ type staticUnaryGrpcManagerPool struct {
 	grpcManagers []*grpcmanagers.TopicGrpcManager
 	managerIndex atomic.Uint64
 	logger       logger.MomentoLogger
+	closeOnce    sync.Once
 }
 
-// GetNextTopicGrpcManager returns the next available TopicGrpcManager from the pool
-// using a round-robin approach.
-//
-// Publish requests can queue up if there are >100 concurrent requests on a grpc connection,
-// but unary requests will eventually complete so no need for the same level of bookkeeping
-// as for the stream grpc manager pools.
-func (list *staticUnaryGrpcManagerPool) GetNextTopicGrpcManager() (*grpcmanagers.TopicGrpcManager, momentoerrors.MomentoSvcErr) {
+// GetNextTopicGrpcManager returns the next manager via round-robin.
+// Reservation.Release is a no-op since unary requests don't hold slots.
+func (list *staticUnaryGrpcManagerPool) GetNextTopicGrpcManager() (*Reservation, momentoerrors.MomentoSvcErr) {
 	nextManagerIndex := list.managerIndex.Add(1)
-	return list.grpcManagers[nextManagerIndex%uint64(len(list.grpcManagers))], nil
+	return NewReservation(list.grpcManagers[nextManagerIndex%uint64(len(list.grpcManagers))], list.releaseManager), nil
 }
 
-// ReleaseTopicGrpcManager is a no-op for the unary pool because unary requests
-// don't hold long-lived stream slots and the pool doesn't track per-channel
-// subscription counts.
-func (list *staticUnaryGrpcManagerPool) ReleaseTopicGrpcManager(_ *grpcmanagers.TopicGrpcManager) int64 {
+func (list *staticUnaryGrpcManagerPool) releaseManager(_ *grpcmanagers.TopicGrpcManager) int64 {
 	return 0
 }
 
-// Close shuts down all the grpc connections in the pool.
+// Close shuts down all gRPC connections. Safe to call multiple times.
 func (list *staticUnaryGrpcManagerPool) Close() {
-	for _, topicManager := range list.grpcManagers {
-		err := topicManager.Close()
-		if err != nil {
-			list.logger.Error("Error closing topic manager: %v", err)
+	list.closeOnce.Do(func() {
+		for _, topicManager := range list.grpcManagers {
+			err := topicManager.Close()
+			if err != nil {
+				list.logger.Error("Error closing topic manager: %v", err)
+			}
 		}
-	}
+	})
 }
 
 // NewStaticUnaryGrpcManagerPool creates a new pool with a fixed number of grpc managers for unary pubsub requests.

--- a/internal/grpcmanagers/topic_manager_lists/stream_pool_core.go
+++ b/internal/grpcmanagers/topic_manager_lists/stream_pool_core.go
@@ -1,0 +1,121 @@
+package topic_manager_lists
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+
+	"github.com/momentohq/client-sdk-go/config"
+	"github.com/momentohq/client-sdk-go/config/logger"
+	"github.com/momentohq/client-sdk-go/internal/grpcmanagers"
+	"github.com/momentohq/client-sdk-go/internal/momentoerrors"
+)
+
+// streamPoolCore implements the reserve/release/Close machinery shared by the
+// static and dynamic stream pools. The mutex serializes allocation, so every
+// capacity decision sees live counters: no slot is held while the pool is
+// idle, and a capacity error can never be stale — a Release that frees a slot
+// is visible to the very next GetNextTopicGrpcManager call.
+//
+// Pools supply their capacity policy via getNextManager and their connection
+// teardown via closeManagers; both run under the mutex.
+type streamPoolCore struct {
+	mu                        sync.Mutex
+	closed                    bool
+	currentActiveStreamsCount atomic.Uint64
+	// getNextManager reserves a slot on success. Called only under mu.
+	getNextManager func() (*grpcmanagers.TopicGrpcManager, momentoerrors.MomentoSvcErr)
+	// closeManagers tears down the pool's connections. Called only under mu.
+	closeManagers func()
+}
+
+func (c *streamPoolCore) initStreamPoolCore(
+	getNextManager func() (*grpcmanagers.TopicGrpcManager, momentoerrors.MomentoSvcErr),
+	closeManagers func(),
+) {
+	c.getNextManager = getNextManager
+	c.closeManagers = closeManagers
+}
+
+// GetNextTopicGrpcManager reserves a manager from the pool. After Close it
+// returns CanceledError.
+func (c *streamPoolCore) GetNextTopicGrpcManager() (*Reservation, momentoerrors.MomentoSvcErr) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.closed {
+		return nil, momentoerrors.NewMomentoSvcErr(momentoerrors.CanceledError, "connection pool is shutting down", context.Canceled)
+	}
+	topicManager, err := c.getNextManager()
+	if err != nil {
+		return nil, err
+	}
+	return NewReservation(topicManager, c.releaseManager), nil
+}
+
+// Close shuts down all gRPC connections. Safe to call multiple times;
+// concurrent calls block on the mutex until the first completes.
+func (c *streamPoolCore) Close() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.closed {
+		return
+	}
+	c.closed = true
+	c.closeManagers()
+}
+
+// GetCurrentActiveStreamsCount returns the current number of active streams in the pool.
+func (c *streamPoolCore) GetCurrentActiveStreamsCount() uint64 {
+	return c.currentActiveStreamsCount.Load()
+}
+
+// releaseManager backs Reservation.Release for the stream pools. Decrements
+// the per-channel and pool-wide counters; the pool-wide CAS bottoms at zero
+// so it can't go negative. Deliberately not guarded by mu so releases can't
+// contend with Close.
+func (c *streamPoolCore) releaseManager(manager *grpcmanagers.TopicGrpcManager) int64 {
+	newCount := manager.NumActiveSubscriptions.Add(-1)
+	for {
+		current := c.currentActiveStreamsCount.Load()
+		if current == 0 {
+			break
+		}
+		if c.currentActiveStreamsCount.CompareAndSwap(current, current-1) {
+			break
+		}
+	}
+	return newCount
+}
+
+// reserveSlot round-robins over managers until one has spare per-channel
+// capacity, reserving a slot on it and bumping the pool-wide counter. index
+// is owned by the calling pool and only advances under the core mutex.
+// Returns nil when no channel has capacity within attempts probes.
+func (c *streamPoolCore) reserveSlot(
+	managers []*grpcmanagers.TopicGrpcManager,
+	index *uint64,
+	attempts uint32,
+	log logger.MomentoLogger,
+) *grpcmanagers.TopicGrpcManager {
+	for i := uint32(0); i < attempts; i++ {
+		(*index)++
+		topicManager := managers[*index%uint64(len(managers))]
+		newCount := topicManager.NumActiveSubscriptions.Add(1)
+		if newCount <= int64(config.MAX_CONCURRENT_STREAMS_PER_CHANNEL) {
+			log.Debug("Starting new subscription on grpc channel %d which now has %d streams", *index%uint64(len(managers)), newCount)
+			c.currentActiveStreamsCount.Add(1)
+			return topicManager
+		}
+		topicManager.NumActiveSubscriptions.Add(-1)
+	}
+	return nil
+}
+
+// closeAllManagers closes every connection in managers, logging failures.
+func closeAllManagers(managers []*grpcmanagers.TopicGrpcManager, log logger.MomentoLogger) {
+	for _, topicManager := range managers {
+		if err := topicManager.Close(); err != nil {
+			log.Error("Error closing topic manager: %s", err.Error())
+		}
+	}
+}

--- a/internal/grpcmanagers/topic_manager_lists/topic_grpc_connection_pool.go
+++ b/internal/grpcmanagers/topic_manager_lists/topic_grpc_connection_pool.go
@@ -5,25 +5,25 @@ import (
 	"github.com/momentohq/client-sdk-go/internal/momentoerrors"
 )
 
-// TopicGrpcConnectionPool is the base interface for all topic grpc connection pool structs,
-// which manage a pool of grpc connections and continually provide the next available grpc stub
-// for the pubsub client to use.
+// TopicGrpcConnectionPool hands out the next available manager to the pubsub
+// client on request.
 type TopicGrpcConnectionPool interface {
-	// GetNextTopicGrpcManager returns the next available TopicGrpcManager from the pool.
-	GetNextTopicGrpcManager() (*grpcmanagers.TopicGrpcManager, momentoerrors.MomentoSvcErr)
+	// GetNextTopicGrpcManager reserves a manager from the pool. Callers must
+	// call Reservation.Release when done; Release is idempotent so overlapping
+	// cleanup paths can each call it. Dropping a Reservation without releasing
+	// leaks the slot for the lifetime of the pool; Close shuts the pool down
+	// but does not reclaim leaked slots.
+	//
+	// The unary pool's Release is a no-op since unary requests don't hold
+	// long-lived slots; callers invoke it uniformly anyway.
+	GetNextTopicGrpcManager() (*Reservation, momentoerrors.MomentoSvcErr)
 
-	// ReleaseTopicGrpcManager decrements the per-channel and pool-wide subscription
-	// counters for a manager that is no longer in use, returning the new per-channel
-	// subscription count for logging. For unary pools that do not track these counters,
-	// this is a no-op that returns 0.
-	ReleaseTopicGrpcManager(manager *grpcmanagers.TopicGrpcManager) int64
-
-	// Close shuts down all the grpc connections in the pool.
+	// Close shuts down all gRPC connections in the pool.
 	Close()
 }
 
-// StreamGrpcManagerRequest is used for putting the next available stream manager on a channel for the
-// pubSubClient to pull from, or an error that specifies why no stream manager is available.
+// StreamGrpcManagerRequest is the dispatcher-to-caller envelope: either the
+// next manager or the allocation error.
 type StreamGrpcManagerRequest struct {
 	TopicManager *grpcmanagers.TopicGrpcManager
 	Err          momentoerrors.MomentoSvcErr

--- a/internal/grpcmanagers/topic_manager_lists/topic_grpc_connection_pool.go
+++ b/internal/grpcmanagers/topic_manager_lists/topic_grpc_connection_pool.go
@@ -1,7 +1,6 @@
 package topic_manager_lists
 
 import (
-	"github.com/momentohq/client-sdk-go/internal/grpcmanagers"
 	"github.com/momentohq/client-sdk-go/internal/momentoerrors"
 )
 
@@ -14,17 +13,12 @@ type TopicGrpcConnectionPool interface {
 	// leaks the slot for the lifetime of the pool; Close shuts the pool down
 	// but does not reclaim leaked slots.
 	//
+	// After Close, the stream pools return CanceledError.
+	//
 	// The unary pool's Release is a no-op since unary requests don't hold
 	// long-lived slots; callers invoke it uniformly anyway.
 	GetNextTopicGrpcManager() (*Reservation, momentoerrors.MomentoSvcErr)
 
 	// Close shuts down all gRPC connections in the pool.
 	Close()
-}
-
-// StreamGrpcManagerRequest is the dispatcher-to-caller envelope: either the
-// next manager or the allocation error.
-type StreamGrpcManagerRequest struct {
-	TopicManager *grpcmanagers.TopicGrpcManager
-	Err          momentoerrors.MomentoSvcErr
 }

--- a/momento/pubsub_client.go
+++ b/momento/pubsub_client.go
@@ -7,7 +7,6 @@ import (
 	"github.com/momentohq/client-sdk-go/config/logger"
 	"github.com/momentohq/client-sdk-go/config/middleware"
 	"github.com/momentohq/client-sdk-go/internal"
-	"github.com/momentohq/client-sdk-go/internal/grpcmanagers"
 	"github.com/momentohq/client-sdk-go/internal/grpcmanagers/topic_manager_lists"
 	"github.com/momentohq/client-sdk-go/internal/models"
 	"github.com/momentohq/client-sdk-go/internal/momentoerrors"
@@ -95,11 +94,11 @@ func newPubSubClient(request *models.PubSubClientRequest) (*pubSubClient, moment
 	}, nil
 }
 
-func (client *pubSubClient) topicSubscribe(ctx context.Context, request *TopicSubscribeRequest) (*grpcmanagers.TopicGrpcManager, pb.Pubsub_SubscribeClient, context.Context, context.CancelFunc, error) {
-	// Get the next available grpc manager
-	topicManager, topicManagerErr := client.streamGrpcConnectionPool.GetNextTopicGrpcManager()
-	if topicManagerErr != nil {
-		return nil, nil, nil, nil, topicManagerErr
+func (client *pubSubClient) topicSubscribe(ctx context.Context, request *TopicSubscribeRequest) (*topic_manager_lists.Reservation, pb.Pubsub_SubscribeClient, context.Context, context.CancelFunc, error) {
+	// Reserve a stream slot; the Reservation owns its release.
+	reservation, reservationErr := client.streamGrpcConnectionPool.GetNextTopicGrpcManager()
+	if reservationErr != nil {
+		return nil, nil, nil, nil, reservationErr
 	}
 
 	subscriptionRequest := &pb.XSubscriptionRequest{
@@ -122,11 +121,13 @@ func (client *pubSubClient) topicSubscribe(ctx context.Context, request *TopicSu
 	requestContext := internal.CreateTopicRequestContextFromMetadataMap(cancelContext, request.CacheName, requestMetadata)
 
 	var header, trailer metadata.MD
-	subscribeClient, err := topicManager.StreamClient.Subscribe(requestContext, subscriptionRequest)
+	subscribeClient, err := reservation.Manager().StreamClient.Subscribe(requestContext, subscriptionRequest)
 
 	if err != nil {
-		client.streamGrpcConnectionPool.ReleaseTopicGrpcManager(topicManager)
+		// Cancel before releasing so the stream's resources tear down before
+		// the slot is reusable.
 		cancelFunction()
+		reservation.Release()
 		if subscribeClient != nil {
 			header, _ = subscribeClient.Header()
 			trailer = subscribeClient.Trailer()
@@ -134,7 +135,7 @@ func (client *pubSubClient) topicSubscribe(ctx context.Context, request *TopicSu
 		return nil, nil, nil, nil, momentoerrors.ConvertSvcErr(err, header, trailer)
 	}
 
-	return topicManager, subscribeClient, cancelContext, cancelFunction, err
+	return reservation, subscribeClient, cancelContext, cancelFunction, err
 }
 
 func (client *pubSubClient) topicPublish(ctx context.Context, request *TopicPublishRequest) error {
@@ -150,10 +151,13 @@ func (client *pubSubClient) topicPublish(ctx context.Context, request *TopicPubl
 	}
 
 	requestContext := internal.CreateTopicRequestContextFromMetadataMap(ctx, request.CacheName, requestMetadata)
-	topicManager, err := client.unaryGrpcConnectionPool.GetNextTopicGrpcManager()
+	reservation, err := client.unaryGrpcConnectionPool.GetNextTopicGrpcManager()
 	if err != nil {
 		return err
 	}
+	// Release is a no-op for the unary pool; called for contract uniformity.
+	defer reservation.Release()
+	topicManager := reservation.Manager()
 	var header, trailer metadata.MD
 	switch value := request.Value.(type) {
 	case String:

--- a/momento/topic_client.go
+++ b/momento/topic_client.go
@@ -108,7 +108,7 @@ func (c defaultTopicClient) Subscribe(ctx context.Context, request *TopicSubscri
 
 func (c defaultTopicClient) sendSubscribe(requestCtx context.Context, request *TopicSubscribeRequest, subChan chan *topicSubscription, errChan chan error) {
 	var firstMsg *pb.XSubscriptionItem
-	topicManager, subscribeClient, cancelContext, cancelFunction, err := c.pubSubClient.topicSubscribe(requestCtx, &TopicSubscribeRequest{
+	reservation, subscribeClient, cancelContext, cancelFunction, err := c.pubSubClient.topicSubscribe(requestCtx, &TopicSubscribeRequest{
 		CacheName:                   request.CacheName,
 		TopicName:                   request.TopicName,
 		ResumeAtTopicSequenceNumber: request.ResumeAtTopicSequenceNumber,
@@ -140,7 +140,7 @@ func (c defaultTopicClient) sendSubscribe(requestCtx context.Context, request *T
 			}
 		}
 		cancelFunction()
-		c.pubSubClient.streamGrpcConnectionPool.ReleaseTopicGrpcManager(topicManager)
+		reservation.Release()
 		errChan <- momentoerrors.ConvertSvcErr(err)
 		return
 	}
@@ -150,7 +150,7 @@ func (c defaultTopicClient) sendSubscribe(requestCtx context.Context, request *T
 		// The first message to a new subscription will always be a heartbeat.
 	default:
 		cancelFunction()
-		c.pubSubClient.streamGrpcConnectionPool.ReleaseTopicGrpcManager(topicManager)
+		reservation.Release()
 		errChan <- momentoerrors.NewMomentoSvcErr(
 			momentoerrors.InternalServerError,
 			fmt.Sprintf("expected a heartbeat message, got: %T", firstMsg.Kind),
@@ -169,7 +169,7 @@ func (c defaultTopicClient) sendSubscribe(requestCtx context.Context, request *T
 		}
 	}
 	subChan <- &topicSubscription{
-		topicManager:       topicManager,
+		reservation:        reservation,
 		topicEventCallback: topicEventCallback,
 		subscribeClient:    subscribeClient,
 		momentoTopicClient: c.pubSubClient,

--- a/momento/topic_manager_test.go
+++ b/momento/topic_manager_test.go
@@ -141,8 +141,8 @@ var _ = Describe("retry topic-grpc-managers", Label(RETRY_LABEL, MOMENTO_LOCAL_L
 
 		// The three burst variants share one body; each Entry supplies the
 		// burst size and whether the pool may refuse reservations. The expected
-		// final count is the burst size plus the pool's prefetched slot,
-		// capped at pool capacity.
+		// final count is the burst size capped at pool capacity — exactly one
+		// slot per successful reservation.
 		DescribeTable("Starts a burst of streams",
 			func(burstSize int, allowExhausted bool) {
 				numGrpcChannels := uint32(2)
@@ -186,10 +186,8 @@ var _ = Describe("retry topic-grpc-managers", Label(RETRY_LABEL, MOMENTO_LOCAL_L
 				// Allow time for all streams to be established
 				time.Sleep(500 * time.Millisecond)
 
-				// The dispatcher eagerly prefetches the next manager, so an
-				// unsaturated pool reports one extra reserved slot.
-				expected := uint64(burstSize + 1)
-				if burstSize >= int(maxConcurrentStreams) {
+				expected := uint64(burstSize)
+				if burstSize > int(maxConcurrentStreams) {
 					expected = uint64(maxConcurrentStreams)
 				}
 				Expect(staticPool.GetCurrentActiveStreamsCount()).To(Equal(expected))
@@ -293,10 +291,8 @@ var _ = Describe("retry topic-grpc-managers", Label(RETRY_LABEL, MOMENTO_LOCAL_L
 			// No new manager should have been added as we did not exceed a single channel's stream capacity.
 			Expect(dynamicPool.GetCurrentNumberOfGrpcManagers()).To(Equal(1))
 
-			// Verify correct number of streams are active. The dispatcher
-			// eagerly prefetches the next manager, so the unsaturated pool
-			// reports one extra reserved slot.
-			Expect(dynamicPool.GetCurrentActiveStreamsCount()).To(Equal(uint64(maxConcurrentStreams / 2)))
+			// Verify correct number of streams are active.
+			Expect(dynamicPool.GetCurrentActiveStreamsCount()).To(Equal(uint64(maxConcurrentStreams/2 - 1)))
 
 			dynamicPool.Close()
 			cancel()

--- a/momento/topic_manager_test.go
+++ b/momento/topic_manager_test.go
@@ -111,11 +111,11 @@ var _ = Describe("retry topic-grpc-managers", Label(RETRY_LABEL, MOMENTO_LOCAL_L
 			ctx, cancel := context.WithCancel(ctx)
 			waitGroup := sync.WaitGroup{}
 			for i := 0; i < int(maxConcurrentStreams); i++ {
-				streamManager, err := staticPool.GetNextTopicGrpcManager()
+				reservation, err := staticPool.GetNextTopicGrpcManager()
 				Expect(err).ToNot(HaveOccurred())
-				Expect(streamManager).NotTo(BeNil())
+				Expect(reservation).NotTo(BeNil())
 
-				subscribeClient, subscribeErr := streamManager.StreamClient.Subscribe(ctx, subscriptionRequest)
+				subscribeClient, subscribeErr := reservation.Manager().StreamClient.Subscribe(ctx, subscriptionRequest)
 				Expect(subscribeErr).ToNot(HaveOccurred())
 				Expect(subscribeClient).NotTo(BeNil())
 
@@ -161,7 +161,7 @@ var _ = Describe("retry topic-grpc-managers", Label(RETRY_LABEL, MOMENTO_LOCAL_L
 					go func() {
 						defer GinkgoRecover()
 						defer waitGroup.Done()
-						streamManager, err := staticPool.GetNextTopicGrpcManager()
+						reservation, err := staticPool.GetNextTopicGrpcManager()
 						if err != nil {
 							// Only the over-capacity burst may be refused, and only
 							// with ResourceExhausted.
@@ -169,9 +169,9 @@ var _ = Describe("retry topic-grpc-managers", Label(RETRY_LABEL, MOMENTO_LOCAL_L
 							Expect(err.Error()).To(ContainSubstring("ClientResourceExhaustedError"))
 							return
 						}
-						Expect(streamManager).NotTo(BeNil())
+						Expect(reservation).NotTo(BeNil())
 
-						subscribeClient, subscribeErr := streamManager.StreamClient.Subscribe(ctx, subscriptionRequest)
+						subscribeClient, subscribeErr := reservation.Manager().StreamClient.Subscribe(ctx, subscriptionRequest)
 						Expect(subscribeErr).ToNot(HaveOccurred())
 						Expect(subscribeClient).NotTo(BeNil())
 
@@ -219,11 +219,11 @@ var _ = Describe("retry topic-grpc-managers", Label(RETRY_LABEL, MOMENTO_LOCAL_L
 			ctx, cancel := context.WithCancel(ctx)
 			waitGroup := sync.WaitGroup{}
 			for i := 0; i < int(maxConcurrentStreams); i++ {
-				streamManager, err := dynamicPool.GetNextTopicGrpcManager()
+				reservation, err := dynamicPool.GetNextTopicGrpcManager()
 				Expect(err).ToNot(HaveOccurred())
-				Expect(streamManager).NotTo(BeNil())
+				Expect(reservation).NotTo(BeNil())
 
-				subscribeClient, subscribeErr := streamManager.StreamClient.Subscribe(ctx, subscriptionRequest)
+				subscribeClient, subscribeErr := reservation.Manager().StreamClient.Subscribe(ctx, subscriptionRequest)
 				Expect(subscribeErr).ToNot(HaveOccurred())
 				Expect(subscribeClient).NotTo(BeNil())
 
@@ -271,11 +271,11 @@ var _ = Describe("retry topic-grpc-managers", Label(RETRY_LABEL, MOMENTO_LOCAL_L
 				go func() {
 					defer GinkgoRecover()
 					defer waitGroup.Done()
-					streamManager, err := dynamicPool.GetNextTopicGrpcManager()
+					reservation, err := dynamicPool.GetNextTopicGrpcManager()
 					Expect(err).ToNot(HaveOccurred())
-					Expect(streamManager).NotTo(BeNil())
+					Expect(reservation).NotTo(BeNil())
 
-					subscribeClient, subscribeErr := streamManager.StreamClient.Subscribe(ctx, subscriptionRequest)
+					subscribeClient, subscribeErr := reservation.Manager().StreamClient.Subscribe(ctx, subscriptionRequest)
 					Expect(subscribeErr).ToNot(HaveOccurred())
 					Expect(subscribeClient).NotTo(BeNil())
 
@@ -324,11 +324,11 @@ var _ = Describe("retry topic-grpc-managers", Label(RETRY_LABEL, MOMENTO_LOCAL_L
 					go func() {
 						defer GinkgoRecover()
 						defer waitGroup.Done()
-						streamManager, err := dynamicPool.GetNextTopicGrpcManager()
+						reservation, err := dynamicPool.GetNextTopicGrpcManager()
 						Expect(err).ToNot(HaveOccurred())
-						Expect(streamManager).NotTo(BeNil())
+						Expect(reservation).NotTo(BeNil())
 
-						subscribeClient, subscribeErr := streamManager.StreamClient.Subscribe(ctx, subscriptionRequest)
+						subscribeClient, subscribeErr := reservation.Manager().StreamClient.Subscribe(ctx, subscriptionRequest)
 						Expect(subscribeErr).ToNot(HaveOccurred())
 						Expect(subscribeClient).NotTo(BeNil())
 
@@ -381,13 +381,13 @@ var _ = Describe("retry topic-grpc-managers", Label(RETRY_LABEL, MOMENTO_LOCAL_L
 						defer GinkgoRecover()
 						defer waitGroup.Done()
 
-						streamManager, err := dynamicPool.GetNextTopicGrpcManager()
+						reservation, err := dynamicPool.GetNextTopicGrpcManager()
 						if err != nil {
 							Expect(err.Error()).To(ContainSubstring("ClientResourceExhaustedError"))
 						} else {
-							Expect(streamManager).NotTo(BeNil())
+							Expect(reservation).NotTo(BeNil())
 
-							subscribeClient, subscribeErr := streamManager.StreamClient.Subscribe(ctx, subscriptionRequest)
+							subscribeClient, subscribeErr := reservation.Manager().StreamClient.Subscribe(ctx, subscriptionRequest)
 							Expect(subscribeErr).ToNot(HaveOccurred())
 							Expect(subscribeClient).NotTo(BeNil())
 

--- a/momento/topic_subscription.go
+++ b/momento/topic_subscription.go
@@ -15,7 +15,7 @@ import (
 	"google.golang.org/grpc/status"
 
 	"github.com/momentohq/client-sdk-go/config/logger"
-	"github.com/momentohq/client-sdk-go/internal/grpcmanagers"
+	"github.com/momentohq/client-sdk-go/internal/grpcmanagers/topic_manager_lists"
 	pb "github.com/momentohq/client-sdk-go/internal/protos"
 )
 
@@ -67,13 +67,13 @@ type TopicSubscription interface {
 }
 
 type topicSubscription struct {
-	// mu guards topicManager, subscribeClient, cancelContext, and cancelFunction
+	// mu guards reservation, subscribeClient, cancelContext, and cancelFunction
 	// against cross-goroutine reads from Close while attemptReconnect (running
 	// in the Event goroutine) installs a new stream. Within the Event goroutine
 	// these fields are read without mu since reads and writes there are already
 	// sequenced by program order.
 	mu              sync.Mutex
-	topicManager    *grpcmanagers.TopicGrpcManager
+	reservation     *topic_manager_lists.Reservation
 	subscribeClient pb.Pubsub_SubscribeClient
 	cancelContext   context.Context
 	cancelFunction  context.CancelFunc
@@ -86,10 +86,6 @@ type topicSubscription struct {
 	lastKnownSequenceNumber uint64
 	lastKnownSequencePage   uint64
 	retryStrategy           retry.Strategy
-	// released gates the per-stream release so it runs exactly once between
-	// successive allocations. It is set to true when the current stream's slot
-	// is released and reset to false on successful reconnect.
-	released atomic.Bool
 	// closed is set permanently to true by Close(). attemptReconnect checks it
 	// to bail out if Close races in while a reconnect is in flight, so a freshly
 	// allocated stream doesn't leak past Close.
@@ -247,12 +243,11 @@ func (s *topicSubscription) onTopicEvent(method string, event middleware.TopicSu
 
 func (s *topicSubscription) decrementSubscriptionCount() int64 {
 	s.mu.Lock()
-	mgr := s.topicManager
+	reservation := s.reservation
 	s.mu.Unlock()
-	if !s.released.CompareAndSwap(false, true) {
-		return mgr.NumActiveSubscriptions.Load()
-	}
-	return s.momentoTopicClient.streamGrpcConnectionPool.ReleaseTopicGrpcManager(mgr)
+	// Reservation.Release is idempotent, so overlapping cleanup paths (an
+	// Event observing a cancel racing a Close) each call it safely.
+	return reservation.Release()
 }
 
 func (s *topicSubscription) attemptReconnect(ctx context.Context, err error) error {
@@ -286,7 +281,7 @@ func (s *topicSubscription) attemptReconnect(ctx context.Context, err error) err
 		}
 
 		s.log.Info("Attempting reconnecting to client stream")
-		topicManager, subscribeClient, cancelContext, cancelFunction, reconnectErr := s.momentoTopicClient.topicSubscribe(ctx, &TopicSubscribeRequest{
+		reservation, subscribeClient, cancelContext, cancelFunction, reconnectErr := s.momentoTopicClient.topicSubscribe(ctx, &TopicSubscribeRequest{
 			CacheName:                   s.cacheName,
 			TopicName:                   s.topicName,
 			ResumeAtTopicSequenceNumber: s.lastKnownSequenceNumber,
@@ -306,21 +301,17 @@ func (s *topicSubscription) attemptReconnect(ctx context.Context, err error) err
 		// Capture the closed flag under the same critical section so that any
 		// Close that ran before we unlock is guaranteed to be seen here.
 		s.mu.Lock()
-		s.topicManager = topicManager
+		s.reservation = reservation
 		s.subscribeClient = subscribeClient
 		s.cancelContext = cancelContext
 		s.cancelFunction = cancelFunction
-		// The new stream has its own release lifecycle; allow the next disconnect
-		// to perform its own decrement.
-		s.released.Store(false)
 		wasClosed := s.closed.Load()
 		s.mu.Unlock()
 
-		// If Close() ran while we were reconnecting, the cancelFunction it called
-		// targeted the *old* (already-cancelled) cancelFunction, and the decrement
-		// it issued was a no-op against the still-true `released` flag. The new
-		// stream we just installed would otherwise leak past Close — tear it down
-		// here.
+		// If Close() ran while we were reconnecting, the cancel and release it
+		// issued targeted the *old* stream's already-released Reservation. The
+		// new stream we just installed would otherwise leak past Close — tear
+		// it down here.
 		if wasClosed {
 			s.log.Info("Subscription closed during reconnect; tearing down newly established stream")
 			cancelFunction()
@@ -332,9 +323,9 @@ func (s *topicSubscription) attemptReconnect(ctx context.Context, err error) err
 }
 
 // Close cancels the stream context and releases the per-channel and pool-wide
-// subscription slots. decrementSubscriptionCount is idempotent (guarded by the
-// `released` flag), so if an in-flight Event() loop also observes the cancel
-// and decrements, the counters stay correct. The `closed` flag is set first so
+// subscription slots. decrementSubscriptionCount is idempotent (the
+// Reservation's Release is CAS-guarded), so if an in-flight Event() loop also
+// observes the cancel and decrements, the counters stay correct. The `closed` flag is set first so
 // that an in-flight attemptReconnect notices and tears down any new stream it
 // allocates instead of leaking it past Close. The cancel function is snapshotted
 // under mu so a concurrent attemptReconnect can't reassign the field while we

--- a/momento/topic_subscription_accounting_test.go
+++ b/momento/topic_subscription_accounting_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/momentohq/client-sdk-go/config/logger"
 	"github.com/momentohq/client-sdk-go/config/retry"
 	"github.com/momentohq/client-sdk-go/internal/grpcmanagers"
+	"github.com/momentohq/client-sdk-go/internal/grpcmanagers/topic_manager_lists"
 	"github.com/momentohq/client-sdk-go/internal/momentoerrors"
 	pb "github.com/momentohq/client-sdk-go/internal/protos"
 	"google.golang.org/grpc"
@@ -30,13 +31,14 @@ func newTestTopicGrpcConnectionPool(streamClient pb.PubsubClient) *testTopicGrpc
 	}
 }
 
-func (p *testTopicGrpcConnectionPool) GetNextTopicGrpcManager() (*grpcmanagers.TopicGrpcManager, momentoerrors.MomentoSvcErr) {
+func (p *testTopicGrpcConnectionPool) GetNextTopicGrpcManager() (*topic_manager_lists.Reservation, momentoerrors.MomentoSvcErr) {
 	p.manager.NumActiveSubscriptions.Add(1)
 	p.activeCount.Add(1)
-	return p.manager, nil
+	return topic_manager_lists.NewReservation(p.manager, p.releaseManager), nil
 }
 
-func (p *testTopicGrpcConnectionPool) ReleaseTopicGrpcManager(manager *grpcmanagers.TopicGrpcManager) int64 {
+// releaseManager mirrors the real stream pool's release for accounting.
+func (p *testTopicGrpcConnectionPool) releaseManager(manager *grpcmanagers.TopicGrpcManager) int64 {
 	p.releaseCount.Add(1)
 	p.activeCount.Add(-1)
 	return manager.NumActiveSubscriptions.Add(-1)


### PR DESCRIPTION
Part 3 of 5 of the topics connection-management stack. The complete pool story, in two commits meant to be read in order.

**Commit 1 — Reservation handle.** `GetNextTopicGrpcManager()` returns a `Reservation` wrapping the acquired manager with a CAS-idempotent `Release()`: only the first call decrements, so overlapping cleanup paths (an Event observing a cancel racing a Close, reconnect teardown, handshake failures) each release safely. Replaces the pool-level `ReleaseTopicGrpcManager` and deletes the subscription's `released` flag, whose reset-on-reconnect was the fragile part — each stream now carries its own single-use handle. Also: `TopicGrpcManager.Close` no longer zeroes `NumActiveSubscriptions` (late releases would push it negative).

**Commit 2 — mutex-serialized pool core.** The eager-prefetch dispatcher goroutine had three artifacts: an idle pool over-reported its count by one (the parked prefetched slot), a parked capacity error could be served stale after slots freed, and a caller blocked during Close got an opaque `ClientSdkError`. The shared `streamPoolCore` serializes allocation with a mutex instead: capacity is evaluated per call against live counters, a freed slot is visible to the very next call, `Get` after `Close` returns `CanceledError`, and ~100 lines of dispatcher/release/Close logic the two pools copied from each other are deduplicated. The pool specs' exact-count assertions drop their prefetch +1 here.

Tests run without credentials (gRPC dials lazily): reservation idempotency under 256-goroutine contention; pool idle/exhaustion/Close/Get-racing-Close/growth/per-channel-cap invariants; the unary pool lifecycle. 73/73 momento-local retry specs pass at each commit.

Stack: #679 → #680 → **#681 (this)** → #682 subscription lifecycle → #683 subscribe watchdog.

