### PR TITLE
feat(topics): subscription lifecycle on atomic snapshots; survivable ctx errors (topics stack 4/5)

### DIFF
--- a/momento/pubsub_client.go
+++ b/momento/pubsub_client.go
@@ -94,11 +94,13 @@ func newPubSubClient(request *models.PubSubClientRequest) (*pubSubClient, moment
 	}, nil
 }
 
-func (client *pubSubClient) topicSubscribe(ctx context.Context, request *TopicSubscribeRequest) (*topic_manager_lists.Reservation, pb.Pubsub_SubscribeClient, context.Context, context.CancelFunc, error) {
-	// Reserve a stream slot; the Reservation owns its release.
+// topicSubscribe reserves a stream slot and opens a gRPC subscribe stream
+// against it. Failures cancel the request context and release the slot
+// before returning.
+func (client *pubSubClient) topicSubscribe(ctx context.Context, request *TopicSubscribeRequest) (*streamState, error) {
 	reservation, reservationErr := client.streamGrpcConnectionPool.GetNextTopicGrpcManager()
 	if reservationErr != nil {
-		return nil, nil, nil, nil, reservationErr
+		return nil, reservationErr
 	}
 
 	subscriptionRequest := &pb.XSubscriptionRequest{
@@ -116,26 +118,29 @@ func (client *pubSubClient) topicSubscribe(ctx context.Context, request *TopicSu
 		}
 	}
 
-	// add withCancel to context
 	cancelContext, cancelFunction := context.WithCancel(ctx)
 	requestContext := internal.CreateTopicRequestContextFromMetadataMap(cancelContext, request.CacheName, requestMetadata)
 
 	var header, trailer metadata.MD
 	subscribeClient, err := reservation.Manager().StreamClient.Subscribe(requestContext, subscriptionRequest)
-
 	if err != nil {
-		// Cancel before releasing so the stream's resources tear down before
-		// the slot is reusable.
+		// Cancel before releasing, like every other cleanup path, so the
+		// stream's resources tear down before the slot is reusable.
 		cancelFunction()
 		reservation.Release()
 		if subscribeClient != nil {
 			header, _ = subscribeClient.Header()
 			trailer = subscribeClient.Trailer()
 		}
-		return nil, nil, nil, nil, momentoerrors.ConvertSvcErr(err, header, trailer)
+		return nil, momentoerrors.ConvertSvcErr(err, header, trailer)
 	}
 
-	return reservation, subscribeClient, cancelContext, cancelFunction, err
+	return &streamState{
+		reservation:     reservation,
+		subscribeClient: subscribeClient,
+		cancelContext:   cancelContext,
+		cancelFunction:  cancelFunction,
+	}, nil
 }
 
 func (client *pubSubClient) topicPublish(ctx context.Context, request *TopicPublishRequest) error {

--- a/momento/topic_client.go
+++ b/momento/topic_client.go
@@ -22,6 +22,15 @@ import (
 )
 
 type TopicClient interface {
+	// Subscribe starts a subscription on the given topic.
+	//
+	// The ctx bounds the subscription's lifetime, not just the Subscribe call:
+	// the underlying stream — including any stream re-established by the
+	// automatic reconnect logic — is a child of this ctx. Cancelling it ends
+	// the subscription: a blocked or subsequent Item/Event call returns an
+	// error and releases the subscription's connection-pool slot. If no
+	// Item/Event call runs after cancellation, call Close (idempotent) to
+	// release the slot.
 	Subscribe(ctx context.Context, request *TopicSubscribeRequest) (TopicSubscription, error)
 	Publish(ctx context.Context, request *TopicPublishRequest) (responses.TopicPublishResponse, error)
 
@@ -83,15 +92,13 @@ func (c defaultTopicClient) Subscribe(ctx context.Context, request *TopicSubscri
 	subChan := make(chan *topicSubscription, 1)
 	errChan := make(chan error, 1)
 
-	// Send the subscribe request in a separate goroutine to avoid blocking the main thread.
-	// Here, we'll block until one of the select cases is triggered.
 	go c.sendSubscribe(ctx, request, subChan, errChan)
 	select {
 	case <-ctx.Done():
 		return nil, momentoerrors.NewMomentoSvcErr(
 			momentoerrors.CanceledError,
 			"subscribe request context was canceled",
-			nil,
+			ctx.Err(),
 		)
 	case <-firstMessageCtx.Done():
 		return nil, momentoerrors.NewMomentoSvcErr(
@@ -107,8 +114,7 @@ func (c defaultTopicClient) Subscribe(ctx context.Context, request *TopicSubscri
 }
 
 func (c defaultTopicClient) sendSubscribe(requestCtx context.Context, request *TopicSubscribeRequest, subChan chan *topicSubscription, errChan chan error) {
-	var firstMsg *pb.XSubscriptionItem
-	reservation, subscribeClient, cancelContext, cancelFunction, err := c.pubSubClient.topicSubscribe(requestCtx, &TopicSubscribeRequest{
+	state, err := c.pubSubClient.topicSubscribe(requestCtx, &TopicSubscribeRequest{
 		CacheName:                   request.CacheName,
 		TopicName:                   request.TopicName,
 		ResumeAtTopicSequenceNumber: request.ResumeAtTopicSequenceNumber,
@@ -125,23 +131,27 @@ func (c defaultTopicClient) sendSubscribe(requestCtx context.Context, request *T
 		c.log.Debug("Resuming subscription from sequence number %d and sequence page %d.", request.ResumeAtTopicSequenceNumber, request.SequencePage)
 	}
 
-	// Ping the stream to provide a nice error message if the cache does not exist.
-	firstMsg, err = subscribeClient.Recv()
+	// Single cleanup path: cancel, release, report.
+	fail := func(err error) {
+		state.cancelFunction()
+		state.reservation.Release()
+		errChan <- err
+	}
+
+	// Ping the stream to surface a nice error if the cache does not exist.
+	firstMsg, err := state.subscribeClient.Recv()
 	if err != nil {
 		c.log.Debug("failed to receive first message from subscription: %s", err.Error())
 
-		// We now count number of active subscriptions per grpc channel, so if we did not return
-		// an error earlier when calling c.pubSubClient.topicSubscribe, we know that the error
-		// here is due to a service-side subscription limit.
+		// topicSubscribe would have errored already if the local pool was
+		// exhausted, so a ResourceExhausted here is a service-side limit.
 		rpcError, _ := status.FromError(err)
 		if rpcError != nil {
 			if rpcError.Code() == codes.ResourceExhausted {
 				c.log.Warn("Topic subscription limit reached for this account; please contact us at support@momentohq.com")
 			}
 		}
-		cancelFunction()
-		reservation.Release()
-		errChan <- momentoerrors.ConvertSvcErr(err)
+		fail(momentoerrors.ConvertSvcErr(err))
 		return
 	}
 
@@ -149,13 +159,11 @@ func (c defaultTopicClient) sendSubscribe(requestCtx context.Context, request *T
 	case *pb.XSubscriptionItem_Heartbeat:
 		// The first message to a new subscription will always be a heartbeat.
 	default:
-		cancelFunction()
-		reservation.Release()
-		errChan <- momentoerrors.NewMomentoSvcErr(
+		fail(momentoerrors.NewMomentoSvcErr(
 			momentoerrors.InternalServerError,
 			fmt.Sprintf("expected a heartbeat message, got: %T", firstMsg.Kind),
 			err,
-		)
+		))
 		return
 	}
 
@@ -168,18 +176,18 @@ func (c defaultTopicClient) sendSubscribe(requestCtx context.Context, request *T
 			break
 		}
 	}
-	subChan <- &topicSubscription{
-		reservation:        reservation,
+	sub := &topicSubscription{
 		topicEventCallback: topicEventCallback,
-		subscribeClient:    subscribeClient,
 		momentoTopicClient: c.pubSubClient,
 		cacheName:          request.CacheName,
 		topicName:          request.TopicName,
 		log:                c.log,
-		cancelContext:      cancelContext,
-		cancelFunction:     cancelFunction,
 		retryStrategy:      c.retryStrategy,
+		streamParentCtx:    requestCtx,
+		closedSignal:       make(chan struct{}),
 	}
+	sub.state.Store(state)
+	subChan <- sub
 }
 
 func (c defaultTopicClient) Publish(ctx context.Context, request *TopicPublishRequest) (responses.TopicPublishResponse, error) {

--- a/momento/topic_client_test.go
+++ b/momento/topic_client_test.go
@@ -352,10 +352,12 @@ var _ = Describe("topic-client", Label(TOPICS_SERVICE_LABEL), func() {
 			panic(err)
 		}
 
-		// expect one Item() success and one failure
+		// expect one Item() success and one failure: the closed subscription
+		// returns a typed CanceledError that unwraps to context.Canceled
 		item, err = sub1.Item(sharedContext.Ctx)
 		Expect(item).To(BeNil())
-		Expect(err.Error()).To(Equal("context canceled"))
+		Expect(err).To(HaveMomentoErrorCode(CanceledError))
+		Expect(errors.Is(err, context.Canceled)).To(BeTrue())
 
 		item, err = sub2.Item(sharedContext.Ctx)
 		if err != nil {

--- a/momento/topic_subscription.go
+++ b/momento/topic_subscription.go
@@ -2,8 +2,8 @@ package momento
 
 import (
 	"context"
+	"errors"
 	"fmt"
-	"sync"
 	"sync/atomic"
 	"time"
 
@@ -19,6 +19,29 @@ import (
 	pb "github.com/momentohq/client-sdk-go/internal/protos"
 )
 
+// TopicSubscription is the consumer-side handle for an active topic subscription.
+//
+// Concurrency contract:
+//   - Item and Event must be called from a single goroutine at a time. The
+//     underlying gRPC stream's Recv is not safe for concurrent use, and the
+//     subscription tracks per-stream sequence state without locking on the
+//     hot path.
+//   - Close is safe to call concurrently with an in-flight Item/Event call,
+//     and is safe to call more than once. Close cancels the stream context;
+//     an in-flight Item/Event call returns an error — immediately if blocked
+//     receiving, or at the next retry check if a reconnect is in flight
+//     (Close also interrupts a reconnect backoff wait).
+//   - An error from the ctx passed to Item/Event means only that the call
+//     stopped waiting: the subscription stays active and a later call with
+//     a live ctx resumes it, including resuming an interrupted reconnect.
+//     A call blocked receiving notices the ctx at the next
+//     message/heartbeat boundary or stream event.
+//   - Terminal errors (Close was called, or the ctx passed to Subscribe
+//     ended) carry the CanceledError code and unwrap to the underlying
+//     context error; check your own ctx first to tell the two apart. The
+//     subscription holds a pool slot while it has a live stream; during a
+//     reconnect the slot is released and re-acquired, and an abandoned
+//     subscription holds its slot until Close.
 type TopicSubscription interface {
 	// Item returns only subscription events that contain a string or byte message.
 	// Example:
@@ -66,17 +89,27 @@ type TopicSubscription interface {
 	Close()
 }
 
-type topicSubscription struct {
-	// mu guards reservation, subscribeClient, cancelContext, and cancelFunction
-	// against cross-goroutine reads from Close while attemptReconnect (running
-	// in the Event goroutine) installs a new stream. Within the Event goroutine
-	// these fields are read without mu since reads and writes there are already
-	// sequenced by program order.
-	mu              sync.Mutex
+// subscribeMethodName is the request name reported to middleware for Subscribe
+// events.
+const subscribeMethodName = "Subscribe"
+
+// errEventCtxInterruptedReconnect marks attemptReconnect aborts caused by the
+// caller's per-call ctx dying. Event converts exactly these into a paused
+// recovery that the next call resumes; it wraps context.Canceled so the error
+// stays errors.Is-compatible on the terminal edges where it can escape.
+var errEventCtxInterruptedReconnect = fmt.Errorf("event context canceled during reconnect: %w", context.Canceled)
+
+// streamState bundles the fields swapped together on every (re)connect. Held
+// in an atomic.Pointer so readers see a consistent snapshot.
+type streamState struct {
 	reservation     *topic_manager_lists.Reservation
 	subscribeClient pb.Pubsub_SubscribeClient
 	cancelContext   context.Context
 	cancelFunction  context.CancelFunc
+}
+
+type topicSubscription struct {
+	state atomic.Pointer[streamState]
 
 	topicEventCallback      func(cacheName string, requestName string, event middleware.TopicSubscriptionEventType)
 	momentoTopicClient      *pubSubClient
@@ -86,21 +119,31 @@ type topicSubscription struct {
 	lastKnownSequenceNumber uint64
 	lastKnownSequencePage   uint64
 	retryStrategy           retry.Strategy
-	// closed is set permanently to true by Close(). attemptReconnect checks it
-	// to bail out if Close races in while a reconnect is in flight, so a freshly
-	// allocated stream doesn't leak past Close.
+	// streamParentCtx is the ctx the caller passed to Subscribe. Reconnected
+	// streams are parented to it so their lifetime matches the original
+	// stream's, not the ctx of whichever Event call triggered the reconnect.
+	streamParentCtx context.Context
+	// needsReconnect and lastStreamErr carry an interrupted recovery across
+	// Event calls: when the caller's ctx dies after a stream failure, the
+	// next call resumes the reconnect instead of the subscription dying.
+	// Only the Event goroutine touches them (see the concurrency contract).
+	needsReconnect bool
+	lastStreamErr  error
+	// closed is set by Close. attemptReconnect bails out if it observes this set.
 	closed atomic.Bool
+	// closedSignal wakes a reconnect backoff wait when Close is called. Only
+	// the Close that wins the closed CAS closes it.
+	closedSignal chan struct{}
 }
 
-// grpcStatusCode returns the gRPC status code embedded in err, unwrapping a
-// MomentoSvcErr if needed. The first call to attemptReconnect receives a raw
-// gRPC error from Recv(); subsequent retries get a MomentoSvcErr back from
-// topicSubscribe — both need to produce the same code for the retry strategy.
+// grpcStatusCode returns the gRPC status code for err, unwrapping
+// MomentoSvcErr if the error came back through topicSubscribe.
 func grpcStatusCode(err error) codes.Code {
 	if err == nil {
 		return codes.OK
 	}
-	if svcErr, ok := err.(momentoerrors.MomentoSvcErr); ok {
+	var svcErr momentoerrors.MomentoSvcErr
+	if errors.As(err, &svcErr) {
 		if original := svcErr.OriginalErr(); original != nil {
 			return status.Code(original)
 		}
@@ -128,68 +171,81 @@ func (s *topicSubscription) Item(ctx context.Context) (TopicValue, error) {
 }
 
 func (s *topicSubscription) Event(ctx context.Context) (TopicEvent, error) {
-	methodName := "Subscribe"
-
 	for {
-		// Its totally possible a client just calls `cancel` on the `context` immediately after subscribing to an
-		// item, so we should check that here.
-		select {
-		case <-ctx.Done():
-			// Context has been canceled, return an error
-			decremented := s.decrementSubscriptionCount()
-			s.log.Debug(
-				"[Event] Context done, number of active streams on current grpc channel: %d",
-				decremented,
-			)
-			return nil, ctx.Err()
-		case <-s.cancelContext.Done():
-			// Context has been canceled, return an error
-			decremented := s.decrementSubscriptionCount()
-			s.log.Debug(
-				"[Event] Context cancelled, number of active streams on current grpc channel: %d",
-				decremented,
-			)
-			return nil, s.cancelContext.Err()
-		default:
-			// Proceed as is
+		// A previous call's ctx may have died mid-recovery; resume the
+		// reconnect before reading so the subscription survives.
+		if s.needsReconnect {
+			if reconnectErr := s.resumeReconnect(ctx); reconnectErr != nil {
+				return nil, reconnectErr
+			}
+			continue // re-snapshot the freshly stored state
 		}
 
-		rawMsg, err := s.subscribeClient.Recv()
+		// Snapshot state once per iteration so every read in this loop body
+		// references the same Reservation/cancelContext/cancelFunction triple.
+		// attemptReconnect (called below, same goroutine) Stores a new state
+		// that the next iteration picks up; the snapshot also keeps a
+		// concurrent Close, which Loads and cancels, from seeing a torn view.
+		state := s.state.Load()
+
+		// Callers can cancel ctx right after subscribing; check before Recv.
+		select {
+		case <-ctx.Done():
+			// If the stream itself is already dead (Close or the Subscribe
+			// ctx ended), prefer the terminal path so the slot is released
+			// even when both contexts died together.
+			select {
+			case <-state.cancelContext.Done():
+				return nil, s.terminate(state)
+			default:
+			}
+			// The caller stopped waiting; the subscription and its slot stay
+			// intact, and the next Item/Event call picks up where we left off.
+			return nil, ctx.Err()
+		case <-state.cancelContext.Done():
+			return nil, s.terminate(state)
+		default:
+		}
+
+		rawMsg, err := state.subscribeClient.Recv()
 		if err != nil {
 			select {
 			case <-ctx.Done():
 				{
-					decremented := s.decrementSubscriptionCount()
+					// The stream failed while the caller's ctx is dead: tear
+					// the dead stream down now (its slot must not stay
+					// counted), and let the next call resume via reconnect.
+					state.cancelFunction()
+					decremented := state.reservation.Release()
+					s.needsReconnect = true
+					s.lastStreamErr = err
 					s.log.Debug(
-						"[Event RecvMsg] Context done, number of active streams on current grpc channel: %d",
+						"[Event RecvMsg] Context done, reconnect deferred to the next call, number of active streams on current grpc channel: %d",
 						decremented,
 					)
 					return nil, ctx.Err()
 				}
-			case <-s.cancelContext.Done():
+			case <-state.cancelContext.Done():
 				{
-					decremented := s.decrementSubscriptionCount()
-					s.log.Debug(
-						"[Event RecvMsg] Context cancelled, number of active streams on current grpc channel: %d",
-						decremented,
-					)
-					return nil, s.cancelContext.Err()
+					return nil, s.terminate(state)
 				}
 			default:
 				{
-					s.onTopicEvent(methodName, middleware.ERROR)
-					// Disconnected, decrement and explicitly close the stream, then attempt to reconnect
+					s.onTopicEvent(subscribeMethodName, middleware.ERROR)
+					// Cancel the dead stream before releasing the slot so the
+					// server-side resources tear down promptly.
 					s.log.Error("Stream disconnected due to error: %s", err.Error())
-					s.cancelFunction()
-					decremented := s.decrementSubscriptionCount()
+					state.cancelFunction()
+					decremented := state.reservation.Release()
 					s.log.Debug(
 						"[Event RecvMsg] Default case, attempting to reconnect, number of active streams on current grpc channel: %d",
 						decremented,
 					)
 
-					err := s.attemptReconnect(ctx, err)
-					if err != nil {
-						return nil, momentoerrors.ConvertSvcErr(err)
+					streamErr := err
+					reconnectErr := s.attemptReconnect(ctx, streamErr)
+					if reconnectErr != nil {
+						return nil, s.reconnectFailure(ctx, streamErr, reconnectErr)
 					}
 				}
 			}
@@ -200,14 +256,14 @@ func (s *topicSubscription) Event(ctx context.Context) (TopicEvent, error) {
 		switch typedMsg := rawMsg.Kind.(type) {
 		case *pb.XSubscriptionItem_Discontinuity:
 			s.log.Debug("received discontinuity item: %+v", typedMsg.Discontinuity)
-			s.onTopicEvent(methodName, middleware.DISCONTINUITY)
+			s.onTopicEvent(subscribeMethodName, middleware.DISCONTINUITY)
 			return NewTopicDiscontinuity(
 				typedMsg.Discontinuity.LastTopicSequence,
 				typedMsg.Discontinuity.NewTopicSequence,
 				typedMsg.Discontinuity.NewSequencePage,
 			), nil
 		case *pb.XSubscriptionItem_Item:
-			s.onTopicEvent(methodName, middleware.ITEM)
+			s.onTopicEvent(subscribeMethodName, middleware.ITEM)
 			s.lastKnownSequenceNumber = typedMsg.Item.GetTopicSequenceNumber()
 			s.lastKnownSequencePage = typedMsg.Item.GetSequencePage()
 			publisherId := typedMsg.Item.GetPublisherId()
@@ -225,7 +281,7 @@ func (s *topicSubscription) Event(ctx context.Context) (TopicEvent, error) {
 			}
 		case *pb.XSubscriptionItem_Heartbeat:
 			s.log.Trace("received heartbeat item")
-			s.onTopicEvent(methodName, middleware.HEARTBEAT)
+			s.onTopicEvent(subscribeMethodName, middleware.HEARTBEAT)
 			return TopicHeartbeat{}, nil
 		default:
 			s.log.Warn("Unrecognized response detected.",
@@ -235,19 +291,95 @@ func (s *topicSubscription) Event(ctx context.Context) (TopicEvent, error) {
 	}
 }
 
+// terminate releases the slot of a subscription whose stream context has
+// ended (Close, or the Subscribe-time ctx died) and returns the typed
+// terminal error. It wraps the context error so errors.Is still matches,
+// while the CanceledError code lets callers distinguish a dead subscription
+// from their own ctx expiring.
+func (s *topicSubscription) terminate(state *streamState) error {
+	decremented := state.reservation.Release()
+	s.log.Debug(
+		"[Event] Subscription stream context ended, number of active streams on current grpc channel: %d",
+		decremented,
+	)
+	return momentoerrors.NewMomentoSvcErr(momentoerrors.CanceledError, "subscription ended", state.cancelContext.Err())
+}
+
+// resumeReconnect re-enters an interrupted recovery at the top of Event.
+// Returns nil when the stream is re-established (needsReconnect cleared).
+func (s *topicSubscription) resumeReconnect(ctx context.Context) error {
+	if ctx.Err() != nil {
+		// Still no live ctx; stay paused.
+		return ctx.Err()
+	}
+	if reconnectErr := s.attemptReconnect(ctx, s.lastStreamErr); reconnectErr != nil {
+		return s.reconnectFailure(ctx, s.lastStreamErr, reconnectErr)
+	}
+	s.needsReconnect = false
+	s.lastStreamErr = nil
+	return nil
+}
+
+// reconnectFailure classifies a failed attemptReconnect: a dead caller ctx
+// pauses the recovery (the next call resumes it), anything else surfaces with
+// its typed code intact.
+func (s *topicSubscription) reconnectFailure(ctx context.Context, streamErr error, reconnectErr error) error {
+	// Pause only when the reconnect was interrupted by the caller's ctx; a
+	// give-up or terminal verdict that merely coincides with a dead ctx must
+	// surface as-is rather than being resurrected by the next call.
+	if errors.Is(reconnectErr, errEventCtxInterruptedReconnect) && !s.closed.Load() && s.streamParentCtx.Err() == nil {
+		s.needsReconnect = true
+		s.lastStreamErr = streamErr
+		return ctx.Err()
+	}
+	// attemptReconnect returns typed MomentoSvcErrs (e.g. CanceledError on
+	// Close); ConvertSvcErr would demote them to ClientSdkError since they
+	// carry no gRPC status, so pass them through unchanged.
+	var svcErr momentoerrors.MomentoSvcErr
+	if errors.As(reconnectErr, &svcErr) {
+		return svcErr
+	}
+	return momentoerrors.ConvertSvcErr(reconnectErr)
+}
+
 func (s *topicSubscription) onTopicEvent(method string, event middleware.TopicSubscriptionEventType) {
 	if s.topicEventCallback != nil {
 		s.topicEventCallback(s.cacheName, method, event)
 	}
 }
 
-func (s *topicSubscription) decrementSubscriptionCount() int64 {
-	s.mu.Lock()
-	reservation := s.reservation
-	s.mu.Unlock()
-	// Reservation.Release is idempotent, so overlapping cleanup paths (an
-	// Event observing a cancel racing a Close) each call it safely.
-	return reservation.Release()
+// waitBackoff sleeps for the retry backoff, waking early when the caller's
+// ctx dies, the Subscribe-time ctx dies, or Close is called. The timer is
+// stopped on early exit so interrupted waits don't leave timers running
+// during reconnect storms with long backoffs.
+func (s *topicSubscription) waitBackoff(ctx context.Context, backoff time.Duration) error {
+	timer := time.NewTimer(backoff)
+	defer timer.Stop()
+	select {
+	case <-timer.C:
+		return nil
+	case <-ctx.Done():
+		// A terminal signal that fired in the same instant wins the tie so
+		// the error carries the terminal cause. (reconnectFailure re-checks
+		// the terminal conditions either way, so classification never
+		// depends on this select.)
+		select {
+		case <-s.streamParentCtx.Done():
+			return momentoerrors.NewMomentoSvcErr(momentoerrors.CanceledError, "subscribe context canceled during reconnect", s.streamParentCtx.Err())
+		default:
+		}
+		select {
+		case <-s.closedSignal:
+			return momentoerrors.NewMomentoSvcErr(momentoerrors.CanceledError, "subscription closed", context.Canceled)
+		default:
+		}
+		return momentoerrors.NewMomentoSvcErr(momentoerrors.CanceledError, "event context canceled during reconnect", errEventCtxInterruptedReconnect)
+	case <-s.streamParentCtx.Done():
+		return momentoerrors.NewMomentoSvcErr(momentoerrors.CanceledError, "subscribe context canceled during reconnect", s.streamParentCtx.Err())
+	case <-s.closedSignal:
+		s.log.Info("Subscription closed during reconnect backoff; aborting retry loop")
+		return momentoerrors.NewMomentoSvcErr(momentoerrors.CanceledError, "subscription closed", context.Canceled)
+	}
 }
 
 func (s *topicSubscription) attemptReconnect(ctx context.Context, err error) error {
@@ -259,7 +391,19 @@ func (s *topicSubscription) attemptReconnect(ctx context.Context, err error) err
 	for {
 		if s.closed.Load() {
 			s.log.Info("Subscription closed during reconnect; aborting retry loop")
-			return momentoerrors.NewMomentoSvcErr(momentoerrors.CanceledError, "subscription closed", nil)
+			return momentoerrors.NewMomentoSvcErr(momentoerrors.CanceledError, "subscription closed", context.Canceled)
+		}
+		// A dead streamParentCtx is terminal (a stream parented to it can
+		// never come up) and is checked before the caller's ctx so a tie
+		// carries the terminal cause; a dead caller ctx pauses recovery
+		// (Event resumes it on the next call).
+		if s.streamParentCtx.Err() != nil {
+			s.log.Info("Subscribe context canceled during reconnect; aborting retry loop")
+			return momentoerrors.NewMomentoSvcErr(momentoerrors.CanceledError, "subscribe context canceled during reconnect", s.streamParentCtx.Err())
+		}
+		if ctx.Err() != nil {
+			s.log.Info("Context canceled during reconnect; aborting retry loop")
+			return momentoerrors.NewMomentoSvcErr(momentoerrors.CanceledError, "event context canceled during reconnect", errEventCtxInterruptedReconnect)
 		}
 
 		retryBackoffTime := s.retryStrategy.DetermineWhenToRetry(retry.StrategyProps{
@@ -273,15 +417,19 @@ func (s *topicSubscription) attemptReconnect(ctx context.Context, err error) err
 			return err
 		}
 
-		s.onTopicEvent("Subscribe", middleware.RECONNECT)
+		s.onTopicEvent(subscribeMethodName, middleware.RECONNECT)
 
 		if *retryBackoffTime > 0 {
 			s.log.Info("Waiting %s milliseconds before attempting to reconnect", fmt.Sprint(*retryBackoffTime))
-			time.Sleep(time.Duration(*retryBackoffTime) * time.Millisecond)
+			if waitErr := s.waitBackoff(ctx, time.Duration(*retryBackoffTime)*time.Millisecond); waitErr != nil {
+				return waitErr
+			}
 		}
 
 		s.log.Info("Attempting reconnecting to client stream")
-		reservation, subscribeClient, cancelContext, cancelFunction, reconnectErr := s.momentoTopicClient.topicSubscribe(ctx, &TopicSubscribeRequest{
+		// Parent the replacement stream to the Subscribe-time ctx, not this
+		// Event call's ctx, so the stream's lifetime is stable across Events.
+		newState, reconnectErr := s.momentoTopicClient.topicSubscribe(s.streamParentCtx, &TopicSubscribeRequest{
 			CacheName:                   s.cacheName,
 			TopicName:                   s.topicName,
 			ResumeAtTopicSequenceNumber: s.lastKnownSequenceNumber,
@@ -289,6 +437,14 @@ func (s *topicSubscription) attemptReconnect(ctx context.Context, err error) err
 		})
 
 		if reconnectErr != nil {
+			// A canceled reconnect can never succeed: the pool is shutting
+			// down or the stream's parent context is dead. Stop instead of
+			// burning retries (the legacy default strategy retries forever).
+			var svcErr momentoerrors.MomentoSvcErr
+			if errors.As(reconnectErr, &svcErr) && svcErr.Code() == momentoerrors.CanceledError {
+				s.log.Info("Reconnect attempt was canceled; aborting retry loop")
+				return reconnectErr
+			}
 			s.log.Warn("Failed to reconnect to stream: %s", reconnectErr.Error())
 			err = reconnectErr
 			attempt++
@@ -296,45 +452,30 @@ func (s *topicSubscription) attemptReconnect(ctx context.Context, err error) err
 		}
 
 		s.log.Info("Successfully reconnected to subscription stream")
-		// Install the new stream under the mutex so that a concurrent Close
-		// observes either the old state or the new state, never a torn mix.
-		// Capture the closed flag under the same critical section so that any
-		// Close that ran before we unlock is guaranteed to be seen here.
-		s.mu.Lock()
-		s.reservation = reservation
-		s.subscribeClient = subscribeClient
-		s.cancelContext = cancelContext
-		s.cancelFunction = cancelFunction
-		wasClosed := s.closed.Load()
-		s.mu.Unlock()
+		s.state.Store(newState)
 
-		// If Close() ran while we were reconnecting, the cancel and release it
-		// issued targeted the *old* stream's already-released Reservation. The
-		// new stream we just installed would otherwise leak past Close — tear
-		// it down here.
-		if wasClosed {
+		// Store before reading closed; Close stores closed before reading
+		// state. Either side observes the other's write, so a Close racing
+		// this reconnect always tears down the new stream.
+		if s.closed.Load() {
 			s.log.Info("Subscription closed during reconnect; tearing down newly established stream")
-			cancelFunction()
-			s.decrementSubscriptionCount()
-			return momentoerrors.NewMomentoSvcErr(momentoerrors.CanceledError, "subscription closed", nil)
+			newState.cancelFunction()
+			newState.reservation.Release()
+			return momentoerrors.NewMomentoSvcErr(momentoerrors.CanceledError, "subscription closed", context.Canceled)
 		}
 		return nil
 	}
 }
 
-// Close cancels the stream context and releases the per-channel and pool-wide
-// subscription slots. decrementSubscriptionCount is idempotent (the
-// Reservation's Release is CAS-guarded), so if an in-flight Event() loop also
-// observes the cancel and decrements, the counters stay correct. The `closed` flag is set first so
-// that an in-flight attemptReconnect notices and tears down any new stream it
-// allocates instead of leaking it past Close. The cancel function is snapshotted
-// under mu so a concurrent attemptReconnect can't reassign the field while we
-// read it.
+// Close cancels the stream and releases the slot. Safe to call concurrently
+// with Event or another Close; Reservation.Release is idempotent.
 func (s *topicSubscription) Close() {
-	s.closed.Store(true)
-	s.mu.Lock()
-	cancel := s.cancelFunction
-	s.mu.Unlock()
-	cancel()
-	s.decrementSubscriptionCount()
+	// Set closed before reading state — see attemptReconnect for the inverse.
+	// The CAS doubles as the once-guard for closing the signal channel.
+	if s.closed.CompareAndSwap(false, true) {
+		close(s.closedSignal)
+	}
+	state := s.state.Load()
+	state.cancelFunction()
+	state.reservation.Release()
 }

--- a/momento/topic_subscription_accounting_test.go
+++ b/momento/topic_subscription_accounting_test.go
@@ -2,6 +2,8 @@ package momento
 
 import (
 	"context"
+	"errors"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -21,6 +23,8 @@ type testTopicGrpcConnectionPool struct {
 	manager      *grpcmanagers.TopicGrpcManager
 	activeCount  atomic.Int64
 	releaseCount atomic.Int64
+	// closed makes GetNextTopicGrpcManager fail like a real pool after Close.
+	closed atomic.Bool
 }
 
 func newTestTopicGrpcConnectionPool(streamClient pb.PubsubClient) *testTopicGrpcConnectionPool {
@@ -32,6 +36,9 @@ func newTestTopicGrpcConnectionPool(streamClient pb.PubsubClient) *testTopicGrpc
 }
 
 func (p *testTopicGrpcConnectionPool) GetNextTopicGrpcManager() (*topic_manager_lists.Reservation, momentoerrors.MomentoSvcErr) {
+	if p.closed.Load() {
+		return nil, momentoerrors.NewMomentoSvcErr(momentoerrors.CanceledError, "connection pool is shutting down", context.Canceled)
+	}
 	p.manager.NumActiveSubscriptions.Add(1)
 	p.activeCount.Add(1)
 	return topic_manager_lists.NewReservation(p.manager, p.releaseManager), nil
@@ -88,7 +95,68 @@ func (alwaysRetryStrategy) DetermineWhenToRetry(retry.StrategyProps) *int {
 	return &delay
 }
 
+// giveUpAfterRetryStrategy retries up to `attempts` times, then returns nil
+// to signal give-up.
+type giveUpAfterRetryStrategy struct {
+	attempts int
+}
+
+func (g giveUpAfterRetryStrategy) DetermineWhenToRetry(props retry.StrategyProps) *int {
+	if props.AttemptNumber > g.attempts {
+		return nil
+	}
+	delay := 0
+	return &delay
+}
+
+// signalingBackoffRetryStrategy always retries after a fixed backoff and
+// closes entered the first time the retry loop commits to that backoff, so
+// tests can deterministically race Close/cancel against the backoff wait.
+type signalingBackoffRetryStrategy struct {
+	backoffMs int
+	entered   chan struct{}
+	once      sync.Once
+}
+
+// firstCallBackoffRetryStrategy returns a long backoff on the first retry
+// consultation (closing entered), then zero for all subsequent ones, so a
+// paused reconnect can resume promptly.
+type firstCallBackoffRetryStrategy struct {
+	firstBackoffMs int
+	calls          atomic.Int64
+	entered        chan struct{}
+}
+
+func (s *firstCallBackoffRetryStrategy) DetermineWhenToRetry(retry.StrategyProps) *int {
+	if s.calls.Add(1) == 1 {
+		close(s.entered)
+		return &s.firstBackoffMs
+	}
+	zero := 0
+	return &zero
+}
+
+func newSignalingBackoffRetryStrategy(backoffMs int) *signalingBackoffRetryStrategy {
+	return &signalingBackoffRetryStrategy{
+		backoffMs: backoffMs,
+		entered:   make(chan struct{}),
+	}
+}
+
+func (s *signalingBackoffRetryStrategy) DetermineWhenToRetry(retry.StrategyProps) *int {
+	s.once.Do(func() { close(s.entered) })
+	return &s.backoffMs
+}
+
 func newAccountingTestClient(streamClient pb.PubsubClient, timeout time.Duration) (defaultTopicClient, *testTopicGrpcConnectionPool) {
+	return newAccountingTestClientWithStrategy(streamClient, timeout, alwaysRetryStrategy{})
+}
+
+func newAccountingTestClientWithStrategy(
+	streamClient pb.PubsubClient,
+	timeout time.Duration,
+	strategy retry.Strategy,
+) (defaultTopicClient, *testTopicGrpcConnectionPool) {
 	pool := newTestTopicGrpcConnectionPool(streamClient)
 	client := defaultTopicClient{
 		pubSubClient: &pubSubClient{
@@ -96,7 +164,7 @@ func newAccountingTestClient(streamClient pb.PubsubClient, timeout time.Duration
 		},
 		log:            logger.NewNoopMomentoLoggerFactory().GetLogger("topic-subscription-accounting-test"),
 		requestTimeout: timeout,
-		retryStrategy:  alwaysRetryStrategy{},
+		retryStrategy:  strategy,
 	}
 	return client, pool
 }
@@ -130,6 +198,26 @@ func topicItem(sequenceNumber uint64) *pb.XSubscriptionItem {
 	}
 }
 
+// assertErrorCode fails unless err is a MomentoSvcErr carrying the given code.
+func assertErrorCode(t *testing.T, err error, code string) {
+	t.Helper()
+	svcErr, ok := err.(momentoerrors.MomentoSvcErr)
+	if !ok {
+		t.Fatalf("error %v (%T) is not a MomentoSvcErr", err, err)
+	}
+	if svcErr.Code() != code {
+		t.Fatalf("error code = %s, want %s (err: %v)", svcErr.Code(), code, err)
+	}
+}
+
+func discontinuityItem() *pb.XSubscriptionItem {
+	return &pb.XSubscriptionItem{
+		Kind: &pb.XSubscriptionItem_Discontinuity{
+			Discontinuity: &pb.XDiscontinuity{},
+		},
+	}
+}
+
 func assertAccounting(t *testing.T, pool *testTopicGrpcConnectionPool, activeCount int64) {
 	t.Helper()
 	if got := pool.activeCount.Load(); got != activeCount {
@@ -149,7 +237,7 @@ func TestTopicSubscribeReleasesPoolCountersWhenStreamOpenFails(t *testing.T) {
 	_, pool := newAccountingTestClient(streamClient, time.Second)
 	client := &pubSubClient{streamGrpcConnectionPool: pool}
 
-	_, _, _, _, err := client.topicSubscribe(context.Background(), testSubscribeRequest())
+	_, err := client.topicSubscribe(context.Background(), testSubscribeRequest())
 	if err == nil {
 		t.Fatal("expected topicSubscribe to return an error")
 	}
@@ -173,6 +261,7 @@ func TestSubscribeReleasesPoolCountersWhenFirstMessageRecvFails(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected Subscribe to return an error")
 	}
+	assertErrorCode(t, err, momentoerrors.ServerUnavailableError)
 	if sub != nil {
 		t.Fatal("expected subscription to be nil")
 	}
@@ -193,6 +282,7 @@ func TestSubscribeReleasesPoolCountersWhenFirstMessageIsNotHeartbeat(t *testing.
 	if err == nil {
 		t.Fatal("expected Subscribe to return an error")
 	}
+	assertErrorCode(t, err, momentoerrors.InternalServerError)
 	if sub != nil {
 		t.Fatal("expected subscription to be nil")
 	}
@@ -217,6 +307,162 @@ func TestTopicSubscriptionCloseReleasesPoolCountersWithoutEvent(t *testing.T) {
 
 	sub.Close()
 	assertAccounting(t, pool, 0)
+}
+
+// TestTopicSubscriptionCloseDuringReconnectTearsDownNewStream covers the
+// close-during-reconnect race: Close sets closed=true while attemptReconnect
+// holds a new Reservation. The post-Store check must release that new
+// Reservation rather than leaking it. The subscribe function is gated so
+// Close runs deterministically inside the race window.
+func TestTopicSubscriptionCloseDuringReconnectTearsDownNewStream(t *testing.T) {
+	reconnectEntered := make(chan struct{})
+	unblockReconnect := make(chan struct{})
+	var subscribeCalls atomic.Uint64
+
+	streamClient := &testPubsubClient{
+		subscribe: func(context.Context, *pb.XSubscriptionRequest, ...grpc.CallOption) (pb.Pubsub_SubscribeClient, error) {
+			call := subscribeCalls.Add(1)
+			switch call {
+			case 1:
+				// Handshake heartbeat, then a disconnect to drive Event into
+				// attemptReconnect.
+				return &testSubscribeClient{
+					results: []recvResult{
+						{item: heartbeatItem()},
+						{err: status.Error(codes.Unavailable, "disconnected")},
+					},
+				}, nil
+			case 2:
+				// Reconnect: signal the test that a new Reservation is held,
+				// then block so Close can race with this in-flight reconnect.
+				close(reconnectEntered)
+				<-unblockReconnect
+				return &testSubscribeClient{
+					results: []recvResult{{item: heartbeatItem()}},
+				}, nil
+			default:
+				return nil, status.Error(codes.Canceled, "test: subscribe should not be called after Close")
+			}
+		},
+	}
+
+	client, pool := newAccountingTestClient(streamClient, time.Second)
+	sub, err := client.Subscribe(context.Background(), testSubscribeRequest())
+	if err != nil {
+		t.Fatalf("Subscribe returned error: %v", err)
+	}
+	assertAccounting(t, pool, 1)
+
+	eventDone := make(chan error, 1)
+	go func() {
+		_, err := sub.Event(context.Background())
+		eventDone <- err
+	}()
+
+	<-reconnectEntered
+
+	// Close while reconnect is mid-flight. Sets closed=true; the old
+	// Reservation was already released by Event before attemptReconnect ran.
+	sub.Close()
+
+	// Let reconnect proceed. The post-Store check observes closed=true and
+	// releases the new Reservation.
+	close(unblockReconnect)
+
+	eventErr := <-eventDone
+	if eventErr == nil {
+		t.Fatal("expected Event to return an error after close-during-reconnect")
+	}
+	assertErrorCode(t, eventErr, momentoerrors.CanceledError)
+	if !errors.Is(eventErr, context.Canceled) {
+		t.Fatalf("terminal error should unwrap to context.Canceled, got %v", eventErr)
+	}
+	assertAccounting(t, pool, 0)
+}
+
+// TestManyConcurrentSubscriptionsKeepsPoolBalanced stresses the pool counter
+// with parallel Subscribe and Close calls.
+func TestManyConcurrentSubscriptionsKeepsPoolBalanced(t *testing.T) {
+	const numSubs = 100
+
+	streamClient := &testPubsubClient{
+		subscribe: func(context.Context, *pb.XSubscriptionRequest, ...grpc.CallOption) (pb.Pubsub_SubscribeClient, error) {
+			return &testSubscribeClient{
+				results: []recvResult{{item: heartbeatItem()}},
+			}, nil
+		},
+	}
+	// Generous timeout: the fake handshake is synchronous, so the handshake
+	// timeout must never fire even on an oversubscribed -race CI runner.
+	client, pool := newAccountingTestClient(streamClient, 30*time.Second)
+
+	subs := make([]TopicSubscription, numSubs)
+	var wg sync.WaitGroup
+	wg.Add(numSubs)
+	for i := 0; i < numSubs; i++ {
+		go func(i int) {
+			defer wg.Done()
+			sub, err := client.Subscribe(context.Background(), testSubscribeRequest())
+			if err != nil {
+				t.Errorf("Subscribe %d returned error: %v", i, err)
+				return
+			}
+			subs[i] = sub
+		}(i)
+	}
+	wg.Wait()
+	assertAccounting(t, pool, numSubs)
+
+	wg.Add(numSubs)
+	for i := 0; i < numSubs; i++ {
+		go func(i int) {
+			defer wg.Done()
+			if subs[i] != nil {
+				subs[i].Close()
+			}
+		}(i)
+	}
+	wg.Wait()
+	assertAccounting(t, pool, 0)
+}
+
+// TestConcurrentCloseOnSameSubscription verifies many goroutines calling
+// Close on the same subscription release the pool slot exactly once.
+func TestConcurrentCloseOnSameSubscription(t *testing.T) {
+	const goroutines = 64
+
+	streamClient := &testPubsubClient{
+		subscribe: func(context.Context, *pb.XSubscriptionRequest, ...grpc.CallOption) (pb.Pubsub_SubscribeClient, error) {
+			return &testSubscribeClient{
+				results: []recvResult{{item: heartbeatItem()}},
+			}, nil
+		},
+	}
+	client, pool := newAccountingTestClient(streamClient, 30*time.Second)
+
+	sub, err := client.Subscribe(context.Background(), testSubscribeRequest())
+	if err != nil {
+		t.Fatalf("Subscribe returned error: %v", err)
+	}
+	assertAccounting(t, pool, 1)
+
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			<-start
+			sub.Close()
+		}()
+	}
+	close(start)
+	wg.Wait()
+
+	assertAccounting(t, pool, 0)
+	if got := pool.releaseCount.Load(); got != 1 {
+		t.Fatalf("releaseCount = %d, want 1 (concurrent Close should release exactly once)", got)
+	}
 }
 
 func TestTopicSubscriptionReconnectKeepsPoolCountersBalanced(t *testing.T) {
@@ -263,3 +509,725 @@ func TestTopicSubscriptionReconnectKeepsPoolCountersBalanced(t *testing.T) {
 	sub.Close()
 	assertAccounting(t, pool, 0)
 }
+
+// TestTopicSubscriptionReconnectGiveUpReleasesPoolCounters drives
+// attemptReconnect to give up after the retry strategy returns nil. Counters
+// must be balanced when Event surfaces the error, and a subsequent Close
+// must be a no-op on the already-released Reservation.
+func TestTopicSubscriptionReconnectGiveUpReleasesPoolCounters(t *testing.T) {
+	const allowedAttempts = 3
+	disconnectErr := status.Error(codes.Unavailable, "stream disconnected")
+	var subscribeCalls atomic.Uint64
+
+	streamClient := &testPubsubClient{
+		subscribe: func(context.Context, *pb.XSubscriptionRequest, ...grpc.CallOption) (pb.Pubsub_SubscribeClient, error) {
+			call := subscribeCalls.Add(1)
+			if call == 1 {
+				return &testSubscribeClient{
+					results: []recvResult{
+						{item: heartbeatItem()},
+						{err: disconnectErr},
+					},
+				}, nil
+			}
+			// Every reconnect attempt fails so the retry strategy is exhausted.
+			return nil, disconnectErr
+		},
+	}
+	client, pool := newAccountingTestClientWithStrategy(
+		streamClient,
+		time.Second,
+		giveUpAfterRetryStrategy{attempts: allowedAttempts},
+	)
+
+	sub, err := client.Subscribe(context.Background(), testSubscribeRequest())
+	if err != nil {
+		t.Fatalf("Subscribe returned error: %v", err)
+	}
+	assertAccounting(t, pool, 1)
+
+	_, eventErr := sub.Event(context.Background())
+	if eventErr == nil {
+		t.Fatal("expected Event to surface the give-up error from attemptReconnect")
+	}
+
+	// Original slot released by Event before reconnect; each failed reconnect
+	// attempt released its slot on the early-return path: 1 + allowedAttempts.
+	assertAccounting(t, pool, 0)
+	if got := pool.releaseCount.Load(); got != int64(1+allowedAttempts) {
+		t.Fatalf("releaseCount = %d, want %d (one per failed attempt plus the original slot)", got, 1+allowedAttempts)
+	}
+
+	// Close after give-up must be a no-op and must not panic.
+	sub.Close()
+	assertAccounting(t, pool, 0)
+}
+
+// TestTopicSubscriptionEventContextErrorKeepsSubscriptionAlive pins the
+// non-terminal per-call ctx contract: an expired or canceled Event ctx stops
+// only that call. The stream and its pool slot stay intact and a later call
+// with a live ctx receives messages, matching the timeout semantics of
+// comparable clients (NATS NextMsg, Kafka ReadMessage).
+func TestTopicSubscriptionEventContextErrorKeepsSubscriptionAlive(t *testing.T) {
+	streamClient := &testPubsubClient{
+		subscribe: func(context.Context, *pb.XSubscriptionRequest, ...grpc.CallOption) (pb.Pubsub_SubscribeClient, error) {
+			return &testSubscribeClient{
+				results: []recvResult{
+					{item: heartbeatItem()},
+					{item: topicItem(2)},
+				},
+			}, nil
+		},
+	}
+	client, pool := newAccountingTestClient(streamClient, time.Second)
+
+	sub, err := client.Subscribe(context.Background(), testSubscribeRequest())
+	if err != nil {
+		t.Fatalf("Subscribe returned error: %v", err)
+	}
+	assertAccounting(t, pool, 1)
+
+	canceledCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, eventErr := sub.Event(canceledCtx); eventErr == nil {
+		t.Fatal("expected Event to return an error for a canceled context")
+	}
+
+	// The slot stays held and the stream stays alive.
+	assertAccounting(t, pool, 1)
+	state := sub.(*topicSubscription).state.Load()
+	if state.cancelContext.Err() != nil {
+		t.Fatal("a per-call ctx error must not cancel the stream context")
+	}
+
+	// A later call with a live ctx picks up where we left off.
+	event, eventErr := sub.Event(context.Background())
+	if eventErr != nil {
+		t.Fatalf("Event after a per-call ctx error returned error: %v", eventErr)
+	}
+	if _, ok := event.(TopicItem); !ok {
+		t.Fatalf("Event = %T, want TopicItem from the surviving stream", event)
+	}
+	assertAccounting(t, pool, 1)
+
+	sub.Close()
+	assertAccounting(t, pool, 0)
+}
+
+// TestTopicSubscriptionEventAfterCloseReturnsTypedCanceled pins the terminal
+// error contract: after Close, Event returns a CanceledError that still
+// unwraps to context.Canceled, so callers can distinguish a dead subscription
+// from their own ctx expiring.
+func TestTopicSubscriptionEventAfterCloseReturnsTypedCanceled(t *testing.T) {
+	streamClient := &testPubsubClient{
+		subscribe: func(context.Context, *pb.XSubscriptionRequest, ...grpc.CallOption) (pb.Pubsub_SubscribeClient, error) {
+			return &testSubscribeClient{
+				results: []recvResult{{item: heartbeatItem()}},
+			}, nil
+		},
+	}
+	client, pool := newAccountingTestClient(streamClient, time.Second)
+
+	sub, err := client.Subscribe(context.Background(), testSubscribeRequest())
+	if err != nil {
+		t.Fatalf("Subscribe returned error: %v", err)
+	}
+	sub.Close()
+	assertAccounting(t, pool, 0)
+
+	_, eventErr := sub.Event(context.Background())
+	if eventErr == nil {
+		t.Fatal("expected Event after Close to return an error")
+	}
+	assertErrorCode(t, eventErr, momentoerrors.CanceledError)
+	if !errors.Is(eventErr, context.Canceled) {
+		t.Fatalf("terminal error should unwrap to context.Canceled, got %v", eventErr)
+	}
+}
+
+// TestTopicSubscriptionSubscribeCtxCancelEndsSubscription pins the other
+// terminal flavor: cancelling the ctx passed to Subscribe tears down an
+// established subscription. The blocked-Recv fake also pins stream lineage —
+// the stream context must be a child of the Subscribe ctx, so cancellation
+// unblocks a waiting Event, which returns the typed terminal error and
+// releases the slot.
+func TestTopicSubscriptionSubscribeCtxCancelEndsSubscription(t *testing.T) {
+	recvBlocked := make(chan struct{})
+	var recvBlockedOnce sync.Once
+	streamClient := &testPubsubClient{
+		subscribe: func(ctx context.Context, _ *pb.XSubscriptionRequest, _ ...grpc.CallOption) (pb.Pubsub_SubscribeClient, error) {
+			heartbeatSent := false
+			return &testSubscribeClient{
+				recv: func() (*pb.XSubscriptionItem, error) {
+					if !heartbeatSent {
+						heartbeatSent = true
+						return heartbeatItem(), nil
+					}
+					recvBlockedOnce.Do(func() { close(recvBlocked) })
+					<-ctx.Done()
+					return nil, status.FromContextError(ctx.Err()).Err()
+				},
+			}, nil
+		},
+	}
+	client, pool := newAccountingTestClient(streamClient, time.Second)
+
+	subscribeCtx, cancelSubscribeCtx := context.WithCancel(context.Background())
+	defer cancelSubscribeCtx()
+	sub, err := client.Subscribe(subscribeCtx, testSubscribeRequest())
+	if err != nil {
+		t.Fatalf("Subscribe returned error: %v", err)
+	}
+	assertAccounting(t, pool, 1)
+
+	eventDone := make(chan error, 1)
+	go func() {
+		_, eventErr := sub.Event(context.Background())
+		eventDone <- eventErr
+	}()
+
+	// Cancel the Subscribe-time ctx while Event is blocked in Recv. The
+	// stream context is its child, so the blocked call must return.
+	<-recvBlocked
+	cancelSubscribeCtx()
+
+	state := sub.(*topicSubscription).state.Load()
+	if state.cancelContext.Err() == nil {
+		t.Fatal("the stream context must be a child of the Subscribe ctx")
+	}
+
+	select {
+	case eventErr := <-eventDone:
+		if eventErr == nil {
+			t.Fatal("expected Event to return an error after Subscribe-ctx cancellation")
+		}
+		assertErrorCode(t, eventErr, momentoerrors.CanceledError)
+		if !errors.Is(eventErr, context.Canceled) {
+			t.Fatalf("terminal error should unwrap to context.Canceled, got %v", eventErr)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Event did not return within 5s of Subscribe-ctx cancellation")
+	}
+	assertAccounting(t, pool, 0)
+}
+
+// TestTopicSubscriptionItemSkipsNonMessageEvents pins Item's contract: it
+// swallows heartbeats and discontinuities and returns the next message value.
+func TestTopicSubscriptionItemSkipsNonMessageEvents(t *testing.T) {
+	streamClient := &testPubsubClient{
+		subscribe: func(context.Context, *pb.XSubscriptionRequest, ...grpc.CallOption) (pb.Pubsub_SubscribeClient, error) {
+			return &testSubscribeClient{
+				results: []recvResult{
+					{item: heartbeatItem()}, // handshake
+					{item: heartbeatItem()},
+					{item: discontinuityItem()},
+					{item: topicItem(2)},
+				},
+			}, nil
+		},
+	}
+	client, pool := newAccountingTestClient(streamClient, time.Second)
+
+	sub, err := client.Subscribe(context.Background(), testSubscribeRequest())
+	if err != nil {
+		t.Fatalf("Subscribe returned error: %v", err)
+	}
+
+	value, err := sub.Item(context.Background())
+	if err != nil {
+		t.Fatalf("Item returned error: %v", err)
+	}
+	if got, ok := value.(String); !ok || got != String("value") {
+		t.Fatalf("Item = %v (%T), want String(\"value\")", value, value)
+	}
+
+	sub.Close()
+	assertAccounting(t, pool, 0)
+}
+
+// TestTopicSubscriptionSubscribeCtxCancelDuringBackoffIsTerminal pins the
+// asymmetry between the two context flavors mid-backoff: the Subscribe-time
+// ctx dying ends the subscription (typed CanceledError, no pause), unlike the
+// per-call ctx, which pauses recovery for the next call.
+func TestTopicSubscriptionSubscribeCtxCancelDuringBackoffIsTerminal(t *testing.T) {
+	disconnectErr := status.Error(codes.Unavailable, "stream disconnected")
+	streamClient := &testPubsubClient{
+		subscribe: func(context.Context, *pb.XSubscriptionRequest, ...grpc.CallOption) (pb.Pubsub_SubscribeClient, error) {
+			return &testSubscribeClient{
+				results: []recvResult{
+					{item: heartbeatItem()},
+					{err: disconnectErr},
+				},
+			}, nil
+		},
+	}
+	strategy := newSignalingBackoffRetryStrategy(10 * 60 * 1000)
+	client, pool := newAccountingTestClientWithStrategy(streamClient, time.Second, strategy)
+
+	subscribeCtx, cancelSubscribeCtx := context.WithCancel(context.Background())
+	defer cancelSubscribeCtx()
+	sub, err := client.Subscribe(subscribeCtx, testSubscribeRequest())
+	if err != nil {
+		t.Fatalf("Subscribe returned error: %v", err)
+	}
+	assertAccounting(t, pool, 1)
+
+	eventDone := make(chan error, 1)
+	go func() {
+		_, eventErr := sub.Event(context.Background())
+		eventDone <- eventErr
+	}()
+
+	<-strategy.entered
+	cancelSubscribeCtx()
+
+	select {
+	case eventErr := <-eventDone:
+		if eventErr == nil {
+			t.Fatal("expected Event to return an error after Subscribe-ctx cancellation")
+		}
+		assertErrorCode(t, eventErr, momentoerrors.CanceledError)
+		if !errors.Is(eventErr, context.Canceled) {
+			t.Fatalf("terminal error should unwrap to context.Canceled, got %v", eventErr)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Event did not return within 5s of Subscribe-ctx cancellation")
+	}
+	assertAccounting(t, pool, 0)
+
+	// Terminal, not paused: a later call must report the dead subscription,
+	// not retry the reconnect.
+	_, eventErr := sub.Event(context.Background())
+	if eventErr == nil {
+		t.Fatal("expected the subscription to stay terminal")
+	}
+	assertErrorCode(t, eventErr, momentoerrors.CanceledError)
+}
+
+// TestTopicSubscriptionReconnectPausesOnContextCancelAndResumes drives the
+// retry loop into a long backoff, cancels the caller's ctx (Event must return
+// promptly), then verifies the next call with a live ctx resumes the
+// interrupted reconnect instead of the subscription dying.
+func TestTopicSubscriptionReconnectPausesOnContextCancelAndResumes(t *testing.T) {
+	disconnectErr := status.Error(codes.Unavailable, "stream disconnected")
+	var subscribeCalls atomic.Uint64
+	streamClient := &testPubsubClient{
+		subscribe: func(context.Context, *pb.XSubscriptionRequest, ...grpc.CallOption) (pb.Pubsub_SubscribeClient, error) {
+			if subscribeCalls.Add(1) == 1 {
+				return &testSubscribeClient{
+					results: []recvResult{
+						{item: heartbeatItem()},
+						{err: disconnectErr},
+					},
+				}, nil
+			}
+			return &testSubscribeClient{
+				results: []recvResult{{item: topicItem(2)}},
+			}, nil
+		},
+	}
+	strategy := &firstCallBackoffRetryStrategy{
+		firstBackoffMs: 10 * 60 * 1000,
+		entered:        make(chan struct{}),
+	}
+	client, pool := newAccountingTestClientWithStrategy(streamClient, time.Second, strategy)
+
+	sub, err := client.Subscribe(context.Background(), testSubscribeRequest())
+	if err != nil {
+		t.Fatalf("Subscribe returned error: %v", err)
+	}
+	assertAccounting(t, pool, 1)
+
+	eventCtx, cancelEventCtx := context.WithCancel(context.Background())
+	eventDone := make(chan error, 1)
+	go func() {
+		_, eventErr := sub.Event(eventCtx)
+		eventDone <- eventErr
+	}()
+
+	// Wait until the retry loop has committed to the 10-minute backoff, then
+	// cancel. Event must return promptly; without the ctx-aware wait this
+	// would block ~10 minutes.
+	<-strategy.entered
+	cancelEventCtx()
+
+	select {
+	case eventErr := <-eventDone:
+		if eventErr == nil {
+			t.Fatal("expected Event to return an error after context cancellation")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Event did not return within 5s of context cancellation")
+	}
+	// The failed stream's slot was released; recovery is paused, not dead.
+	assertAccounting(t, pool, 0)
+
+	// A call with another dead ctx stays paused rather than resuming.
+	deadCtx, cancelDead := context.WithCancel(context.Background())
+	cancelDead()
+	if _, pausedErr := sub.Event(deadCtx); pausedErr == nil {
+		t.Fatal("expected a dead-ctx call on a paused subscription to return an error")
+	}
+	assertAccounting(t, pool, 0)
+
+	// A live ctx resumes the reconnect (zero backoff on the second
+	// consultation) and delivers from the new stream.
+	event, eventErr := sub.Event(context.Background())
+	if eventErr != nil {
+		t.Fatalf("Event after paused reconnect returned error: %v", eventErr)
+	}
+	if _, ok := event.(TopicItem); !ok {
+		t.Fatalf("Event = %T, want TopicItem from the resumed stream", event)
+	}
+	assertAccounting(t, pool, 1)
+
+	sub.Close()
+	assertAccounting(t, pool, 0)
+}
+
+// TestTopicSubscriptionStreamErrorWithDeadContextResumesNextCall covers the
+// other pause entry: the stream fails while the caller's ctx is already dead.
+// The dead stream's slot is released immediately and the next call with a
+// live ctx reconnects.
+func TestTopicSubscriptionStreamErrorWithDeadContextResumesNextCall(t *testing.T) {
+	disconnectErr := status.Error(codes.Unavailable, "stream disconnected")
+	gate := make(chan struct{})
+	recvBlocked := make(chan struct{})
+	var recvBlockedOnce sync.Once
+	var subscribeCalls atomic.Uint64
+	streamClient := &testPubsubClient{
+		subscribe: func(context.Context, *pb.XSubscriptionRequest, ...grpc.CallOption) (pb.Pubsub_SubscribeClient, error) {
+			if subscribeCalls.Add(1) == 1 {
+				heartbeatSent := false
+				return &testSubscribeClient{
+					recv: func() (*pb.XSubscriptionItem, error) {
+						if !heartbeatSent {
+							heartbeatSent = true
+							return heartbeatItem(), nil
+						}
+						recvBlockedOnce.Do(func() { close(recvBlocked) })
+						<-gate
+						return nil, disconnectErr
+					},
+				}, nil
+			}
+			return &testSubscribeClient{
+				results: []recvResult{{item: topicItem(2)}},
+			}, nil
+		},
+	}
+	client, pool := newAccountingTestClient(streamClient, time.Second)
+
+	sub, err := client.Subscribe(context.Background(), testSubscribeRequest())
+	if err != nil {
+		t.Fatalf("Subscribe returned error: %v", err)
+	}
+	assertAccounting(t, pool, 1)
+
+	eventCtx, cancelEventCtx := context.WithCancel(context.Background())
+	eventDone := make(chan error, 1)
+	go func() {
+		_, eventErr := sub.Event(eventCtx)
+		eventDone <- eventErr
+	}()
+
+	// Kill the caller's ctx while Event is blocked in Recv, then fail the
+	// stream: Event observes the dead ctx on the error path.
+	<-recvBlocked
+	cancelEventCtx()
+	close(gate)
+
+	select {
+	case eventErr := <-eventDone:
+		if eventErr == nil {
+			t.Fatal("expected Event to return an error")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Event did not return within 5s")
+	}
+	assertAccounting(t, pool, 0)
+
+	event, eventErr := sub.Event(context.Background())
+	if eventErr != nil {
+		t.Fatalf("Event after deferred reconnect returned error: %v", eventErr)
+	}
+	if _, ok := event.(TopicItem); !ok {
+		t.Fatalf("Event = %T, want TopicItem from the reconnected stream", event)
+	}
+	assertAccounting(t, pool, 1)
+
+	sub.Close()
+	assertAccounting(t, pool, 0)
+}
+
+// TestTopicSubscriptionCloseInterruptsReconnectBackoff verifies Close wakes a
+// reconnect backoff wait instead of letting it sleep out the full interval.
+func TestTopicSubscriptionCloseInterruptsReconnectBackoff(t *testing.T) {
+	disconnectErr := status.Error(codes.Unavailable, "stream disconnected")
+	var subscribeCalls atomic.Uint64
+	streamClient := &testPubsubClient{
+		subscribe: func(context.Context, *pb.XSubscriptionRequest, ...grpc.CallOption) (pb.Pubsub_SubscribeClient, error) {
+			if subscribeCalls.Add(1) == 1 {
+				return &testSubscribeClient{
+					results: []recvResult{
+						{item: heartbeatItem()},
+						{err: disconnectErr},
+					},
+				}, nil
+			}
+			return nil, disconnectErr
+		},
+	}
+	strategy := newSignalingBackoffRetryStrategy(10 * 60 * 1000)
+	client, pool := newAccountingTestClientWithStrategy(
+		streamClient,
+		time.Second,
+		strategy,
+	)
+
+	sub, err := client.Subscribe(context.Background(), testSubscribeRequest())
+	if err != nil {
+		t.Fatalf("Subscribe returned error: %v", err)
+	}
+	assertAccounting(t, pool, 1)
+
+	eventDone := make(chan error, 1)
+	go func() {
+		_, eventErr := sub.Event(context.Background())
+		eventDone <- eventErr
+	}()
+
+	// Wait until the retry loop has committed to the 10-minute backoff, then
+	// Close. The closedSignal case must interrupt the wait promptly.
+	<-strategy.entered
+	sub.Close()
+
+	select {
+	case eventErr := <-eventDone:
+		if eventErr == nil {
+			t.Fatal("expected Event to return an error after Close")
+		}
+		assertErrorCode(t, eventErr, momentoerrors.CanceledError)
+		if !errors.Is(eventErr, context.Canceled) {
+			t.Fatalf("terminal error should unwrap to context.Canceled, got %v", eventErr)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Event did not return within 5s of Close (backoff not interrupted)")
+	}
+	assertAccounting(t, pool, 0)
+}
+
+// TestTopicSubscriptionReconnectUsesSubscribeContext pins stream-context
+// lineage: reconnected streams are parented to the ctx passed to Subscribe,
+// so canceling the Event ctx that happened to drive the reconnect must not
+// kill the replacement stream.
+func TestTopicSubscriptionReconnectUsesSubscribeContext(t *testing.T) {
+	disconnectErr := status.Error(codes.Unavailable, "stream disconnected")
+	var subscribeCalls atomic.Uint64
+	streamClient := &testPubsubClient{
+		subscribe: func(context.Context, *pb.XSubscriptionRequest, ...grpc.CallOption) (pb.Pubsub_SubscribeClient, error) {
+			if subscribeCalls.Add(1) == 1 {
+				return &testSubscribeClient{
+					results: []recvResult{
+						{item: heartbeatItem()},
+						{err: disconnectErr},
+					},
+				}, nil
+			}
+			return &testSubscribeClient{
+				results: []recvResult{
+					{item: topicItem(2)},
+					{item: topicItem(3)},
+				},
+			}, nil
+		},
+	}
+	client, pool := newAccountingTestClient(streamClient, time.Second)
+
+	sub, err := client.Subscribe(context.Background(), testSubscribeRequest())
+	if err != nil {
+		t.Fatalf("Subscribe returned error: %v", err)
+	}
+	assertAccounting(t, pool, 1)
+
+	// This Event call drives the disconnect -> reconnect -> item(2) sequence.
+	eventCtx, cancelEventCtx := context.WithCancel(context.Background())
+	event, eventErr := sub.Event(eventCtx)
+	if eventErr != nil {
+		t.Fatalf("Event returned error: %v", eventErr)
+	}
+	if _, ok := event.(TopicItem); !ok {
+		t.Fatalf("Event = %T, want TopicItem after reconnect", event)
+	}
+	assertAccounting(t, pool, 1)
+
+	// Cancel the ctx that drove the reconnect; the reconnected stream must
+	// survive because it is parented to the Subscribe-time ctx.
+	cancelEventCtx()
+
+	event, eventErr = sub.Event(context.Background())
+	if eventErr != nil {
+		t.Fatalf("Event after canceling the reconnect-driving ctx returned error: %v", eventErr)
+	}
+	if _, ok := event.(TopicItem); !ok {
+		t.Fatalf("Event = %T, want TopicItem from the surviving stream", event)
+	}
+	assertAccounting(t, pool, 1)
+
+	sub.Close()
+	assertAccounting(t, pool, 0)
+}
+
+// TestTopicSubscriptionCloseUnblocksEventBlockedInRecv pins the documented
+// Close contract: an Event call blocked in Recv returns promptly with an
+// error when Close cancels the stream context, with the slot released.
+func TestTopicSubscriptionCloseUnblocksEventBlockedInRecv(t *testing.T) {
+	recvBlocked := make(chan struct{})
+	var recvBlockedOnce sync.Once
+	streamClient := &testPubsubClient{
+		subscribe: func(ctx context.Context, _ *pb.XSubscriptionRequest, _ ...grpc.CallOption) (pb.Pubsub_SubscribeClient, error) {
+			heartbeatSent := false
+			return &testSubscribeClient{
+				recv: func() (*pb.XSubscriptionItem, error) {
+					if !heartbeatSent {
+						heartbeatSent = true
+						return heartbeatItem(), nil
+					}
+					recvBlockedOnce.Do(func() { close(recvBlocked) })
+					<-ctx.Done()
+					return nil, status.FromContextError(ctx.Err()).Err()
+				},
+			}, nil
+		},
+	}
+	client, pool := newAccountingTestClient(streamClient, time.Second)
+
+	sub, err := client.Subscribe(context.Background(), testSubscribeRequest())
+	if err != nil {
+		t.Fatalf("Subscribe returned error: %v", err)
+	}
+	assertAccounting(t, pool, 1)
+
+	eventDone := make(chan error, 1)
+	go func() {
+		_, eventErr := sub.Event(context.Background())
+		eventDone <- eventErr
+	}()
+
+	<-recvBlocked // Event is now blocked inside Recv
+	sub.Close()
+
+	select {
+	case eventErr := <-eventDone:
+		if eventErr == nil {
+			t.Fatal("expected Event to return an error after Close")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Event blocked in Recv did not return within 5s of Close")
+	}
+	assertAccounting(t, pool, 0)
+}
+
+// TestTopicSubscriptionReconnectStopsWhenPoolIsClosed verifies the retry loop
+// treats the pool's shutdown CanceledError as terminal: even an always-retry
+// strategy must not spin against a closed pool.
+func TestTopicSubscriptionReconnectStopsWhenPoolIsClosed(t *testing.T) {
+	disconnectErr := status.Error(codes.Unavailable, "stream disconnected")
+	streamClient := &testPubsubClient{
+		subscribe: func(context.Context, *pb.XSubscriptionRequest, ...grpc.CallOption) (pb.Pubsub_SubscribeClient, error) {
+			return &testSubscribeClient{
+				results: []recvResult{
+					{item: heartbeatItem()},
+					{err: disconnectErr},
+				},
+			}, nil
+		},
+	}
+	client, pool := newAccountingTestClient(streamClient, time.Second)
+
+	sub, err := client.Subscribe(context.Background(), testSubscribeRequest())
+	if err != nil {
+		t.Fatalf("Subscribe returned error: %v", err)
+	}
+	assertAccounting(t, pool, 1)
+
+	// Shut the pool down, then drive Event into the disconnect. Every
+	// reconnect attempt now fails with the pool's CanceledError; the
+	// always-retry strategy must not loop on it.
+	pool.closed.Store(true)
+
+	eventDone := make(chan error, 1)
+	go func() {
+		_, eventErr := sub.Event(context.Background())
+		eventDone <- eventErr
+	}()
+
+	select {
+	case eventErr := <-eventDone:
+		if eventErr == nil {
+			t.Fatal("expected Event to return an error after the pool closed")
+		}
+		assertErrorCode(t, eventErr, momentoerrors.CanceledError)
+		if !errors.Is(eventErr, context.Canceled) {
+			t.Fatalf("terminal error should unwrap to context.Canceled, got %v", eventErr)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Event did not return within 5s; reconnect loop is spinning against a closed pool")
+	}
+	assertAccounting(t, pool, 0)
+}
+
+// TestTopicPublishUnaryReleasesReservationOncePerCall verifies the unary
+// path's defer reservation.Release() runs exactly once per publish.
+func TestTopicPublishUnaryReleasesReservationOncePerCall(t *testing.T) {
+	streamClient := &testPubsubClient{
+		subscribe: func(context.Context, *pb.XSubscriptionRequest, ...grpc.CallOption) (pb.Pubsub_SubscribeClient, error) {
+			return nil, status.Error(codes.Internal, "Subscribe should not be called from a publish-only test")
+		},
+	}
+	pool := newTestTopicGrpcConnectionPool(streamClient)
+	client := &pubSubClient{
+		unaryGrpcConnectionPool: pool,
+		log:                     logger.NewNoopMomentoLoggerFactory().GetLogger("unary-publish-test"),
+		requestTimeout:          time.Second,
+	}
+
+	const publishCount = 50
+	for i := 0; i < publishCount; i++ {
+		err := client.topicPublish(context.Background(), &TopicPublishRequest{
+			CacheName: "cache",
+			TopicName: "topic",
+			Value:     String("payload"),
+		})
+		if err != nil {
+			t.Fatalf("topicPublish %d returned error: %v", i, err)
+		}
+	}
+
+	// The Bytes branch and the unsupported-value branch release too.
+	if err := client.topicPublish(context.Background(), &TopicPublishRequest{
+		CacheName: "cache",
+		TopicName: "topic",
+		Value:     Bytes("payload"),
+	}); err != nil {
+		t.Fatalf("topicPublish with Bytes returned error: %v", err)
+	}
+	err := client.topicPublish(context.Background(), &TopicPublishRequest{
+		CacheName: "cache",
+		TopicName: "topic",
+		Value:     unsupportedTopicValue{},
+	})
+	if err == nil {
+		t.Fatal("expected an error for an unsupported topic value type")
+	}
+	assertErrorCode(t, err, momentoerrors.InvalidArgumentError)
+
+	if got := pool.releaseCount.Load(); got != publishCount+2 {
+		t.Fatalf("releaseCount = %d, want %d (exactly one Release per publish)", got, publishCount+2)
+	}
+}
+
+// unsupportedTopicValue drives topicPublish's default branch.
+type unsupportedTopicValue struct{}
+
+func (unsupportedTopicValue) isTopicValue() {}


### PR DESCRIPTION
Part 4 of 5 of the topics connection-management stack. The subscription lifecycle story — one production commit (~290 lines across `topic_subscription.go`/`topic_client.go`/`pubsub_client.go`) plus its accounting test suite.

### Behavior changes

1. An error from the context you pass to `Item`/`Event` no longer kills the pool accounting, and the subscription survives it. Previously the call returned `context.Canceled`/`context.DeadlineExceeded` but released the subscription's pool slot while leaving the stream open, so the accounting drifted every time it happened. Now an error from your per-call context means only that the call stopped waiting: the subscription stays usable and a later call with a live context picks up where you left off, including resuming an interrupted reconnect (a healthy stream keeps its slot; a failed one releases it and re-acquires on resume). One migration note: cancelling a per-call context no longer frees the pool slot as a side effect, so call `Close()` (idempotent) when abandoning a subscription.

2. Terminal errors are now typed. After `Close()`, or after the context passed to `Subscribe` ends, `Item`/`Event` returns a `CanceledError` (previously a raw `context.Canceled`). The error unwraps to the underlying context error (`context.Canceled`, or `context.DeadlineExceeded` when the Subscribe context hit a deadline), so `errors.Is` still matches; only identity or string comparisons need to change:

   ```go
   _, err := sub.Item(ctx) // after sub.Close()

   // before: matched on the old SDK, silently stops matching after upgrade
   if err == context.Canceled { ... }
   if err.Error() == "context canceled" { ... }

   // after: works on both old and new SDK
   if errors.Is(err, context.Canceled) { ... }
   ```

   The typed code is what lets a consumer loop tell a dead subscription apart from its own per-call context expiring (which now leaves the subscription usable, per behavior change 1 above):

   ```go
   var merr momento.MomentoError
   if ctx.Err() != nil {
       // my ctx expired; subscription still alive, call again when ready
   } else if errors.As(err, &merr) && merr.Code() == momento.CanceledError {
       // subscription ended: Close() was called or the Subscribe ctx ended
   }
   ```

### Other fixes you may notice

- `Close()` interrupts an in-flight reconnect backoff instead of waiting out the full interval
- a subscription no longer reconnect-loops forever after `TopicClient.Close()` under the default retry strategy
- reconnected streams stay parented to the Subscribe ctx; previously a reconnect re-parented the stream to whichever Event call triggered it, so an unrelated per-call context could later kill the subscription
- reconnect failures keep their real error codes instead of being demoted to a generic `ClientSdkError`

### Internals

- `topicSubscription` drops its mutex for an `atomic.Pointer[streamState]` snapshot; close-during-reconnect is handled with a store/load ordering on closed/state so either side observes the other's write
- a reconnect interrupted by the caller's ctx dying is carried across calls as a paused recovery (`needsReconnect`/`lastStreamErr`, owned by the single Event goroutine per the documented contract); the next live-ctx call resumes it
- the backoff wait uses a stoppable timer and wakes on the Event ctx, the Subscribe ctx, and Close, with terminal conditions winning ties

The accounting suite pins exact error codes and release counts on every path above, several mutation-verified. This tree matches the final validated head of the original #677.

Stack: #679 → #680 → #681 → **#682 (this)** → #683 subscribe watchdog.

