### PR TITLE
fix(topics): bound the subscribe handshake and stop leaking slots on timeout (topics stack 5/5)

### DIFF
--- a/momento/pubsub_client.go
+++ b/momento/pubsub_client.go
@@ -95,11 +95,15 @@ func newPubSubClient(request *models.PubSubClientRequest) (*pubSubClient, moment
 }
 
 // topicSubscribe reserves a stream slot and opens a gRPC subscribe stream
-// against it. Failures cancel the request context and release the slot
-// before returning.
-func (client *pubSubClient) topicSubscribe(ctx context.Context, request *TopicSubscribeRequest) (*streamState, error) {
+// against it. The caller owns the cancelContext/cancelFunction pair — created
+// before this call so a watchdog can bound stream establishment — and
+// failures cancel it and release the slot before returning.
+func (client *pubSubClient) topicSubscribe(cancelContext context.Context, cancelFunction context.CancelFunc, request *TopicSubscribeRequest) (*streamState, error) {
 	reservation, reservationErr := client.streamGrpcConnectionPool.GetNextTopicGrpcManager()
 	if reservationErr != nil {
+		// Cancel the caller-owned pair so the child context doesn't stay
+		// registered on a long-lived parent (e.g. across reconnect retries).
+		cancelFunction()
 		return nil, reservationErr
 	}
 
@@ -118,7 +122,6 @@ func (client *pubSubClient) topicSubscribe(ctx context.Context, request *TopicSu
 		}
 	}
 
-	cancelContext, cancelFunction := context.WithCancel(ctx)
 	requestContext := internal.CreateTopicRequestContextFromMetadataMap(cancelContext, request.CacheName, requestMetadata)
 
 	var header, trailer metadata.MD

--- a/momento/topic_client.go
+++ b/momento/topic_client.go
@@ -4,6 +4,7 @@ package momento
 import (
 	"context"
 	"fmt"
+	"sync/atomic"
 	"time"
 
 	"github.com/momentohq/client-sdk-go/config/middleware"
@@ -92,15 +93,34 @@ func (c defaultTopicClient) Subscribe(ctx context.Context, request *TopicSubscri
 	subChan := make(chan *topicSubscription, 1)
 	errChan := make(chan error, 1)
 
-	go c.sendSubscribe(ctx, request, subChan, errChan)
+	// sendSubscribe opens the stream in the background; firstMessageCtx is its
+	// watchdog for the first-heartbeat handshake.
+	go c.sendSubscribe(ctx, firstMessageCtx, request, subChan, errChan)
 	select {
-	case <-ctx.Done():
-		return nil, momentoerrors.NewMomentoSvcErr(
-			momentoerrors.CanceledError,
-			"subscribe request context was canceled",
-			ctx.Err(),
-		)
 	case <-firstMessageCtx.Done():
+		// Handshake deadline or caller cancellation (firstMessageCtx is a
+		// child of ctx, so it fires for both). The watchdog cancels the
+		// stream unless the first message already won the handshake; the
+		// drainer closes a live subscription that lands on subChan after this
+		// return, and the error path releases the slot otherwise.
+		if ctx.Err() == nil {
+			// The deadline tied with a successful delivery: prefer the
+			// subscription. Anything on subChan won the handshake arbiter,
+			// so its stream is live.
+			select {
+			case subscription := <-subChan:
+				return subscription, nil
+			default:
+			}
+		}
+		go drainAndCloseSubscription(subChan, errChan)
+		if ctx.Err() != nil {
+			return nil, momentoerrors.NewMomentoSvcErr(
+				momentoerrors.CanceledError,
+				"subscribe request context was canceled",
+				ctx.Err(),
+			)
+		}
 		return nil, momentoerrors.NewMomentoSvcErr(
 			momentoerrors.TimeoutError,
 			"subscription did not receive first message within the expected time",
@@ -113,14 +133,64 @@ func (c defaultTopicClient) Subscribe(ctx context.Context, request *TopicSubscri
 	}
 }
 
-func (c defaultTopicClient) sendSubscribe(requestCtx context.Context, request *TopicSubscribeRequest, subChan chan *topicSubscription, errChan chan error) {
-	state, err := c.pubSubClient.topicSubscribe(requestCtx, &TopicSubscribeRequest{
+// drainAndCloseSubscription closes a subscription that sendSubscribe delivers
+// on subChan after Subscribe has already returned via the timeout or
+// cancellation path. Without it the slot would leak.
+func drainAndCloseSubscription(subChan chan *topicSubscription, errChan chan error) {
+	select {
+	case sub := <-subChan:
+		if sub != nil {
+			sub.Close()
+		}
+	case <-errChan:
+		// Error path in sendSubscribe already released the slot.
+	}
+}
+
+func (c defaultTopicClient) sendSubscribe(requestCtx context.Context, firstMessageCtx context.Context, request *TopicSubscribeRequest, subChan chan *topicSubscription, errChan chan error) {
+	// The stream context pair is created before topicSubscribe so the
+	// watchdog bounds stream ESTABLISHMENT as well as the first-message wait;
+	// otherwise a black-holed endpoint would hold the reserved pool slot
+	// until gRPC's connect timeout, long after Subscribe returned.
+	cancelContext, cancelFunction := context.WithCancel(requestCtx)
+
+	// Watchdog: cancel the stream if firstMessageCtx fires before the
+	// handshake completes. handshakeDecided is the single arbiter: exactly
+	// one of {handshake outcome, watchdog} wins it, so a stream the watchdog
+	// cancelled is never delivered to the caller, and a stream whose first
+	// message won is never cancelled by the watchdog.
+	var handshakeDecided atomic.Bool
+	firstMessageDone := make(chan struct{})
+	go func() {
+		select {
+		case <-firstMessageDone:
+			return
+		case <-firstMessageCtx.Done():
+			if handshakeDecided.CompareAndSwap(false, true) {
+				cancelFunction()
+			}
+		}
+	}()
+
+	state, err := c.pubSubClient.topicSubscribe(cancelContext, cancelFunction, &TopicSubscribeRequest{
 		CacheName:                   request.CacheName,
 		TopicName:                   request.TopicName,
 		ResumeAtTopicSequenceNumber: request.ResumeAtTopicSequenceNumber,
 		SequencePage:                request.SequencePage,
 	})
 	if err != nil {
+		establishmentWon := handshakeDecided.CompareAndSwap(false, true)
+		close(firstMessageDone)
+		if !establishmentWon && requestCtx.Err() == nil {
+			// The watchdog cancelled establishment at the deadline; report
+			// the handshake timeout rather than the cancellation it induced.
+			errChan <- momentoerrors.NewMomentoSvcErr(
+				momentoerrors.TimeoutError,
+				"subscription did not receive first message within the expected time",
+				err,
+			)
+			return
+		}
 		errChan <- err
 		return
 	}
@@ -140,8 +210,21 @@ func (c defaultTopicClient) sendSubscribe(requestCtx context.Context, request *T
 
 	// Ping the stream to surface a nice error if the cache does not exist.
 	firstMsg, err := state.subscribeClient.Recv()
+	messageWon := handshakeDecided.CompareAndSwap(false, true)
+	close(firstMessageDone)
 	if err != nil {
 		c.log.Debug("failed to receive first message from subscription: %s", err.Error())
+
+		if !messageWon && requestCtx.Err() == nil {
+			// The watchdog cancelled the stream at the deadline; report the
+			// handshake timeout rather than the cancellation it induced.
+			fail(momentoerrors.NewMomentoSvcErr(
+				momentoerrors.TimeoutError,
+				"subscription did not receive first message within the expected time",
+				err,
+			))
+			return
+		}
 
 		// topicSubscribe would have errored already if the local pool was
 		// exhausted, so a ResourceExhausted here is a service-side limit.
@@ -152,6 +235,16 @@ func (c defaultTopicClient) sendSubscribe(requestCtx context.Context, request *T
 			}
 		}
 		fail(momentoerrors.ConvertSvcErr(err))
+		return
+	}
+	if !messageWon {
+		// The watchdog fired between Recv returning and the arbiter check; the
+		// stream is already cancelled, so don't hand it to the caller.
+		fail(momentoerrors.NewMomentoSvcErr(
+			momentoerrors.TimeoutError,
+			"subscription did not receive first message within the expected time",
+			nil,
+		))
 		return
 	}
 

--- a/momento/topic_subscription.go
+++ b/momento/topic_subscription.go
@@ -430,14 +430,49 @@ func (s *topicSubscription) attemptReconnect(ctx context.Context, err error) err
 		// Parent the replacement stream to the Subscribe-time ctx, not this
 		// Event call's ctx, so the stream's lifetime is stable across Events.
 		reconnectCtx, reconnectCancel := context.WithCancel(s.streamParentCtx)
+		// The stream is parented to the Subscribe ctx for stable lineage, but
+		// the caller's ctx must still be able to interrupt a dial that blocks
+		// (e.g. mid-outage), or Event couldn't return promptly. The induced
+		// cancellation is converted into a pause below.
+		establishmentDone := make(chan struct{})
+		interrupterExited := make(chan struct{})
+		go func() {
+			defer close(interrupterExited)
+			select {
+			case <-establishmentDone:
+			case <-ctx.Done():
+				reconnectCancel()
+			}
+		}()
 		newState, reconnectErr := s.momentoTopicClient.topicSubscribe(reconnectCtx, reconnectCancel, &TopicSubscribeRequest{
 			CacheName:                   s.cacheName,
 			TopicName:                   s.topicName,
 			ResumeAtTopicSequenceNumber: s.lastKnownSequenceNumber,
 			SequencePage:                s.lastKnownSequencePage,
 		})
+		close(establishmentDone)
+		// Join the interrupter: after this, either reconnectCancel has already
+		// happened (visible to the check below) or it never will.
+		<-interrupterExited
+
+		if reconnectErr == nil && newState.cancelContext.Err() != nil &&
+			ctx.Err() != nil && s.streamParentCtx.Err() == nil && !s.closed.Load() {
+			// The interrupter cancelled a stream that had just come up;
+			// release it and pause rather than handing Event a dead stream
+			// or terminating the subscription.
+			newState.reservation.Release()
+			return momentoerrors.NewMomentoSvcErr(momentoerrors.CanceledError, "event context canceled during reconnect", errEventCtxInterruptedReconnect)
+		}
 
 		if reconnectErr != nil {
+			// The caller's ctx dying mid-establishment pauses recovery; this
+			// is checked before the canceled-terminal classification below,
+			// which would otherwise treat the induced cancellation as
+			// terminal.
+			if ctx.Err() != nil && s.streamParentCtx.Err() == nil && !s.closed.Load() {
+				s.log.Info("Context canceled during reconnect establishment; pausing retry loop")
+				return momentoerrors.NewMomentoSvcErr(momentoerrors.CanceledError, "event context canceled during reconnect", errEventCtxInterruptedReconnect)
+			}
 			// A canceled reconnect can never succeed: the pool is shutting
 			// down or the stream's parent context is dead. Stop instead of
 			// burning retries (the legacy default strategy retries forever).

--- a/momento/topic_subscription.go
+++ b/momento/topic_subscription.go
@@ -429,7 +429,8 @@ func (s *topicSubscription) attemptReconnect(ctx context.Context, err error) err
 		s.log.Info("Attempting reconnecting to client stream")
 		// Parent the replacement stream to the Subscribe-time ctx, not this
 		// Event call's ctx, so the stream's lifetime is stable across Events.
-		newState, reconnectErr := s.momentoTopicClient.topicSubscribe(s.streamParentCtx, &TopicSubscribeRequest{
+		reconnectCtx, reconnectCancel := context.WithCancel(s.streamParentCtx)
+		newState, reconnectErr := s.momentoTopicClient.topicSubscribe(reconnectCtx, reconnectCancel, &TopicSubscribeRequest{
 			CacheName:                   s.cacheName,
 			TopicName:                   s.topicName,
 			ResumeAtTopicSequenceNumber: s.lastKnownSequenceNumber,

--- a/momento/topic_subscription_accounting_test.go
+++ b/momento/topic_subscription_accounting_test.go
@@ -237,7 +237,9 @@ func TestTopicSubscribeReleasesPoolCountersWhenStreamOpenFails(t *testing.T) {
 	_, pool := newAccountingTestClient(streamClient, time.Second)
 	client := &pubSubClient{streamGrpcConnectionPool: pool}
 
-	_, err := client.topicSubscribe(context.Background(), testSubscribeRequest())
+	cancelCtx, cancelFn := context.WithCancel(context.Background())
+	defer cancelFn()
+	_, err := client.topicSubscribe(cancelCtx, cancelFn, testSubscribeRequest())
 	if err == nil {
 		t.Fatal("expected topicSubscribe to return an error")
 	}
@@ -1231,3 +1233,303 @@ func TestTopicPublishUnaryReleasesReservationOncePerCall(t *testing.T) {
 type unsupportedTopicValue struct{}
 
 func (unsupportedTopicValue) isTopicValue() {}
+
+// TestSubscribeWatchdogDoesNotCancelLiveSubscription guards the sendSubscribe
+// watchdog race: when both firstMessageDone and firstMessageCtx are ready by
+// the time the watchdog wakes, Go's select picks randomly. Without the
+// handshakeDecided arbiter, ~half of those wakeups would cancel a
+// subscription that was already handed back to the caller. Concurrent Subscribe calls
+// force the watchdog to be descheduled across the race window.
+func TestSubscribeWatchdogDoesNotCancelLiveSubscription(t *testing.T) {
+	streamClient := &testPubsubClient{
+		subscribe: func(context.Context, *pb.XSubscriptionRequest, ...grpc.CallOption) (pb.Pubsub_SubscribeClient, error) {
+			return &testSubscribeClient{
+				results: []recvResult{{item: heartbeatItem()}},
+			}, nil
+		},
+	}
+	// 50ms gives sendSubscribe time to populate subChan before the timeout
+	// fires, while still leaving defer cancel() racing the watchdog.
+	client, _ := newAccountingTestClient(streamClient, 50*time.Millisecond)
+
+	const goroutines = 64
+	const perGoroutine = 50
+
+	var wg sync.WaitGroup
+	var successes atomic.Int64
+	var cancelled atomic.Int64
+
+	wg.Add(goroutines)
+	for g := 0; g < goroutines; g++ {
+		go func() {
+			defer wg.Done()
+			for i := 0; i < perGoroutine; i++ {
+				sub, err := client.Subscribe(context.Background(), testSubscribeRequest())
+				if err != nil {
+					continue
+				}
+				successes.Add(1)
+				ts := sub.(*topicSubscription)
+				state := ts.state.Load()
+				select {
+				case <-state.cancelContext.Done():
+					cancelled.Add(1)
+				default:
+				}
+				sub.Close()
+			}
+		}()
+	}
+	wg.Wait()
+
+	if cancelled.Load() > 0 {
+		t.Fatalf("watchdog cancelled %d of %d returned subscriptions (race condition)",
+			cancelled.Load(), successes.Load())
+	}
+	if successes.Load() == 0 {
+		t.Fatal("no Subscribe calls succeeded; test is vacuous")
+	}
+}
+
+// TestSubscribeDeadlineBoundaryNeverLeaksOrDeliversDeadSubscriptions hammers
+// the handshake-deadline boundary, where an instant heartbeat and a tiny
+// requestTimeout race inside Subscribe's select. Every returned subscription
+// must be live (the deadline tie prefers a delivered subscription), every
+// timeout must leave no slot behind, and the counters must drain to zero.
+func TestSubscribeDeadlineBoundaryNeverLeaksOrDeliversDeadSubscriptions(t *testing.T) {
+	streamClient := &testPubsubClient{
+		subscribe: func(context.Context, *pb.XSubscriptionRequest, ...grpc.CallOption) (pb.Pubsub_SubscribeClient, error) {
+			return &testSubscribeClient{
+				results: []recvResult{{item: heartbeatItem()}},
+			}, nil
+		},
+	}
+	// 1ms keeps the deadline and the instant heartbeat permanently racing.
+	client, pool := newAccountingTestClient(streamClient, time.Millisecond)
+
+	const goroutines = 16
+	const perGoroutine = 100
+
+	var wg sync.WaitGroup
+	var successes, timeouts atomic.Int64
+	wg.Add(goroutines)
+	for g := 0; g < goroutines; g++ {
+		go func() {
+			defer wg.Done()
+			for i := 0; i < perGoroutine; i++ {
+				sub, err := client.Subscribe(context.Background(), testSubscribeRequest())
+				if err != nil {
+					timeouts.Add(1)
+					continue
+				}
+				successes.Add(1)
+				state := sub.(*topicSubscription).state.Load()
+				select {
+				case <-state.cancelContext.Done():
+					t.Error("Subscribe returned a subscription with a dead stream")
+				default:
+				}
+				sub.Close()
+			}
+		}()
+	}
+	wg.Wait()
+
+	if successes.Load() == 0 && timeouts.Load() == 0 {
+		t.Fatal("no outcomes recorded; test is vacuous")
+	}
+	// Timed-out handshakes release in sendSubscribe's goroutine; poll for the
+	// stragglers.
+	waitForReleasedAccounting(t, pool)
+}
+
+// TestTopicSubscribeReleasesSlotOnFirstMessageTimeout exercises the
+// firstMessageCtx timeout path. Recv blocks on the stream context (matching
+// production gRPC behavior); the watchdog cancels it after the timeout fires
+// and the error path releases the slot.
+func TestTopicSubscribeReleasesSlotOnFirstMessageTimeout(t *testing.T) {
+	streamClient := &testPubsubClient{
+		subscribe: func(ctx context.Context, _ *pb.XSubscriptionRequest, _ ...grpc.CallOption) (pb.Pubsub_SubscribeClient, error) {
+			return &testSubscribeClient{
+				recv: func() (*pb.XSubscriptionItem, error) {
+					<-ctx.Done()
+					return nil, ctx.Err()
+				},
+			}, nil
+		},
+	}
+	client, pool := newAccountingTestClient(streamClient, 50*time.Millisecond)
+
+	sub, err := client.Subscribe(context.Background(), testSubscribeRequest())
+	if err == nil {
+		t.Fatal("expected Subscribe to return a timeout error")
+	}
+	if sub != nil {
+		t.Fatal("expected Subscribe to return a nil subscription on timeout")
+	}
+	assertErrorCode(t, err, momentoerrors.TimeoutError)
+
+	waitForReleasedAccounting(t, pool)
+	if got := pool.releaseCount.Load(); got != 1 {
+		t.Fatalf("releaseCount = %d, want 1 (exactly one Release for the cleanup path)", got)
+	}
+}
+
+// waitForReleasedAccounting polls until the pool counters drain to zero;
+// cleanup runs in sendSubscribe's goroutine after Subscribe has returned, so
+// the release lands asynchronously. Generous deadline for loaded CI runners.
+func waitForReleasedAccounting(t *testing.T, pool *testTopicGrpcConnectionPool) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if pool.activeCount.Load() == 0 && pool.manager.NumActiveSubscriptions.Load() == 0 {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	assertAccounting(t, pool, 0)
+}
+
+// TestSubscribeReleasesSlotWhenStreamEstablishmentHangs pins that the
+// handshake watchdog bounds stream ESTABLISHMENT too: a stream-open call that
+// blocks (black-holed endpoint) must not hold the reserved slot past the
+// handshake deadline, even though Subscribe already returned TimeoutError.
+func TestSubscribeReleasesSlotWhenStreamEstablishmentHangs(t *testing.T) {
+	streamClient := &testPubsubClient{
+		subscribe: func(ctx context.Context, _ *pb.XSubscriptionRequest, _ ...grpc.CallOption) (pb.Pubsub_SubscribeClient, error) {
+			// Establishment completes only when the stream context is
+			// cancelled, as with a black-holed endpoint.
+			<-ctx.Done()
+			return nil, ctx.Err()
+		},
+	}
+	client, pool := newAccountingTestClient(streamClient, 50*time.Millisecond)
+
+	sub, err := client.Subscribe(context.Background(), testSubscribeRequest())
+	if err == nil {
+		t.Fatal("expected Subscribe to return a timeout error")
+	}
+	if sub != nil {
+		t.Fatal("expected Subscribe to return a nil subscription on timeout")
+	}
+	assertErrorCode(t, err, momentoerrors.TimeoutError)
+
+	waitForReleasedAccounting(t, pool)
+	if got := pool.releaseCount.Load(); got != 1 {
+		t.Fatalf("releaseCount = %d, want 1 (exactly one Release for the hung establishment)", got)
+	}
+}
+
+// TestSubscribeLateFirstMessageAfterTimeoutReleasesSlot pins the
+// dead-on-arrival guard: the first heartbeat lands only after Subscribe has
+// returned via the timeout path, so the handshake arbiter must refuse to
+// deliver the already-cancelled stream and release its slot instead.
+func TestSubscribeLateFirstMessageAfterTimeoutReleasesSlot(t *testing.T) {
+	releaseHeartbeat := make(chan struct{})
+	streamClient := &testPubsubClient{
+		subscribe: func(context.Context, *pb.XSubscriptionRequest, ...grpc.CallOption) (pb.Pubsub_SubscribeClient, error) {
+			return &testSubscribeClient{
+				recv: func() (*pb.XSubscriptionItem, error) {
+					<-releaseHeartbeat
+					return heartbeatItem(), nil
+				},
+			}, nil
+		},
+	}
+	client, pool := newAccountingTestClient(streamClient, 50*time.Millisecond)
+
+	sub, err := client.Subscribe(context.Background(), testSubscribeRequest())
+	if err == nil {
+		t.Fatal("expected Subscribe to return a timeout error")
+	}
+	if sub != nil {
+		t.Fatal("expected Subscribe to return a nil subscription on timeout")
+	}
+	assertErrorCode(t, err, momentoerrors.TimeoutError)
+
+	// Deliver the heartbeat only now, after the timeout return. The watchdog
+	// already cancelled the stream, so sendSubscribe must fail the handshake
+	// and release the slot instead of delivering a dead subscription.
+	close(releaseHeartbeat)
+
+	waitForReleasedAccounting(t, pool)
+	if got := pool.releaseCount.Load(); got != 1 {
+		t.Fatalf("releaseCount = %d, want 1 (exactly one Release for the late-message path)", got)
+	}
+}
+
+// TestSubscribeUserContextCancelReturnsCanceledError verifies a caller
+// cancellation is reported as CanceledError — never as a handshake timeout —
+// even though firstMessageCtx (a child of the caller's ctx) fires at the same
+// instant. Repeated because the wrong outcome was a random select pick.
+func TestSubscribeUserContextCancelReturnsCanceledError(t *testing.T) {
+	// One gate per Subscribe call; recv holds the handshake open until the
+	// test closes the gate, keeping errChan empty until Subscribe has returned.
+	gates := make(chan chan struct{}, 16)
+	streamClient := &testPubsubClient{
+		subscribe: func(context.Context, *pb.XSubscriptionRequest, ...grpc.CallOption) (pb.Pubsub_SubscribeClient, error) {
+			gate := make(chan struct{})
+			gates <- gate
+			return &testSubscribeClient{
+				recv: func() (*pb.XSubscriptionItem, error) {
+					<-gate
+					return heartbeatItem(), nil
+				},
+			}, nil
+		},
+	}
+	client, pool := newAccountingTestClient(streamClient, 10*time.Second)
+
+	for i := 0; i < 10; i++ {
+		ctx, cancel := context.WithCancel(context.Background())
+		subscribeDone := make(chan error, 1)
+		go func() {
+			_, err := client.Subscribe(ctx, testSubscribeRequest())
+			subscribeDone <- err
+		}()
+
+		gate := <-gates // the stream is open and the handshake is in flight
+		cancel()
+
+		var err error
+		select {
+		case err = <-subscribeDone:
+		case <-time.After(5 * time.Second):
+			t.Fatal("Subscribe did not return after context cancellation")
+		}
+		if err == nil {
+			t.Fatal("expected Subscribe to return an error after context cancellation")
+		}
+		assertErrorCode(t, err, momentoerrors.CanceledError)
+
+		// Let the held-open handshake finish; the drainer must release the slot.
+		close(gate)
+		waitForReleasedAccounting(t, pool)
+	}
+}
+
+// TestDrainerClosesLateDeliveredSubscription pins drainAndCloseSubscription's
+// subscription branch directly: a live subscription that lands on subChan
+// after Subscribe has returned must be closed and its slot released.
+func TestDrainerClosesLateDeliveredSubscription(t *testing.T) {
+	streamClient := &testPubsubClient{
+		subscribe: func(context.Context, *pb.XSubscriptionRequest, ...grpc.CallOption) (pb.Pubsub_SubscribeClient, error) {
+			return &testSubscribeClient{
+				results: []recvResult{{item: heartbeatItem()}},
+			}, nil
+		},
+	}
+	client, pool := newAccountingTestClient(streamClient, time.Second)
+
+	sub, err := client.Subscribe(context.Background(), testSubscribeRequest())
+	if err != nil {
+		t.Fatalf("Subscribe returned error: %v", err)
+	}
+	assertAccounting(t, pool, 1)
+
+	subChan := make(chan *topicSubscription, 1)
+	errChan := make(chan error, 1)
+	subChan <- sub.(*topicSubscription)
+	drainAndCloseSubscription(subChan, errChan)
+	assertAccounting(t, pool, 0)
+}

--- a/momento/topic_subscription_accounting_test.go
+++ b/momento/topic_subscription_accounting_test.go
@@ -1234,6 +1234,83 @@ type unsupportedTopicValue struct{}
 
 func (unsupportedTopicValue) isTopicValue() {}
 
+// TestTopicSubscriptionReconnectEstablishmentInterruptedByEventCtx pins the
+// pause contract against a dial that blocks: the reconnect stream is parented
+// to the Subscribe ctx for lineage, but the caller's per-call ctx must still
+// interrupt a blocked establishment promptly, pausing recovery for the next
+// call instead of terminating the subscription.
+func TestTopicSubscriptionReconnectEstablishmentInterruptedByEventCtx(t *testing.T) {
+	disconnectErr := status.Error(codes.Unavailable, "stream disconnected")
+	establishmentEntered := make(chan struct{})
+	var establishmentOnce sync.Once
+	var subscribeCalls atomic.Uint64
+	streamClient := &testPubsubClient{
+		subscribe: func(ctx context.Context, _ *pb.XSubscriptionRequest, _ ...grpc.CallOption) (pb.Pubsub_SubscribeClient, error) {
+			switch subscribeCalls.Add(1) {
+			case 1:
+				return &testSubscribeClient{
+					results: []recvResult{
+						{item: heartbeatItem()},
+						{err: disconnectErr},
+					},
+				}, nil
+			case 2:
+				// A dial that blocks mid-outage: completes only when the
+				// stream context dies.
+				establishmentOnce.Do(func() { close(establishmentEntered) })
+				<-ctx.Done()
+				return nil, status.FromContextError(ctx.Err()).Err()
+			default:
+				return &testSubscribeClient{
+					results: []recvResult{{item: topicItem(2)}},
+				}, nil
+			}
+		},
+	}
+	client, pool := newAccountingTestClient(streamClient, time.Second)
+
+	sub, err := client.Subscribe(context.Background(), testSubscribeRequest())
+	if err != nil {
+		t.Fatalf("Subscribe returned error: %v", err)
+	}
+	assertAccounting(t, pool, 1)
+
+	eventCtx, cancelEventCtx := context.WithCancel(context.Background())
+	eventDone := make(chan error, 1)
+	go func() {
+		_, eventErr := sub.Event(eventCtx)
+		eventDone <- eventErr
+	}()
+
+	// Cancel the caller's ctx while the reconnect dial is blocked. Event must
+	// return promptly even though the stream is parented to the Subscribe ctx.
+	<-establishmentEntered
+	cancelEventCtx()
+
+	select {
+	case eventErr := <-eventDone:
+		if eventErr == nil {
+			t.Fatal("expected Event to return an error after context cancellation")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Event blocked in reconnect establishment did not return within 5s of ctx cancellation")
+	}
+	assertAccounting(t, pool, 0)
+
+	// Paused, not dead: a live ctx resumes and delivers from a fresh stream.
+	event, eventErr := sub.Event(context.Background())
+	if eventErr != nil {
+		t.Fatalf("Event after interrupted establishment returned error: %v", eventErr)
+	}
+	if _, ok := event.(TopicItem); !ok {
+		t.Fatalf("Event = %T, want TopicItem from the resumed stream", event)
+	}
+	assertAccounting(t, pool, 1)
+
+	sub.Close()
+	assertAccounting(t, pool, 0)
+}
+
 // TestSubscribeWatchdogDoesNotCancelLiveSubscription guards the sendSubscribe
 // watchdog race: when both firstMessageDone and firstMessageCtx are ready by
 // the time the watchdog wakes, Go's select picks randomly. Without the


### PR DESCRIPTION
Part 5 of 5 of the topics connection-management stack. Fixes a permanent pool slot leak in the Subscribe handshake and makes its timeout behavior deterministic; equals the final validated content of the original #678.

When Subscribe timed out waiting for the first heartbeat, `sendSubscribe` kept running in the background. A late heartbeat would build a subscription that nobody read and its slot leaked permanently; repeated timeouts during an outage could eat the whole pool until the process restarted.

What changed:

- `sendSubscribe` creates the stream context up front and arms a watchdog across the whole handshake, so the deadline also bounds connection establishment. Previously, against an unreachable endpoint, Subscribe returned `TimeoutError` while the reserved slot sat there until gRPC's ~20s connect timeout.
- a `handshakeDecided` CAS decides the race between the watchdog and the first message: a stream the watchdog cancelled is never handed to the caller (it fails with `TimeoutError` and releases the slot), and a delivered stream is never cancelled by the watchdog. When the deadline ties with a successful delivery, Subscribe returns the live subscription instead of a spurious timeout
- `drainAndCloseSubscription` releases the slot of a subscription that completes after Subscribe already returned via the timeout/cancel path
- error codes are deterministic: canceling your ctx during Subscribe returns `CanceledError`, a handshake timeout returns `TimeoutError`. It used to be a coin flip when both raced.
- second commit: the caller's per-call ctx can interrupt a reconnect dial that blocks mid-outage (the interrupter is joined before the outcome is classified, so it can never cancel an establishment that already won); the induced cancellation pauses recovery for the next call

Tests cover slot release on timeout, on hung establishment (fails against the old structure), and on a late heartbeat; the cancel error code across 10 deterministic iterations; the drainer; a 64x50 watchdog stress (catches removal of the arbiter in 3/3 mutation runs); a 1600-iteration deadline-boundary stress; and the interrupted-dial pause/resume.

Stack: #679 → #680 → #681 → #682 → **#683 (this)**. Merge in order; release together.

